### PR TITLE
Simple memory optimization for grid-based solvers

### DIFF
--- a/include/jet/custom_scalar_field2.h
+++ b/include/jet/custom_scalar_field2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_CUSTOM_SCALAR_FIELD2_H_
 #define INCLUDE_JET_CUSTOM_SCALAR_FIELD2_H_
@@ -86,6 +86,9 @@ class CustomScalarField2::Builder final {
     Builder& withLaplacianFunction(
         const std::function<double(const Vector2D&)>& func);
 
+    //! Returns builder with derivative resolution.
+    Builder& withDerivativeResolution(double resolution);
+
     //! Builds CustomScalarField2.
     CustomScalarField2 build() const;
 
@@ -93,6 +96,7 @@ class CustomScalarField2::Builder final {
     CustomScalarField2Ptr makeShared() const;
 
  private:
+    double _resolution = 1e-3;
     std::function<double(const Vector2D&)> _customFunction;
     std::function<Vector2D(const Vector2D&)> _customGradientFunction;
     std::function<double(const Vector2D&)> _customLaplacianFunction;

--- a/include/jet/custom_scalar_field3.h
+++ b/include/jet/custom_scalar_field3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_CUSTOM_SCALAR_FIELD3_H_
 #define INCLUDE_JET_CUSTOM_SCALAR_FIELD3_H_
@@ -86,6 +86,9 @@ class CustomScalarField3::Builder final {
     Builder& withLaplacianFunction(
         const std::function<double(const Vector3D&)>& func);
 
+    //! Returns builder with derivative resolution.
+    Builder& withDerivativeResolution(double resolution);
+
     //! Builds CustomScalarField3.
     CustomScalarField3 build() const;
 
@@ -93,6 +96,7 @@ class CustomScalarField3::Builder final {
     CustomScalarField3Ptr makeShared() const;
 
  private:
+    double _resolution = 1e-3;
     std::function<double(const Vector3D&)> _customFunction;
     std::function<Vector3D(const Vector3D&)> _customGradientFunction;
     std::function<double(const Vector3D&)> _customLaplacianFunction;

--- a/include/jet/custom_vector_field2.h
+++ b/include/jet/custom_vector_field2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_CUSTOM_VECTOR_FIELD2_H_
 #define INCLUDE_JET_CUSTOM_VECTOR_FIELD2_H_
@@ -86,6 +86,9 @@ class CustomVectorField2::Builder final {
     Builder& withCurlFunction(
         const std::function<double(const Vector2D&)>& func);
 
+    //! Returns builder with derivative resolution.
+    Builder& withDerivativeResolution(double resolution);
+
     //! Builds CustomVectorField2.
     CustomVectorField2 build() const;
 
@@ -93,6 +96,7 @@ class CustomVectorField2::Builder final {
     CustomVectorField2Ptr makeShared() const;
 
  private:
+    double _resolution = 1e-3;
     std::function<Vector2D(const Vector2D&)> _customFunction;
     std::function<double(const Vector2D&)> _customDivergenceFunction;
     std::function<double(const Vector2D&)> _customCurlFunction;

--- a/include/jet/custom_vector_field3.h
+++ b/include/jet/custom_vector_field3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_CUSTOM_VECTOR_FIELD3_H_
 #define INCLUDE_JET_CUSTOM_VECTOR_FIELD3_H_
@@ -86,6 +86,9 @@ class CustomVectorField3::Builder final {
     Builder& withCurlFunction(
         const std::function<Vector3D(const Vector3D&)>& func);
 
+    //! Returns builder with derivative resolution.
+    Builder& withDerivativeResolution(double resolution);
+
     //! Builds CustomVectorField3.
     CustomVectorField3 build() const;
 
@@ -93,6 +96,7 @@ class CustomVectorField3::Builder final {
     CustomVectorField3Ptr makeShared() const;
 
  private:
+    double _resolution = 1e-3;
     std::function<Vector3D(const Vector3D&)> _customFunction;
     std::function<double(const Vector3D&)> _customDivergenceFunction;
     std::function<Vector3D(const Vector3D&)> _customCurlFunction;

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_FDM_LINEAR_SYSTEM2_H_
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM2_H_
@@ -7,15 +7,15 @@
 
 namespace jet {
 
-//! The row of FdmMatrix2 where row corresponds to (i, j, k) grid point.
+//! The row of FdmMatrix2 where row corresponds to (i, j) grid point.
 struct FdmMatrixRow2 {
     //! Diagonal component of the matrix (row, row).
     double center = 0.0;
 
-    //! Off-diagonal element where colum refers to (i+1, j, k) grid point.
+    //! Off-diagonal element where colum refers to (i+1, j) grid point.
     double right = 0.0;
 
-    //! Off-diagonal element where column refers to (i, j+1, k) grid point.
+    //! Off-diagonal element where column refers to (i, j+1) grid point.
     double up = 0.0;
 };
 

--- a/include/jet/fdm_linear_system3.h
+++ b/include/jet/fdm_linear_system3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_FDM_LINEAR_SYSTEM3_H_
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM3_H_

--- a/include/jet/flip_solver2.h
+++ b/include/jet/flip_solver2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_FLIP_SOLVER2_H_
 #define INCLUDE_JET_FLIP_SOLVER2_H_
@@ -45,7 +45,8 @@ class FlipSolver2 : public PicSolver2 {
     void transferFromGridsToParticles() override;
 
  private:
-    FaceCenteredGrid2 _delta;
+    Array2<float> _uDelta;
+    Array2<float> _vDelta;
 };
 
 //! Shared pointer type for the FlipSolver2.

--- a/include/jet/flip_solver3.h
+++ b/include/jet/flip_solver3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_FLIP_SOLVER3_H_
 #define INCLUDE_JET_FLIP_SOLVER3_H_
@@ -45,7 +45,9 @@ class FlipSolver3 : public PicSolver3 {
     void transferFromGridsToParticles() override;
 
  private:
-    FaceCenteredGrid3 _delta;
+    Array3<float> _uDelta;
+    Array3<float> _vDelta;
+    Array3<float> _wDelta;
 };
 
 //! Shared pointer type for the FlipSolver3.

--- a/include/jet/grid_boundary_condition_solver2.h
+++ b/include/jet/grid_boundary_condition_solver2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_BOUNDARY_CONDITION_SOLVER2_H_
 #define INCLUDE_JET_GRID_BOUNDARY_CONDITION_SOLVER2_H_
@@ -6,6 +6,7 @@
 #include <jet/collider2.h>
 #include <jet/constants.h>
 #include <jet/face_centered_grid2.h>
+#include <jet/scalar_field2.h>
 
 #include <memory>
 
@@ -63,6 +64,12 @@ class GridBoundaryConditionSolver2 {
     virtual void constrainVelocity(
         FaceCenteredGrid2* velocity,
         unsigned int extrapolationDepth = 5) = 0;
+
+    //! Returns the signed distance field of the collider.
+    virtual ScalarField2Ptr colliderSdf() const = 0;
+
+    //! Returns the velocity field of the collider.
+    virtual VectorField2Ptr colliderVelocityField() const = 0;
 
  protected:
     //! Invoked when a new collider is set.

--- a/include/jet/grid_boundary_condition_solver3.h
+++ b/include/jet/grid_boundary_condition_solver3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_BOUNDARY_CONDITION_SOLVER3_H_
 #define INCLUDE_JET_GRID_BOUNDARY_CONDITION_SOLVER3_H_
@@ -6,6 +6,7 @@
 #include <jet/collider3.h>
 #include <jet/constants.h>
 #include <jet/face_centered_grid3.h>
+#include <jet/scalar_field3.h>
 
 #include <memory>
 
@@ -63,6 +64,12 @@ class GridBoundaryConditionSolver3 {
     virtual void constrainVelocity(
         FaceCenteredGrid3* velocity,
         unsigned int extrapolationDepth = 5) = 0;
+
+    //! Returns the signed distance field of the collider.
+    virtual ScalarField3Ptr colliderSdf() const = 0;
+
+    //! Returns the velocity field of the collider.
+    virtual VectorField3Ptr colliderVelocityField() const = 0;
 
  protected:
     //! Invoked when a new collider is set.

--- a/include/jet/grid_fluid_solver2.h
+++ b/include/jet/grid_fluid_solver2.h
@@ -1,11 +1,10 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FLUID_SOLVER2_H_
 #define INCLUDE_JET_GRID_FLUID_SOLVER2_H_
 
 #include <jet/advection_solver2.h>
 #include <jet/cell_centered_scalar_grid2.h>
-#include <jet/cell_centered_vector_grid2.h>
 #include <jet/collider2.h>
 #include <jet/grid_emitter2.h>
 #include <jet/face_centered_grid2.h>
@@ -255,7 +254,10 @@ class GridFluidSolver2 : public PhysicsAnimation {
     void extrapolateIntoCollider(FaceCenteredGrid2* grid);
 
     //! Returns the signed-distance field representation of the collider.
-    const CellCenteredScalarGrid2& colliderSdf() const;
+    ScalarField2Ptr colliderSdf() const;
+
+    //! Returns the velocity field of the collider.
+    VectorField2Ptr colliderVelocityField() const;
 
  private:
     Vector2D _gravity = Vector2D(0.0, -9.8);
@@ -265,8 +267,6 @@ class GridFluidSolver2 : public PhysicsAnimation {
 
     GridSystemData2Ptr _grids;
     Collider2Ptr _collider;
-    CellCenteredScalarGrid2 _colliderSdf;
-    CellCenteredVectorGrid2 _colliderVel;
     GridEmitter2Ptr _emitter;
 
     AdvectionSolver2Ptr _advectionSolver;

--- a/include/jet/grid_fluid_solver3.h
+++ b/include/jet/grid_fluid_solver3.h
@@ -1,11 +1,10 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FLUID_SOLVER3_H_
 #define INCLUDE_JET_GRID_FLUID_SOLVER3_H_
 
 #include <jet/advection_solver3.h>
 #include <jet/cell_centered_scalar_grid3.h>
-#include <jet/cell_centered_vector_grid3.h>
 #include <jet/collider3.h>
 #include <jet/grid_emitter3.h>
 #include <jet/face_centered_grid3.h>
@@ -255,7 +254,10 @@ class GridFluidSolver3 : public PhysicsAnimation {
     void extrapolateIntoCollider(FaceCenteredGrid3* grid);
 
     //! Returns the signed-distance field representation of the collider.
-    const CellCenteredScalarGrid3& colliderSdf() const;
+    ScalarField3Ptr colliderSdf() const;
+
+    //! Returns the velocity field of the collider.
+    VectorField3Ptr colliderVelocityField() const;
 
  private:
     Vector3D _gravity = Vector3D(0.0, -9.8, 0.0);
@@ -265,8 +267,6 @@ class GridFluidSolver3 : public PhysicsAnimation {
 
     GridSystemData3Ptr _grids;
     Collider3Ptr _collider;
-    CellCenteredScalarGrid3 _colliderSdf;
-    CellCenteredVectorGrid3 _colliderVel;
     GridEmitter3Ptr _emitter;
 
     AdvectionSolver3Ptr _advectionSolver;

--- a/include/jet/grid_fractional_boundary_condition_solver2.h
+++ b/include/jet/grid_fractional_boundary_condition_solver2.h
@@ -1,9 +1,10 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FRACTIONAL_BOUNDARY_CONDITION_SOLVER2_H_
 #define INCLUDE_JET_GRID_FRACTIONAL_BOUNDARY_CONDITION_SOLVER2_H_
 
 #include <jet/cell_centered_scalar_grid2.h>
+#include <jet/custom_vector_field2.h>
 #include <jet/grid_boundary_condition_solver2.h>
 
 #include <memory>
@@ -39,7 +40,10 @@ class GridFractionalBoundaryConditionSolver2
         unsigned int extrapolationDepth = 5) override;
 
     //! Returns the signed distance field of the collider.
-    const CellCenteredScalarGrid2& colliderSdf() const;
+    ScalarField2Ptr colliderSdf() const override;
+
+    //! Returns the velocity field of the collider.
+    VectorField2Ptr colliderVelocityField() const override;
 
  protected:
     //! Invoked when a new collider is set.
@@ -49,7 +53,8 @@ class GridFractionalBoundaryConditionSolver2
         const Vector2D& gridOrigin) override;
 
  private:
-    CellCenteredScalarGrid2 _colliderSdf;
+    CellCenteredScalarGrid2Ptr _colliderSdf;
+    CustomVectorField2Ptr _colliderVel;
 };
 
 //! Shared pointer type for the GridFractionalBoundaryConditionSolver2.

--- a/include/jet/grid_fractional_boundary_condition_solver3.h
+++ b/include/jet/grid_fractional_boundary_condition_solver3.h
@@ -1,9 +1,10 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FRACTIONAL_BOUNDARY_CONDITION_SOLVER3_H_
 #define INCLUDE_JET_GRID_FRACTIONAL_BOUNDARY_CONDITION_SOLVER3_H_
 
 #include <jet/cell_centered_scalar_grid3.h>
+#include <jet/custom_vector_field3.h>
 #include <jet/grid_boundary_condition_solver3.h>
 
 #include <memory>
@@ -39,7 +40,10 @@ class GridFractionalBoundaryConditionSolver3
         unsigned int extrapolationDepth = 5) override;
 
     //! Returns the signed distance field of the collider.
-    const CellCenteredScalarGrid3& colliderSdf() const;
+    ScalarField3Ptr colliderSdf() const override;
+
+    //! Returns the velocity field of the collider.
+    VectorField3Ptr colliderVelocityField() const override;
 
  protected:
     //! Invoked when a new collider is set.
@@ -49,7 +53,8 @@ class GridFractionalBoundaryConditionSolver3
         const Vector3D& gridOrigin) override;
 
  private:
-    CellCenteredScalarGrid3 _colliderSdf;
+    CellCenteredScalarGrid3Ptr _colliderSdf;
+    CustomVectorField3Ptr _colliderVel;
 };
 
 //! Shared pointer type for the GridFractionalBoundaryConditionSolver3.

--- a/include/jet/grid_fractional_single_phase_pressure_solver2.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FRACTIONAL_SINGLE_PHASE_PRESSURE_SOLVER2_H_
 #define INCLUDE_JET_GRID_FRACTIONAL_SINGLE_PHASE_PRESSURE_SOLVER2_H_
@@ -97,11 +97,10 @@ class GridFractionalSinglePhasePressureSolver2 final :
  private:
     FdmLinearSystem2 _system;
     FdmLinearSystemSolver2Ptr _systemSolver;
-    Array2<double> _uWeights;
-    Array2<double> _vWeights;
-    Array2<double> _uBoundary;
-    Array2<double> _vBoundary;
-    CellCenteredScalarGrid2 _fluidSdf;
+    Array2<float> _uWeights;
+    Array2<float> _vWeights;
+    Array2<float> _fluidSdf;
+    std::function<Vector2D(const Vector2D&)> _boundaryVel;
 
     void buildWeights(
         const FaceCenteredGrid2& input,

--- a/include/jet/grid_fractional_single_phase_pressure_solver3.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_GRID_FRACTIONAL_SINGLE_PHASE_PRESSURE_SOLVER3_H_
 #define INCLUDE_JET_GRID_FRACTIONAL_SINGLE_PHASE_PRESSURE_SOLVER3_H_
@@ -94,13 +94,11 @@ class GridFractionalSinglePhasePressureSolver3 : public GridPressureSolver3 {
  private:
     FdmLinearSystem3 _system;
     FdmLinearSystemSolver3Ptr _systemSolver;
-    Array3<double> _uWeights;
-    Array3<double> _vWeights;
-    Array3<double> _wWeights;
-    Array3<double> _uBoundary;
-    Array3<double> _vBoundary;
-    Array3<double> _wBoundary;
-    CellCenteredScalarGrid3 _fluidSdf;
+    Array3<float> _uWeights;
+    Array3<float> _vWeights;
+    Array3<float> _wWeights;
+    Array3<float> _fluidSdf;
+    std::function<Vector3D(const Vector3D&)> _boundaryVel;
 
     void buildWeights(
         const FaceCenteredGrid3& input,

--- a/src/examples/hybrid_liquid_sim/main.cpp
+++ b/src/examples/hybrid_liquid_sim/main.cpp
@@ -247,26 +247,30 @@ void runExample3(
     const std::string& format,
     double fps) {
     // Build solver
-    Size3 resolution{3 * resolutionX, 2 * resolutionX, (3 * resolutionX) / 2};
+    // Size3 resolution{3 * resolutionX, 2 * resolutionX, (3 * resolutionX) / 2};
+    Size3 resolution{300, 300, 300};
+    Vector3D gridSpacing(0.1, 0.1, 0.1);
     auto solver = FlipSolver3::builder()
         .withResolution(resolution)
-        .withDomainSizeX(3.0)
+        .withGridSpacing(gridSpacing)
         .makeShared();
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
     BoundingBox3D domain = grids->boundingBox();
+    double lx = 1.0;//domain.width();
+    double ly = 1.0;//domain.height();
     double lz = domain.depth();
 
     // Build emitter
     auto box1 = Box3::builder()
         .withLowerCorner({0, 0, 0})
-        .withUpperCorner({0.5 + 0.001, 0.75 + 0.001, 0.75 * lz + 0.001})
+        .withUpperCorner({0.5 * lx + 0.001, 0.75 * ly + 0.001, 0.75 * lz + 0.001})
         .makeShared();
 
     auto box2 = Box3::builder()
-        .withLowerCorner({2.5 - 0.001, 0, 0.25 * lz - 0.001})
-        .withUpperCorner({3.5 + 0.001, 0.75 + 0.001, 1.5 * lz + 0.001})
+        .withLowerCorner({2.5 * lx - 0.001, 0, 0.25 * lz - 0.001})
+        .withUpperCorner({3.5 * lx + 0.001, 0.75 * ly + 0.001, 1.5 * lz + 0.001})
         .makeShared();
 
     auto boxSet = ImplicitSurfaceSet3::builder()
@@ -277,6 +281,7 @@ void runExample3(
         .withSurface(boxSet)
         .withMaxRegion(domain)
         .withSpacing(0.5 * dx)
+        .withAllowOverlapping(true)
         .makeShared();
 
     emitter->setPointGenerator(std::make_shared<GridPointGenerator3>());

--- a/src/jet/custom_scalar_field2.cpp
+++ b/src/jet/custom_scalar_field2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/custom_scalar_field2.h>
@@ -95,18 +95,44 @@ CustomScalarField2::Builder::withLaplacianFunction(
     return *this;
 }
 
+CustomScalarField2::Builder&
+CustomScalarField2::Builder::withDerivativeResolution(double resolution) {
+    _resolution = resolution;
+    return *this;
+}
+
 CustomScalarField2 CustomScalarField2::Builder::build() const {
-    return CustomScalarField2(
-        _customFunction, _customGradientFunction, _customLaplacianFunction);
+    if (_customLaplacianFunction) {
+        return CustomScalarField2(
+            _customFunction,
+            _customGradientFunction,
+            _customLaplacianFunction);
+    } else {
+        return CustomScalarField2(
+            _customFunction,
+            _customGradientFunction,
+            _resolution);
+    }
 }
 
 CustomScalarField2Ptr CustomScalarField2::Builder::makeShared() const {
-    return std::shared_ptr<CustomScalarField2>(
-        new CustomScalarField2(
-            _customFunction,
-            _customGradientFunction,
-            _customLaplacianFunction),
-        [] (CustomScalarField2* obj) {
-            delete obj;
-        });
+    if (_customLaplacianFunction) {
+        return std::shared_ptr<CustomScalarField2>(
+            new CustomScalarField2(
+                _customFunction,
+                _customGradientFunction,
+                _customLaplacianFunction),
+            [] (CustomScalarField2* obj) {
+                delete obj;
+            });
+    } else {
+        return std::shared_ptr<CustomScalarField2>(
+            new CustomScalarField2(
+                _customFunction,
+                _customGradientFunction,
+                _resolution),
+            [] (CustomScalarField2* obj) {
+                delete obj;
+            });
+    }
 }

--- a/src/jet/custom_scalar_field3.cpp
+++ b/src/jet/custom_scalar_field3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/custom_scalar_field3.h>
@@ -112,18 +112,44 @@ CustomScalarField3::Builder::withLaplacianFunction(
     return *this;
 }
 
+CustomScalarField3::Builder&
+CustomScalarField3::Builder::withDerivativeResolution(double resolution) {
+    _resolution = resolution;
+    return *this;
+}
+
 CustomScalarField3 CustomScalarField3::Builder::build() const {
-    return CustomScalarField3(
-        _customFunction, _customGradientFunction, _customLaplacianFunction);
+    if (_customLaplacianFunction) {
+        return CustomScalarField3(
+            _customFunction,
+            _customGradientFunction,
+            _customLaplacianFunction);
+    } else {
+        return CustomScalarField3(
+            _customFunction,
+            _customGradientFunction,
+            _resolution);
+    }
 }
 
 CustomScalarField3Ptr CustomScalarField3::Builder::makeShared() const {
-    return std::shared_ptr<CustomScalarField3>(
-        new CustomScalarField3(
-            _customFunction,
-            _customGradientFunction,
-            _customLaplacianFunction),
-        [] (CustomScalarField3* obj) {
-            delete obj;
-        });
+    if (_customLaplacianFunction) {
+        return std::shared_ptr<CustomScalarField3>(
+            new CustomScalarField3(
+                _customFunction,
+                _customGradientFunction,
+                _customLaplacianFunction),
+            [] (CustomScalarField3* obj) {
+                delete obj;
+            });
+    } else {
+        return std::shared_ptr<CustomScalarField3>(
+            new CustomScalarField3(
+                _customFunction,
+                _customGradientFunction,
+                _resolution),
+            [] (CustomScalarField3* obj) {
+                delete obj;
+            });
+    }
 }

--- a/src/jet/custom_vector_field2.cpp
+++ b/src/jet/custom_vector_field2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/custom_vector_field2.h>
@@ -90,18 +90,44 @@ CustomVectorField2::Builder::withCurlFunction(
     return *this;
 }
 
+CustomVectorField2::Builder&
+CustomVectorField2::Builder::withDerivativeResolution(double resolution) {
+    _resolution = resolution;
+    return *this;
+}
+
 CustomVectorField2 CustomVectorField2::Builder::build() const {
-    return CustomVectorField2(
-        _customFunction, _customDivergenceFunction, _customCurlFunction);
+    if (_customCurlFunction) {
+        return CustomVectorField2(
+            _customFunction,
+            _customDivergenceFunction,
+            _customCurlFunction);
+    } else {
+        return CustomVectorField2(
+            _customFunction,
+            _customDivergenceFunction,
+            _resolution);
+    }
 }
 
 CustomVectorField2Ptr CustomVectorField2::Builder::makeShared() const {
-    return std::shared_ptr<CustomVectorField2>(
-        new CustomVectorField2(
-            _customFunction,
-            _customDivergenceFunction,
-            _customCurlFunction),
-        [] (CustomVectorField2* obj) {
-            delete obj;
-        });
+    if (_customCurlFunction) {
+        return std::shared_ptr<CustomVectorField2>(
+            new CustomVectorField2(
+                _customFunction,
+                _customDivergenceFunction,
+                _customCurlFunction),
+            [] (CustomVectorField2* obj) {
+                delete obj;
+            });
+    } else {
+        return std::shared_ptr<CustomVectorField2>(
+            new CustomVectorField2(
+                _customFunction,
+                _customDivergenceFunction,
+                _resolution),
+            [] (CustomVectorField2* obj) {
+                delete obj;
+            });
+    }
 }

--- a/src/jet/custom_vector_field3.cpp
+++ b/src/jet/custom_vector_field3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/custom_vector_field3.h>
@@ -124,18 +124,44 @@ CustomVectorField3::Builder::withCurlFunction(
     return *this;
 }
 
+CustomVectorField3::Builder&
+CustomVectorField3::Builder::withDerivativeResolution(double resolution) {
+    _resolution = resolution;
+    return *this;
+}
+
 CustomVectorField3 CustomVectorField3::Builder::build() const {
-    return CustomVectorField3(
-        _customFunction, _customDivergenceFunction, _customCurlFunction);
+    if (_customCurlFunction) {
+        return CustomVectorField3(
+            _customFunction,
+            _customDivergenceFunction,
+            _customCurlFunction);
+    } else {
+        return CustomVectorField3(
+            _customFunction,
+            _customDivergenceFunction,
+            _resolution);
+    }
 }
 
 CustomVectorField3Ptr CustomVectorField3::Builder::makeShared() const {
-    return std::shared_ptr<CustomVectorField3>(
-        new CustomVectorField3(
-            _customFunction,
-            _customDivergenceFunction,
-            _customCurlFunction),
-        [] (CustomVectorField3* obj) {
-            delete obj;
-        });
+    if (_customCurlFunction) {
+        return std::shared_ptr<CustomVectorField3>(
+            new CustomVectorField3(
+                _customFunction,
+                _customDivergenceFunction,
+                _customCurlFunction),
+            [] (CustomVectorField3* obj) {
+                delete obj;
+            });
+    } else {
+        return std::shared_ptr<CustomVectorField3>(
+            new CustomVectorField3(
+                _customFunction,
+                _customDivergenceFunction,
+                _resolution),
+            [] (CustomVectorField3* obj) {
+                delete obj;
+            });
+    }
 }

--- a/src/jet/grid_blocked_boundary_condition_solver2.cpp
+++ b/src/jet/grid_blocked_boundary_condition_solver2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <physics_helpers.h>
@@ -62,11 +62,12 @@ void GridBlockedBoundaryConditionSolver2::onColliderUpdated(
     GridFractionalBoundaryConditionSolver2::onColliderUpdated(
         gridSize, gridSpacing, gridOrigin);
 
-    const CellCenteredScalarGrid2& sdf = colliderSdf();
+    const auto sdf
+        = std::dynamic_pointer_cast<CellCenteredScalarGrid2>(colliderSdf());
 
     _marker.resize(gridSize);
     _marker.parallelForEachIndex([&](size_t i, size_t j) {
-        if (isInsideSdf(sdf(i, j))) {
+        if (isInsideSdf((*sdf)(i, j))) {
             _marker(i, j) = kCollider;
         } else {
             _marker(i, j) = kFluid;

--- a/src/jet/grid_blocked_boundary_condition_solver3.cpp
+++ b/src/jet/grid_blocked_boundary_condition_solver3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <physics_helpers.h>
@@ -75,11 +75,12 @@ void GridBlockedBoundaryConditionSolver3::onColliderUpdated(
     GridFractionalBoundaryConditionSolver3::onColliderUpdated(
         gridSize, gridSpacing, gridOrigin);
 
-    const CellCenteredScalarGrid3& sdf = colliderSdf();
+    const auto sdf
+        = std::dynamic_pointer_cast<CellCenteredScalarGrid3>(colliderSdf());
 
     _marker.resize(gridSize);
     _marker.parallelForEachIndex([&](size_t i, size_t j, size_t k) {
-        if (isInsideSdf(sdf(i, j, k))) {
+        if (isInsideSdf((*sdf)(i, j, k))) {
             _marker(i, j, k) = kCollider;
         } else {
             _marker(i, j, k) = kFluid;

--- a/src/jet/grid_fluid_solver2.cpp
+++ b/src/jet/grid_fluid_solver2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/array_utils.h>
@@ -240,7 +240,7 @@ void GridFluidSolver2::computeViscosity(double timeIntervalInSeconds) {
             _viscosityCoefficient,
             timeIntervalInSeconds,
             vel.get(),
-            _colliderSdf,
+            *colliderSdf(),
             *fluidSdf());
         applyBoundaryCondition();
     }
@@ -255,8 +255,8 @@ void GridFluidSolver2::computePressure(double timeIntervalInSeconds) {
             *vel0,
             timeIntervalInSeconds,
             vel.get(),
-            _colliderSdf,
-            _colliderVel,
+            *colliderSdf(),
+            *colliderVelocityField(),
             *fluidSdf());
         applyBoundaryCondition();
     }
@@ -275,7 +275,7 @@ void GridFluidSolver2::computeAdvection(double timeIntervalInSeconds) {
                 *vel,
                 timeIntervalInSeconds,
                 grid.get(),
-                _colliderSdf);
+                *colliderSdf());
             extrapolateIntoCollider(grid.get());
         }
 
@@ -301,7 +301,7 @@ void GridFluidSolver2::computeAdvection(double timeIntervalInSeconds) {
                     *vel,
                     timeIntervalInSeconds,
                     collocated.get(),
-                    _colliderSdf);
+                    *colliderSdf());
                 extrapolateIntoCollider(collocated.get());
                 continue;
             }
@@ -316,7 +316,7 @@ void GridFluidSolver2::computeAdvection(double timeIntervalInSeconds) {
                     *vel,
                     timeIntervalInSeconds,
                     faceCentered.get(),
-                    _colliderSdf);
+                    *colliderSdf());
                 extrapolateIntoCollider(faceCentered.get());
                 continue;
             }
@@ -329,7 +329,7 @@ void GridFluidSolver2::computeAdvection(double timeIntervalInSeconds) {
             *vel0,
             timeIntervalInSeconds,
             vel.get(),
-            _colliderSdf);
+            *colliderSdf());
         applyBoundaryCondition();
     }
 }
@@ -373,7 +373,7 @@ void GridFluidSolver2::extrapolateIntoCollider(ScalarGrid2* grid) {
     Array2<char> marker(grid->dataSize());
     auto pos = grid->dataPosition();
     marker.parallelForEachIndex([&](size_t i, size_t j) {
-        if (isInsideSdf(_colliderSdf.sample(pos(i, j)))) {
+        if (isInsideSdf(colliderSdf()->sample(pos(i, j)))) {
             marker(i, j) = 0;
         } else {
             marker(i, j) = 1;
@@ -389,7 +389,7 @@ void GridFluidSolver2::extrapolateIntoCollider(CollocatedVectorGrid2* grid) {
     Array2<char> marker(grid->dataSize());
     auto pos = grid->dataPosition();
     marker.parallelForEachIndex([&](size_t i, size_t j) {
-        if (isInsideSdf(_colliderSdf.sample(pos(i, j)))) {
+        if (isInsideSdf(colliderSdf()->sample(pos(i, j)))) {
             marker(i, j) = 0;
         } else {
             marker(i, j) = 1;
@@ -411,7 +411,7 @@ void GridFluidSolver2::extrapolateIntoCollider(FaceCenteredGrid2* grid) {
     Array2<char> vMarker(v.size());
 
     uMarker.parallelForEachIndex([&](size_t i, size_t j) {
-        if (isInsideSdf(_colliderSdf.sample(uPos(i, j)))) {
+        if (isInsideSdf(colliderSdf()->sample(uPos(i, j)))) {
             uMarker(i, j) = 0;
         } else {
             uMarker(i, j) = 1;
@@ -419,7 +419,7 @@ void GridFluidSolver2::extrapolateIntoCollider(FaceCenteredGrid2* grid) {
     });
 
     vMarker.parallelForEachIndex([&](size_t i, size_t j) {
-        if (isInsideSdf(_colliderSdf.sample(vPos(i, j)))) {
+        if (isInsideSdf(colliderSdf()->sample(vPos(i, j)))) {
             vMarker(i, j) = 0;
         } else {
             vMarker(i, j) = 1;
@@ -431,19 +431,15 @@ void GridFluidSolver2::extrapolateIntoCollider(FaceCenteredGrid2* grid) {
     extrapolateToRegion(grid->vConstAccessor(), vMarker, depth, v);
 }
 
-const CellCenteredScalarGrid2& GridFluidSolver2::colliderSdf() const {
-    return _colliderSdf;
+ScalarField2Ptr GridFluidSolver2::colliderSdf() const {
+    return _boundaryConditionSolver->colliderSdf();
+}
+
+VectorField2Ptr GridFluidSolver2::colliderVelocityField() const {
+    return _boundaryConditionSolver->colliderVelocityField();
 }
 
 void GridFluidSolver2::beginAdvanceTimeStep(double timeIntervalInSeconds) {
-    Size2 res = _grids->resolution();
-    Vector2D h = _grids->gridSpacing();
-    Vector2D o = _grids->origin();
-
-    // Reserve memory
-    _colliderSdf.resize(res, h, o);
-    _colliderVel.resize(res, h, o);
-
     // Update collider and emitter
     Timer timer;
     updateCollider(timeIntervalInSeconds);
@@ -454,28 +450,6 @@ void GridFluidSolver2::beginAdvanceTimeStep(double timeIntervalInSeconds) {
     updateEmitter(timeIntervalInSeconds);
     JET_INFO << "Update emitter took "
              << timer.durationInSeconds() << " seconds";
-
-    // Rasterize collider into SDF
-    if (_collider != nullptr) {
-        auto pos = _colliderSdf.dataPosition();
-        Surface2Ptr surface = _collider->surface();
-        ImplicitSurface2Ptr implicitSurface
-            = std::dynamic_pointer_cast<ImplicitSurface2>(surface);
-        if (implicitSurface == nullptr) {
-            implicitSurface = std::make_shared<SurfaceToImplicit2>(surface);
-        }
-
-        _colliderSdf.fill([&](const Vector2D& pt) {
-            return implicitSurface->signedDistance(pt);
-        });
-
-        _colliderVel.fill([&] (const Vector2D& pt) {
-            return _collider->velocityAt(pt);
-        });
-    } else {
-        _colliderSdf.fill(kMaxD);
-        _colliderVel.fill({0, 0});
-    }
 
     // Update boundary condition solver
     if (_boundaryConditionSolver != nullptr) {

--- a/src/jet/grid_fluid_solver2.cpp
+++ b/src/jet/grid_fluid_solver2.cpp
@@ -510,3 +510,7 @@ void GridFluidSolver2::updateEmitter(double timeIntervalInSeconds) {
         _emitter->update(currentTimeInSeconds(), timeIntervalInSeconds);
     }
 }
+
+GridFluidSolver2::Builder GridFluidSolver2::builder() {
+    return Builder();
+}

--- a/src/jet/grid_fluid_solver3.cpp
+++ b/src/jet/grid_fluid_solver3.cpp
@@ -532,3 +532,7 @@ void GridFluidSolver3::updateEmitter(double timeIntervalInSeconds) {
         _emitter->update(currentTimeInSeconds(), timeIntervalInSeconds);
     }
 }
+
+GridFluidSolver3::Builder GridFluidSolver3::builder() {
+    return Builder();
+}

--- a/src/jet/grid_fractional_boundary_condition_solver2.cpp
+++ b/src/jet/grid_fractional_boundary_condition_solver2.cpp
@@ -194,7 +194,7 @@ void GridFractionalBoundaryConditionSolver2::onColliderUpdated(
             .withFunction([&] (const Vector2D& x) {
                 return collider()->velocityAt(x);
             })
-            .withDerivativeResolution(gridSize.x)
+            .withDerivativeResolution(gridSpacing.x)
             .makeShared();
     } else {
         _colliderSdf->fill(kMaxD);
@@ -203,7 +203,7 @@ void GridFractionalBoundaryConditionSolver2::onColliderUpdated(
             .withFunction([] (const Vector2D& x) {
                 return Vector2D();
             })
-            .withDerivativeResolution(gridSize.x)
+            .withDerivativeResolution(gridSpacing.x)
             .makeShared();
     }
 }

--- a/src/jet/grid_fractional_boundary_condition_solver2.cpp
+++ b/src/jet/grid_fractional_boundary_condition_solver2.cpp
@@ -1,8 +1,9 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <physics_helpers.h>
 #include <jet/array_utils.h>
+#include <jet/cell_centered_scalar_grid3.h>
 #include <jet/grid_fractional_boundary_condition_solver2.h>
 #include <jet/level_set_utils.h>
 #include <jet/surface_to_implicit2.h>
@@ -22,7 +23,7 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
     FaceCenteredGrid2* velocity,
     unsigned int extrapolationDepth) {
     Size2 size = velocity->resolution();
-    if (_colliderSdf.resolution() != size) {
+    if (_colliderSdf == nullptr || _colliderSdf->resolution() != size) {
         updateCollider(
             collider(),
             size,
@@ -45,8 +46,8 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
     // Assign collider's velocity first and initialize markers
     velocity->parallelForEachUIndex([&](size_t i, size_t j) {
         Vector2D pt = uPos(i, j);
-        double phi0 = _colliderSdf.sample(pt - Vector2D(0.5 * h.x, 0.0));
-        double phi1 = _colliderSdf.sample(pt + Vector2D(0.5 * h.x, 0.0));
+        double phi0 = _colliderSdf->sample(pt - Vector2D(0.5 * h.x, 0.0));
+        double phi1 = _colliderSdf->sample(pt + Vector2D(0.5 * h.x, 0.0));
         double frac = fractionInsideSdf(phi0, phi1);
         frac = 1.0 - clamp(frac, 0.0, 1.0);
 
@@ -61,8 +62,8 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
 
     velocity->parallelForEachVIndex([&](size_t i, size_t j) {
         Vector2D pt = vPos(i, j);
-        double phi0 = _colliderSdf.sample(pt - Vector2D(0.0, 0.5 * h.y));
-        double phi1 = _colliderSdf.sample(pt + Vector2D(0.0, 0.5 * h.y));
+        double phi0 = _colliderSdf->sample(pt - Vector2D(0.0, 0.5 * h.y));
+        double phi1 = _colliderSdf->sample(pt + Vector2D(0.0, 0.5 * h.y));
         double frac = fractionInsideSdf(phi0, phi1);
         frac = 1.0 - clamp(frac, 0.0, 1.0);
 
@@ -85,10 +86,10 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
     // normal
     velocity->parallelForEachUIndex([&](size_t i, size_t j) {
         Vector2D pt = uPos(i, j);
-        if (isInsideSdf(_colliderSdf.sample(pt))) {
+        if (isInsideSdf(_colliderSdf->sample(pt))) {
             Vector2D colliderVel = collider()->velocityAt(pt);
             Vector2D vel = velocity->sample(pt);
-            Vector2D g = _colliderSdf.gradient(pt);
+            Vector2D g = _colliderSdf->gradient(pt);
             if (g.lengthSquared() > 0.0) {
                 Vector2D n = g.normalized();
                 Vector2D velr = vel - colliderVel;
@@ -107,10 +108,10 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
 
     velocity->parallelForEachVIndex([&](size_t i, size_t j) {
         Vector2D pt = vPos(i, j);
-        if (isInsideSdf(_colliderSdf.sample(pt))) {
+        if (isInsideSdf(_colliderSdf->sample(pt))) {
             Vector2D colliderVel = collider()->velocityAt(pt);
             Vector2D vel = velocity->sample(pt);
-            Vector2D g = _colliderSdf.gradient(pt);
+            Vector2D g = _colliderSdf->gradient(pt);
             if (g.lengthSquared() > 0.0) {
                 Vector2D n = g.normalized();
                 Vector2D velr = vel - colliderVel;
@@ -158,16 +159,24 @@ void GridFractionalBoundaryConditionSolver2::constrainVelocity(
     }
 }
 
-const CellCenteredScalarGrid2&
+ScalarField2Ptr
 GridFractionalBoundaryConditionSolver2::colliderSdf() const {
     return _colliderSdf;
+}
+
+VectorField2Ptr
+GridFractionalBoundaryConditionSolver2::colliderVelocityField() const {
+    return _colliderVel;
 }
 
 void GridFractionalBoundaryConditionSolver2::onColliderUpdated(
     const Size2& gridSize,
     const Vector2D& gridSpacing,
     const Vector2D& gridOrigin) {
-    _colliderSdf.resize(gridSize, gridSpacing, gridOrigin);
+    if (_colliderSdf == nullptr) {
+        _colliderSdf = std::make_shared<CellCenteredScalarGrid2>();
+    }
+    _colliderSdf->resize(gridSize, gridSpacing, gridOrigin);
 
     if (collider() != nullptr) {
         Surface2Ptr surface = collider()->surface();
@@ -177,10 +186,24 @@ void GridFractionalBoundaryConditionSolver2::onColliderUpdated(
             implicitSurface = std::make_shared<SurfaceToImplicit2>(surface);
         }
 
-        _colliderSdf.fill([&](const Vector2D& pt) {
+        _colliderSdf->fill([&](const Vector2D& pt) {
             return implicitSurface->signedDistance(pt);
         });
+
+        _colliderVel = CustomVectorField2::builder()
+            .withFunction([&] (const Vector2D& x) {
+                return collider()->velocityAt(x);
+            })
+            .withDerivativeResolution(gridSize.x)
+            .makeShared();
     } else {
-        _colliderSdf.fill(kMaxD);
+        _colliderSdf->fill(kMaxD);
+
+        _colliderVel = CustomVectorField2::builder()
+            .withFunction([] (const Vector2D& x) {
+                return Vector2D();
+            })
+            .withDerivativeResolution(gridSize.x)
+            .makeShared();
     }
 }

--- a/src/jet/grid_fractional_boundary_condition_solver3.cpp
+++ b/src/jet/grid_fractional_boundary_condition_solver3.cpp
@@ -261,7 +261,7 @@ void GridFractionalBoundaryConditionSolver3::onColliderUpdated(
             .withFunction([&] (const Vector3D& x) {
                 return collider()->velocityAt(x);
             })
-            .withDerivativeResolution(gridSize.x)
+            .withDerivativeResolution(gridSpacing.x)
             .makeShared();
         });
     } else {
@@ -271,7 +271,7 @@ void GridFractionalBoundaryConditionSolver3::onColliderUpdated(
             .withFunction([] (const Vector3D& x) {
                 return Vector3D();
             })
-            .withDerivativeResolution(gridSize.x)
+            .withDerivativeResolution(gridSpacing.x)
             .makeShared();
     }
 }

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -219,10 +219,14 @@ void GridFractionalSinglePhasePressureSolver2::buildSystem(
 
             // Accumulate contributions from the moving boundary
             double boundaryContribution
-                = (1.0 - _uWeights(i + 1, j)) * _boundaryVel(uPos(i + 1, j)).x * invH.x
-                - (1.0 - _uWeights(i, j)) * _boundaryVel(uPos(i, j)).x * invH.x
-                + (1.0 - _vWeights(i, j + 1)) * _boundaryVel(vPos(i, j + 1)).y * invH.y
-                - (1.0 - _vWeights(i, j)) * _boundaryVel(vPos(i, j)).y * invH.y;
+                = (1.0 - _uWeights(i + 1, j))
+                    * _boundaryVel(uPos(i + 1, j)).x * invH.x
+                - (1.0 - _uWeights(i, j))
+                    * _boundaryVel(uPos(i, j)).x * invH.x
+                + (1.0 - _vWeights(i, j + 1))
+                    * _boundaryVel(vPos(i, j + 1)).y * invH.y
+                - (1.0 - _vWeights(i, j))
+                    * _boundaryVel(vPos(i, j)).y * invH.y;
             _system.b(i, j) += boundaryContribution;
         } else {
             row.center = 1.0;

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -104,7 +104,7 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
             weight = kMinWeight;
         }
 
-        _uWeights(i, j) = weight;
+        _uWeights(i, j) = static_cast<float>(weight);
     });
 
     _vWeights.parallelForEachIndex([&](size_t i, size_t j) {
@@ -120,7 +120,7 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
             weight = kMinWeight;
         }
 
-        _vWeights(i, j) = weight;
+        _vWeights(i, j) = static_cast<float>(weight);
     });
 }
 

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -80,12 +80,13 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
     auto vPos = input.vPosition();
     _uWeights.resize(uSize);
     _vWeights.resize(vSize);
-    _uBoundary.resize(uSize);
-    _vBoundary.resize(vSize);
-    _fluidSdf.resize(input.resolution(), input.gridSpacing(), input.origin());
+    _fluidSdf.resize(input.resolution());
+    _boundaryVel = boundaryVelocity.sampler();
 
-    _fluidSdf.fill([&](const Vector2D& x) {
-        return fluidSdf.sample(x);
+    auto cellPos = input.cellCenterPosition();
+    _fluidSdf.parallelForEachIndex([&](size_t i, size_t j) {
+        _fluidSdf(i, j)
+            = static_cast<float>(fluidSdf.sample(cellPos(i, j)));
     });
 
     Vector2D h = input.gridSpacing();
@@ -104,7 +105,6 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
         }
 
         _uWeights(i, j) = weight;
-        _uBoundary(i, j) = boundaryVelocity.sample(pt).x;
     });
 
     _vWeights.parallelForEachIndex([&](size_t i, size_t j) {
@@ -121,19 +121,20 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
         }
 
         _vWeights(i, j) = weight;
-        _vBoundary(i, j) = boundaryVelocity.sample(pt).y;
     });
 }
 
 void GridFractionalSinglePhasePressureSolver2::buildSystem(
     const FaceCenteredGrid2& input) {
-    Size2 size = input.resolution();
+    const Size2 size = input.resolution();
+    const auto uPos = input.uPosition();
+    const auto vPos = input.vPosition();
     _system.A.resize(size);
     _system.x.resize(size);
     _system.b.resize(size);
 
-    Vector2D invH = 1.0 / input.gridSpacing();
-    Vector2D invHSqr = invH * invH;
+    const Vector2D invH = 1.0 / input.gridSpacing();
+    const Vector2D invHSqr = invH * invH;
 
     // Build linear system
     _system.A.parallelForEachIndex([&](size_t i, size_t j) {
@@ -218,10 +219,10 @@ void GridFractionalSinglePhasePressureSolver2::buildSystem(
 
             // Accumulate contributions from the moving boundary
             double boundaryContribution
-                = (1.0 - _uWeights(i + 1, j)) * _uBoundary(i + 1, j) * invH.x
-                - (1.0 - _uWeights(i, j)) * _uBoundary(i, j) * invH.x
-                + (1.0 - _vWeights(i, j + 1)) * _vBoundary(i, j + 1) * invH.y
-                - (1.0 - _vWeights(i, j)) * _vBoundary(i, j) * invH.y;
+                = (1.0 - _uWeights(i + 1, j)) * _boundaryVel(uPos(i + 1, j)).x * invH.x
+                - (1.0 - _uWeights(i, j)) * _boundaryVel(uPos(i, j)).x * invH.x
+                + (1.0 - _vWeights(i, j + 1)) * _boundaryVel(vPos(i, j + 1)).y * invH.y
+                - (1.0 - _vWeights(i, j)) * _boundaryVel(vPos(i, j)).y * invH.y;
             _system.b(i, j) += boundaryContribution;
         } else {
             row.center = 1.0;

--- a/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
@@ -276,12 +276,18 @@ void GridFractionalSinglePhasePressureSolver3::buildSystem(
 
             // Accumulate contributions from the moving boundary
             double boundaryContribution
-             = (1.0 - _uWeights(i + 1, j, k)) * _boundaryVel(uPos(i + 1, j, k)).x * invH.x
-             - (1.0 - _uWeights(i, j, k)) * _boundaryVel(uPos(i, j, k)).x * invH.x
-             + (1.0 - _vWeights(i, j + 1, k)) * _boundaryVel(vPos(i, j + 1, k)).y * invH.y
-             - (1.0 - _vWeights(i, j, k)) * _boundaryVel(vPos(i, j, k)).y * invH.y
-             + (1.0 - _wWeights(i, j, k + 1)) * _boundaryVel(wPos(i, j, k + 1)).y * invH.z
-             - (1.0 - _wWeights(i, j, k)) * _boundaryVel(wPos(i, j, k)).y * invH.z;
+             = (1.0 - _uWeights(i + 1, j, k))
+                * _boundaryVel(uPos(i + 1, j, k)).x * invH.x
+             - (1.0 - _uWeights(i, j, k))
+                * _boundaryVel(uPos(i, j, k)).x * invH.x
+             + (1.0 - _vWeights(i, j + 1, k))
+                * _boundaryVel(vPos(i, j + 1, k)).y * invH.y
+             - (1.0 - _vWeights(i, j, k))
+                * _boundaryVel(vPos(i, j, k)).y * invH.y
+             + (1.0 - _wWeights(i, j, k + 1))
+                * _boundaryVel(wPos(i, j, k + 1)).y * invH.z
+             - (1.0 - _wWeights(i, j, k))
+                * _boundaryVel(wPos(i, j, k)).y * invH.z;
             _system.b(i, j, k) += boundaryContribution;
         } else {
             row.center = 1.0;

--- a/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
@@ -276,18 +276,18 @@ void GridFractionalSinglePhasePressureSolver3::buildSystem(
 
             // Accumulate contributions from the moving boundary
             double boundaryContribution
-             = (1.0 - _uWeights(i + 1, j, k))
-                * _boundaryVel(uPos(i + 1, j, k)).x * invH.x
-             - (1.0 - _uWeights(i, j, k))
-                * _boundaryVel(uPos(i, j, k)).x * invH.x
-             + (1.0 - _vWeights(i, j + 1, k))
-                * _boundaryVel(vPos(i, j + 1, k)).y * invH.y
-             - (1.0 - _vWeights(i, j, k))
-                * _boundaryVel(vPos(i, j, k)).y * invH.y
-             + (1.0 - _wWeights(i, j, k + 1))
-                * _boundaryVel(wPos(i, j, k + 1)).y * invH.z
-             - (1.0 - _wWeights(i, j, k))
-                * _boundaryVel(wPos(i, j, k)).y * invH.z;
+                = (1.0 - _uWeights(i + 1, j, k))
+                    * _boundaryVel(uPos(i + 1, j, k)).x * invH.x
+                - (1.0 - _uWeights(i, j, k))
+                    * _boundaryVel(uPos(i, j, k)).x * invH.x
+                + (1.0 - _vWeights(i, j + 1, k))
+                    * _boundaryVel(vPos(i, j + 1, k)).y * invH.y
+                - (1.0 - _vWeights(i, j, k))
+                    * _boundaryVel(vPos(i, j, k)).y * invH.y
+                + (1.0 - _wWeights(i, j, k + 1))
+                    * _boundaryVel(wPos(i, j, k + 1)).y * invH.z
+                - (1.0 - _wWeights(i, j, k))
+                    * _boundaryVel(wPos(i, j, k)).y * invH.z;
             _system.b(i, j, k) += boundaryContribution;
         } else {
             row.center = 1.0;

--- a/src/jet/grid_smoke_solver2.cpp
+++ b/src/jet/grid_smoke_solver2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/grid_smoke_solver2.h>
@@ -101,7 +101,7 @@ void GridSmokeSolver2::computeDiffusion(double timeIntervalInSeconds) {
                 _smokeDiffusionCoefficient,
                 timeIntervalInSeconds,
                 den0.get(),
-                colliderSdf());
+                *colliderSdf());
             extrapolateIntoCollider(den.get());
         }
 
@@ -115,7 +115,7 @@ void GridSmokeSolver2::computeDiffusion(double timeIntervalInSeconds) {
                 _temperatureDiffusionCoefficient,
                 timeIntervalInSeconds,
                 temp.get(),
-                colliderSdf());
+                *colliderSdf());
             extrapolateIntoCollider(temp.get());
         }
     }

--- a/src/jet/grid_smoke_solver3.cpp
+++ b/src/jet/grid_smoke_solver3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <pch.h>
 #include <jet/grid_smoke_solver3.h>
@@ -101,7 +101,7 @@ void GridSmokeSolver3::computeDiffusion(double timeIntervalInSeconds) {
                 _smokeDiffusionCoefficient,
                 timeIntervalInSeconds,
                 den0.get(),
-                colliderSdf());
+                *colliderSdf());
             extrapolateIntoCollider(den.get());
         }
 
@@ -115,7 +115,7 @@ void GridSmokeSolver3::computeDiffusion(double timeIntervalInSeconds) {
                 _temperatureDiffusionCoefficient,
                 timeIntervalInSeconds,
                 temp.get(),
-                colliderSdf());
+                *colliderSdf());
             extrapolateIntoCollider(temp.get());
         }
     }

--- a/src/tests/perf_tests/PerfTests.vcxproj
+++ b/src/tests/perf_tests/PerfTests.vcxproj
@@ -19,10 +19,16 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="fdm_iccg_solver3_tests.cpp" />
     <ClCompile Include="fdm_linear_systems_tests.cpp" />
+    <ClCompile Include="flip_solver3_tests.cpp" />
+    <ClCompile Include="get_rss.cpp" />
+    <ClCompile Include="grid_fluid_solver3_tests.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="parallel_tests.cpp" />
+    <ClCompile Include="perf_tests.cpp" />
     <ClCompile Include="point_hash_grid_searchers_tests.cpp" />
+    <ClCompile Include="volume_particle_emitter3_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="perf_tests.h" />

--- a/src/tests/perf_tests/PerfTests.vcxproj.filters
+++ b/src/tests/perf_tests/PerfTests.vcxproj.filters
@@ -15,7 +15,19 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="point_hash_grid_searchers_tests.cpp">
+    <ClCompile Include="fdm_iccg_solver3_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fdm_linear_systems_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="flip_solver3_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="get_rss.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="grid_fluid_solver3_tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="main.cpp">
@@ -24,7 +36,13 @@
     <ClCompile Include="parallel_tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="fdm_linear_systems_tests.cpp">
+    <ClCompile Include="perf_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="point_hash_grid_searchers_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="volume_particle_emitter3_tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/tests/perf_tests/fdm_iccg_solver3_tests.cpp
+++ b/src/tests/perf_tests/fdm_iccg_solver3_tests.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <perf_tests.h>
+#include <jet/fdm_iccg_solver3.h>
+#include <jet/timer.h>
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+TEST(FdmIccgSolver3, Memory) {
+    const size_t n = 300;
+
+    const size_t mem0 = getCurrentRSS();
+
+    FdmLinearSystem3 system;
+    system.A.resize(n, n, n);
+    system.x.resize(n, n, n);
+    system.b.resize(n, n, n);
+
+    FdmIccgSolver3 solver(1, 0.0);
+    solver.solve(&system);
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO("Mem usage: %f %s.\n", msg.first, msg.second.c_str());
+}

--- a/src/tests/perf_tests/fdm_linear_systems_tests.cpp
+++ b/src/tests/perf_tests/fdm_linear_systems_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <perf_tests.h>
 #include <jet/fdm_linear_system2.h>

--- a/src/tests/perf_tests/flip_solver3_tests.cpp
+++ b/src/tests/perf_tests/flip_solver3_tests.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <perf_tests.h>
+#include <jet/flip_solver3.h>
+#include <jet/timer.h>
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+TEST(FlipSolver3, Memory) {
+    const size_t n = 300;
+
+    const size_t mem0 = getCurrentRSS();
+
+    auto solver = FlipSolver3::builder()
+        .withResolution({n, n, n})
+        .makeShared();
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg1 = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO(
+        "Start mem. usage: %f %s.\n",
+        msg1.first,
+        msg1.second.c_str());
+
+    solver->update(Frame(1, 0.01));
+
+    const size_t mem2 = getCurrentRSS();
+
+    const auto msg2 = makeReadableByteSize(mem2 - mem0);
+
+    JET_PRINT_INFO(
+        "Single update mem. usage: %f %s.\n",
+        msg2.first,
+        msg2.second.c_str());
+}

--- a/src/tests/perf_tests/get_rss.cpp
+++ b/src/tests/perf_tests/get_rss.cpp
@@ -1,0 +1,122 @@
+/*
+ * Author:  David Robert Nadeau
+ * Site:    http://NadeauSoftware.com/
+ * License: Creative Commons Attribution 3.0 Unported License
+ *          http://creativecommons.org/licenses/by/3.0/deed.en_US
+ */
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <psapi.h>
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>
+#include <sys/resource.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach.h>
+
+#elif (defined(_AIX) || defined(__TOS__AIX__)) || (defined(__sun__) || defined(__sun) || defined(sun) && (defined(__SVR4) || defined(__svr4__)))
+#include <fcntl.h>
+#include <procfs.h>
+
+#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+#include <stdio.h>
+
+#endif
+
+#else
+#error "Cannot define getPeakRSS( ) or getCurrentRSS( ) for an unknown OS."
+#endif
+
+
+
+
+
+/**
+ * Returns the peak (maximum so far) resident set size (physical
+ * memory use) measured in bytes, or zero if the value cannot be
+ * determined on this OS.
+ */
+size_t getPeakRSS( )
+{
+#if defined(_WIN32)
+    /* Windows -------------------------------------------------- */
+    PROCESS_MEMORY_COUNTERS info;
+    GetProcessMemoryInfo( GetCurrentProcess( ), &info, sizeof(info) );
+    return (size_t)info.PeakWorkingSetSize;
+
+#elif (defined(_AIX) || defined(__TOS__AIX__)) || (defined(__sun__) || defined(__sun) || defined(sun) && (defined(__SVR4) || defined(__svr4__)))
+    /* AIX and Solaris ------------------------------------------ */
+    struct psinfo psinfo;
+    int fd = -1;
+    if ( (fd = open( "/proc/self/psinfo", O_RDONLY )) == -1 )
+        return (size_t)0L;      /* Can't open? */
+    if ( read( fd, &psinfo, sizeof(psinfo) ) != sizeof(psinfo) )
+    {
+        close( fd );
+        return (size_t)0L;      /* Can't read? */
+    }
+    close( fd );
+    return (size_t)(psinfo.pr_rssize * 1024L);
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
+    /* BSD, Linux, and OSX -------------------------------------- */
+    struct rusage rusage;
+    getrusage( RUSAGE_SELF, &rusage );
+#if defined(__APPLE__) && defined(__MACH__)
+    return (size_t)rusage.ru_maxrss;
+#else
+    return (size_t)(rusage.ru_maxrss * 1024L);
+#endif
+
+#else
+    /* Unknown OS ----------------------------------------------- */
+    return (size_t)0L;          /* Unsupported. */
+#endif
+}
+
+
+
+
+
+/**
+ * Returns the current resident set size (physical memory use) measured
+ * in bytes, or zero if the value cannot be determined on this OS.
+ */
+size_t getCurrentRSS( )
+{
+#if defined(_WIN32)
+    /* Windows -------------------------------------------------- */
+    PROCESS_MEMORY_COUNTERS info;
+    GetProcessMemoryInfo( GetCurrentProcess( ), &info, sizeof(info) );
+    return (size_t)info.WorkingSetSize;
+
+#elif defined(__APPLE__) && defined(__MACH__)
+    /* OSX ------------------------------------------------------ */
+    struct mach_task_basic_info info;
+    mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
+    if ( task_info( mach_task_self( ), MACH_TASK_BASIC_INFO,
+        (task_info_t)&info, &infoCount ) != KERN_SUCCESS )
+        return (size_t)0L;      /* Can't access? */
+    return (size_t)info.resident_size;
+
+#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+    /* Linux ---------------------------------------------------- */
+    long rss = 0L;
+    FILE* fp = NULL;
+    if ( (fp = fopen( "/proc/self/statm", "r" )) == NULL )
+        return (size_t)0L;      /* Can't open? */
+    if ( fscanf( fp, "%*s%ld", &rss ) != 1 )
+    {
+        fclose( fp );
+        return (size_t)0L;      /* Can't read? */
+    }
+    fclose( fp );
+    return (size_t)rss * (size_t)sysconf( _SC_PAGESIZE);
+
+#else
+    /* AIX, BSD, Solaris, and Unknown OS ------------------------ */
+    return (size_t)0L;          /* Unsupported. */
+#endif
+}

--- a/src/tests/perf_tests/grid_fluid_solver3_tests.cpp
+++ b/src/tests/perf_tests/grid_fluid_solver3_tests.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <perf_tests.h>
+#include <jet/grid_fluid_solver3.h>
+#include <jet/timer.h>
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+TEST(GridFluidSolver3, Memory) {
+    const size_t n = 300;
+
+    const size_t mem0 = getCurrentRSS();
+
+    auto solver = GridFluidSolver3::builder()
+        .withResolution({n, n, n})
+        .makeShared();
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg1 = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO(
+        "Start mem. usage: %f %s.\n",
+        msg1.first,
+        msg1.second.c_str());
+
+    solver->update(Frame(1, 0.01));
+
+    const size_t mem2 = getCurrentRSS();
+
+    const auto msg2 = makeReadableByteSize(mem2 - mem0);
+
+    JET_PRINT_INFO(
+        "Single update mem. usage: %f %s.\n",
+        msg2.first,
+        msg2.second.c_str());
+}

--- a/src/tests/perf_tests/perf_tests.cpp
+++ b/src/tests/perf_tests/perf_tests.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <perf_tests.h>
+#include <string>
+#include <utility>
+
+std::pair<double, std::string> makeReadableByteSize(size_t bytes) {
+    double s = bytes;
+    std::string unit = "B";
+
+    if (s > 1024) {
+        s /= 1024;
+        unit = "kB";
+    }
+
+    if (s > 1024) {
+        s /= 1024;
+        unit = "MB";
+    }
+
+    if (s > 1024) {
+        s /= 1024;
+        unit = "GB";
+    }
+
+    if (s > 1024) {
+        s /= 1024;
+        unit = "TB";
+    }
+
+    return std::make_pair(s, unit);
+}

--- a/src/tests/perf_tests/perf_tests.cpp
+++ b/src/tests/perf_tests/perf_tests.cpp
@@ -5,7 +5,7 @@
 #include <utility>
 
 std::pair<double, std::string> makeReadableByteSize(size_t bytes) {
-    double s = bytes;
+    double s = static_cast<double>(bytes);
     std::string unit = "B";
 
     if (s > 1024) {

--- a/src/tests/perf_tests/perf_tests.h
+++ b/src/tests/perf_tests/perf_tests.h
@@ -31,7 +31,7 @@ std::pair<double, std::string> makeReadableByteSize(size_t bytes);
 
 #define JET_PRINT_INFO(fmt, ...) \
     testing::internal::ColoredPrintf( \
-        testing::internal::COLOR_YELLOW,  "[----------] "); \
+        testing::internal::COLOR_YELLOW,  "[ STAT     ] "); \
     testing::internal::ColoredPrintf( \
         testing::internal::COLOR_YELLOW, fmt, __VA_ARGS__); \
 

--- a/src/tests/perf_tests/perf_tests.h
+++ b/src/tests/perf_tests/perf_tests.h
@@ -3,8 +3,8 @@
 #ifndef SRC_TESTS_PERF_TESTS_PERF_TESTS_H_
 #define SRC_TESTS_PERF_TESTS_PERF_TESTS_H_
 
-#include <chrono>
 #include <string>
+#include <utility>
 #include <vector>
 
 // gtest hack
@@ -24,6 +24,10 @@ extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
 }  // namespace internal
 
 }  // namespace testing
+
+size_t getCurrentRSS();
+
+std::pair<double, std::string> makeReadableByteSize(size_t bytes);
 
 #define JET_PRINT_INFO(fmt, ...) \
     testing::internal::ColoredPrintf( \

--- a/src/tests/perf_tests/volume_particle_emitter3_tests.cpp
+++ b/src/tests/perf_tests/volume_particle_emitter3_tests.cpp
@@ -11,7 +11,7 @@
 using namespace jet;
 
 TEST(VolumeParticleEmitter3, Update) {
-    double dx = 0.1;
+    double dx = 0.2;
     double lx = 30.0;
     double ly = 30.0;
     double lz = 30.0;
@@ -48,5 +48,5 @@ TEST(VolumeParticleEmitter3, Update) {
 
     JET_PRINT_INFO(
         "VolumeParticleEmitter3::build avg. %f sec.\n",
-        timer.durationInSeconds() / 10.0);
+        timer.durationInSeconds());
 }

--- a/src/tests/perf_tests/volume_particle_emitter3_tests.cpp
+++ b/src/tests/perf_tests/volume_particle_emitter3_tests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <perf_tests.h>
+#include <jet/box3.h>
+#include <jet/implicit_surface_set3.h>
+#include <jet/timer.h>
+#include <jet/volume_particle_emitter3.h>
+#include <gtest/gtest.h>
+#include <random>
+
+using namespace jet;
+
+TEST(VolumeParticleEmitter3, Update) {
+    double dx = 0.1;
+    double lx = 30.0;
+    double ly = 30.0;
+    double lz = 30.0;
+    double pd = 0.001;
+
+    // Build emitter
+    auto box1 = Box3::builder()
+        .withLowerCorner({0, 0, 0})
+        .withUpperCorner({0.5 * lx + pd, 0.75 * ly + pd, 0.75 * lz + pd})
+        .makeShared();
+
+    auto box2 = Box3::builder()
+        .withLowerCorner({2.5 * lx - pd, 0, 0.25 * lz - pd})
+        .withUpperCorner({3.5 * lx + pd, 0.75 * ly + pd, 1.5 * lz + pd})
+        .makeShared();
+
+    auto boxSet = ImplicitSurfaceSet3::builder()
+        .withExplicitSurfaces({box1, box2})
+        .makeShared();
+
+    auto emitter = VolumeParticleEmitter3::builder()
+        .withSurface(boxSet)
+        .withMaxRegion(BoundingBox3D({0, 0, 0}, {lx, ly, lz}))
+        .withSpacing(0.5 * dx)
+        .withAllowOverlapping(true)
+        .makeShared();
+
+    auto particles = std::make_shared<ParticleSystemData3>();
+    emitter->setTarget(particles);
+
+    Timer timer;
+
+    emitter->update(0.0, 0.01);
+
+    JET_PRINT_INFO(
+        "VolumeParticleEmitter3::build avg. %f sec.\n",
+        timer.durationInSeconds() / 10.0);
+}


### PR DESCRIPTION
This PR improves memory performance for about 30% and more for pure GridFluidSolver3D. Subclasses also take benefit of this enhancement. Such an optimization was done by:

* Getting rid of redundant data
* Use float instead of double for static cache

However, this PR somewhat fixes #51, but not entirely. Issue #51 may be fixed by introducing better sparse matrix and vector.

Also, Jet Framework uses double as its default currency which is by-design for better numerical stability. However, similar to this PR, there could be more room for further optimization by using float buffers for static caches (things that do not accumulate over iterations).