### PR TITLE
Modify begin(), end() to cbegin(), cend()

### DIFF
--- a/include/jet/detail/array1-inl.h
+++ b/include/jet/detail/array1-inl.h
@@ -98,7 +98,7 @@ typename Array<T, 1>::ContainerType::iterator Array<T, 1>::begin() {
 
 template <typename T>
 typename Array<T, 1>::ContainerType::const_iterator Array<T, 1>::begin() const {
-    return _data.begin();
+    return _data.cbegin();
 }
 
 template <typename T>
@@ -108,7 +108,7 @@ typename Array<T, 1>::ContainerType::iterator Array<T, 1>::end() {
 
 template <typename T>
 typename Array<T, 1>::ContainerType::const_iterator Array<T, 1>::end() const {
-    return _data.end();
+    return _data.cend();
 }
 
 template <typename T>

--- a/include/jet/detail/array2-inl.h
+++ b/include/jet/detail/array2-inl.h
@@ -160,7 +160,7 @@ typename Array<T, 2>::ContainerType::iterator Array<T, 2>::begin() {
 
 template <typename T>
 typename Array<T, 2>::ContainerType::const_iterator Array<T, 2>::begin() const {
-    return _data.begin();
+    return _data.cbegin();
 }
 
 template <typename T>
@@ -170,7 +170,7 @@ typename Array<T, 2>::ContainerType::iterator Array<T, 2>::end() {
 
 template <typename T>
 typename Array<T, 2>::ContainerType::const_iterator Array<T, 2>::end() const {
-    return _data.end();
+    return _data.cend();
 }
 
 template <typename T>

--- a/include/jet/detail/array3-inl.h
+++ b/include/jet/detail/array3-inl.h
@@ -180,7 +180,7 @@ typename Array<T, 3>::ContainerType::iterator Array<T, 3>::begin() {
 
 template <typename T>
 typename Array<T, 3>::ContainerType::const_iterator Array<T, 3>::begin() const {
-    return _data.begin();
+    return _data.cbegin();
 }
 
 template <typename T>
@@ -190,7 +190,7 @@ typename Array<T, 3>::ContainerType::iterator Array<T, 3>::end() {
 
 template <typename T>
 typename Array<T, 3>::ContainerType::const_iterator Array<T, 3>::end() const {
-    return _data.end();
+    return _data.cend();
 }
 
 template <typename T>


### PR DESCRIPTION
Hello,

```typename Array<T, 1>::ContainerType::const_iterator Array<T, 1>::begin() const;```
In begin() function, return type is ```const_iterator```. Therefore, I think that body part should be the function call of ```cbegin()``` instead of ```begin()```. In the same way, the body part of ```end()``` should be the function call of ```cend()``` instead of ```end()```. What do you think?

Chris.