### PR TITLE
Adding ImplicitTriangleMesh3

### DIFF
--- a/include/jet/implicit_triangle_mesh3.h
+++ b/include/jet/implicit_triangle_mesh3.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 Doyub Kim
+
+#ifndef INCLUDE_JET_IMPLICIT_TRIANGLE_MESH3_H_
+#define INCLUDE_JET_IMPLICIT_TRIANGLE_MESH3_H_
+
+#include <jet/custom_implicit_surface3.h>
+#include <jet/implicit_surface3.h>
+#include <jet/triangle_mesh3.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+namespace jet {
+
+//!
+//! \brief  TriangleMesh3 to ImplicitSurface3 converter.
+//!
+//! This class builds signed-distance field for given TriangleMesh3 instance so
+//! that it can be used as an ImplicitSurface3 instance. The mesh is discretized
+//! into a regular grid and the signed-distance is measured at each grid point.
+//! Thus, there is a sampling error and its magnitude depends on the grid
+//! resolution.
+//!
+class ImplicitTriangleMesh3 final : public ImplicitSurface3 {
+ public:
+    class Builder;
+
+    ImplicitTriangleMesh3(
+        const TriangleMesh3Ptr& mesh,
+        size_t resolutionX,
+        double margin,
+        const Transform3& transform = Transform3(),
+        bool isNormalFlipped = false);
+
+    virtual ~ImplicitTriangleMesh3();
+
+    //! Returns builder fox ImplicitTriangleMesh3.
+    static Builder builder();
+
+ private:
+    TriangleMesh3Ptr _mesh;
+    VertexCenteredScalarGrid3 _grid;
+    CustomImplicitSurface3Ptr _customImplicitSurface;
+
+    Vector3D closestPointLocal(const Vector3D& otherPoint) const override;
+
+    double closestDistanceLocal(const Vector3D& otherPoint) const override;
+
+    bool intersectsLocal(const Ray3D& ray) const override;
+
+    BoundingBox3D boundingBoxLocal() const override;
+
+    Vector3D closestNormalLocal(
+        const Vector3D& otherPoint) const override;
+
+    double signedDistanceLocal(const Vector3D& otherPoint) const override;
+
+    SurfaceRayIntersection3 closestIntersectionLocal(
+        const Ray3D& ray) const override;
+};
+
+//! Shared pointer for the ImplicitTriangleMesh3 type.
+typedef std::shared_ptr<ImplicitTriangleMesh3> ImplicitTriangleMesh3Ptr;
+
+//!
+//! \brief Front-end to create ImplicitTriangleMesh3 objects step by step.
+//!
+class ImplicitTriangleMesh3::Builder final
+    : public SurfaceBuilderBase3<ImplicitTriangleMesh3::Builder> {
+ public:
+    //! Returns builder with triangle mesh.
+    Builder& withTriangleMesh(const TriangleMesh3Ptr& mesh);
+
+    //! Returns builder with resolution in x axis.
+    Builder& withResolutionX(size_t resolutionX);
+
+    //! Returns builder with margin around the mesh.
+    Builder& withMargin(double margin);
+
+    //! Builds ImplicitTriangleMesh3.
+    ImplicitTriangleMesh3 build() const;
+
+    //! Builds shared pointer of ImplicitTriangleMesh3 instance.
+    ImplicitTriangleMesh3Ptr makeShared() const;
+
+ private:
+    TriangleMesh3Ptr _mesh;
+    size_t _resolutionX = 32;
+    double _margin = 0.2;
+};
+
+}  // namespace jet
+
+#endif  // INCLUDE_JET_IMPLICIT_TRIANGLE_MESH3_H_

--- a/include/jet/jet.h
+++ b/include/jet/jet.h
@@ -111,6 +111,7 @@
 #include <jet/implicit_surface3.h>
 #include <jet/implicit_surface_set2.h>
 #include <jet/implicit_surface_set3.h>
+#include <jet/implicit_triangle_mesh3.h>
 #include <jet/iterative_level_set_solver2.h>
 #include <jet/iterative_level_set_solver3.h>
 #include <jet/jet.h>

--- a/include/jet/surface_to_implicit2.h
+++ b/include/jet/surface_to_implicit2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_SURFACE_TO_IMPLICIT2_H_
 #define INCLUDE_JET_SURFACE_TO_IMPLICIT2_H_
@@ -12,7 +12,10 @@ namespace jet {
 //! \brief 2-D implicit surface wrapper for generic Surface2 instance.
 //!
 //! This class represents 2-D implicit surface that converts Surface2 instance
-//! to an ImplicitSurface2 object.
+//! to an ImplicitSurface2 object. The conversion is made by evaluating closest
+//! point and normal from a given point for the given (explicit) surface. Thus,
+//! this conversion won't work for every single surfaces. Use this class only
+//! for the basic primitives such as Sphere2 or Box2.
 //!
 class SurfaceToImplicit2 final : public ImplicitSurface2 {
  public:

--- a/include/jet/surface_to_implicit3.h
+++ b/include/jet/surface_to_implicit3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #ifndef INCLUDE_JET_SURFACE_TO_IMPLICIT3_H_
 #define INCLUDE_JET_SURFACE_TO_IMPLICIT3_H_
@@ -12,7 +12,12 @@ namespace jet {
 //! \brief 3-D implicit surface wrapper for generic Surface3 instance.
 //!
 //! This class represents 3-D implicit surface that converts Surface3 instance
-//! to an ImplicitSurface3 object.
+//! to an ImplicitSurface3 object. The conversion is made by evaluating closest
+//! point and normal from a given point for the given (explicit) surface. Thus,
+//! this conversion won't work for every single surfaces, especially
+//! TriangleMesh3. To use TriangleMesh3 as an ImplicitSurface3 instance,
+//! please take a look at ImplicitTriangleMesh3. Use this class only
+//! for the basic primitives such as Sphere3 or Box3.
 //!
 class SurfaceToImplicit3 final : public ImplicitSurface3 {
  public:

--- a/src/examples/level_set_liquid_sim/main.cpp
+++ b/src/examples/level_set_liquid_sim/main.cpp
@@ -234,26 +234,17 @@ void runExample3(
     auto grids = solver->gridSystemData();
 
     // Build emitters
-    VertexCenteredScalarGrid3 bunnySdf;
-    std::ifstream sdfFile("bunny.sdf", std::ifstream::binary);
-    if (sdfFile) {
-        std::vector<uint8_t> buffer(
-            (std::istreambuf_iterator<char>(sdfFile)),
-            (std::istreambuf_iterator<char>()));
-        bunnySdf.deserialize(buffer);
-        sdfFile.close();
+    auto bunnyMesh = TriangleMesh3::builder().makeShared();
+    std::ifstream objFile("resources/bunny.obj");
+    if (objFile) {
+        bunnyMesh->readObj(&objFile);
     } else {
-        fprintf(stderr, "Cannot open bunny.sdf\n");
-        fprintf(
-            stderr,
-            "Run\nbin/obj2sdf -i resources/bunny.obj"
-            " -o bunny.sdf\nto generate the sdf file.\n");
+        fprintf(stderr, "Cannot open resources/bunny.obj\n");
         exit(EXIT_FAILURE);
     }
-
-    auto bunny = CustomImplicitSurface3::builder()
-        .withSignedDistanceFunction(bunnySdf.sampler())
-        .withResolution(grids->gridSpacing().x)
+    auto bunny = ImplicitTriangleMesh3::builder()
+        .withTriangleMesh(bunnyMesh)
+        .withResolutionX(resX)
         .makeShared();
 
     auto emitter = VolumeGridEmitter3::builder()
@@ -289,26 +280,17 @@ void runExample4(
     auto grids = solver->gridSystemData();
 
     // Build emitters
-    VertexCenteredScalarGrid3 bunnySdf;
-    std::ifstream sdfFile("bunny.sdf", std::ifstream::binary);
-    if (sdfFile) {
-        std::vector<uint8_t> buffer(
-            (std::istreambuf_iterator<char>(sdfFile)),
-            (std::istreambuf_iterator<char>()));
-        bunnySdf.deserialize(buffer);
-        sdfFile.close();
+    auto bunnyMesh = TriangleMesh3::builder().makeShared();
+    std::ifstream objFile("resources/bunny.obj");
+    if (objFile) {
+        bunnyMesh->readObj(&objFile);
     } else {
-        fprintf(stderr, "Cannot open bunny.sdf\n");
-        fprintf(
-            stderr,
-            "Run\nbin/obj2sdf -i resources/bunny.obj"
-            " -o bunny.sdf\nto generate the sdf file.\n");
+        fprintf(stderr, "Cannot open resources/bunny.obj\n");
         exit(EXIT_FAILURE);
     }
-
-    auto bunny = CustomImplicitSurface3::builder()
-        .withSignedDistanceFunction(bunnySdf.sampler())
-        .withResolution(grids->gridSpacing().x)
+    auto bunny = ImplicitTriangleMesh3::builder()
+        .withTriangleMesh(bunnyMesh)
+        .withResolutionX(resX)
         .makeShared();
 
     auto emitter = VolumeGridEmitter3::builder()

--- a/src/examples/smoke_sim/SConscript
+++ b/src/examples/smoke_sim/SConscript
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2016 Doyub Kim
+Copyright (c) 2017 Doyub Kim
 """
 
 Import('env', 'os', 'utils')
@@ -14,8 +14,8 @@ def from_build_dir(path):
 
 app_env = env.Clone()
 app_env.Append(CPPPATH = [from_root_dir('include'), from_root_dir('external/src/cnpy'), from_root_dir('external/src/pystring'), script_dir])
-app_env.Append(LIBPATH = [from_build_dir('src/jet'), from_build_dir('external/src/cnpy'), from_build_dir('external/src/pystring')])
-app_env.Prepend(LIBS = ['jet', 'cnpy', 'pystring'])
+app_env.Append(LIBPATH = [from_build_dir('src/jet'), from_build_dir('external/src/cnpy'), from_build_dir('external/src/pystring'), from_build_dir('external/src/obj')])
+app_env.Prepend(LIBS = ['jet', 'cnpy', 'obj', 'pystring'])
 
 # TODO: This is BAD! Should be fixed from cnpy
 app_env.Append(CXXFLAGS=['-Wno-sign-compare'])

--- a/src/examples/smoke_sim/SmokeSim.vcxproj
+++ b/src/examples/smoke_sim/SmokeSim.vcxproj
@@ -81,20 +81,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)src\winix;$(SolutionDir)external\src\pystring;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -107,7 +107,7 @@
 $(Command)</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>jet.lib;Winix.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jet.lib;Winix.lib;obj.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,7 +121,7 @@ $(Command)</Command>
 $(Command)</Command>
     </PostBuildEvent>
     <Link>
-      <AdditionalDependencies>jet.lib;Winix.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jet.lib;Winix.lib;obj.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -135,7 +135,7 @@ $(Command)</Command>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>jet.lib;Winix.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jet.lib;Winix.lib;obj.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\SmokeSim.exe %%* &gt; $(SolutionDir)bin\smoke_sim.bat
@@ -153,7 +153,7 @@ $(Command)</Command>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>jet.lib;Winix.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>jet.lib;Winix.lib;obj.lib;pystring.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\SmokeSim.exe %%* &gt; $(SolutionDir)bin\smoke_sim.bat

--- a/src/examples/smoke_sim/main.cpp
+++ b/src/examples/smoke_sim/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Doyub Kim
+// Copyright (c) 2017 Doyub Kim
 
 #include <jet/jet.h>
 #include <pystring/pystring.h>
@@ -339,7 +339,7 @@ void runExample3(
     }
     auto dragon = ImplicitTriangleMesh3::builder()
         .withTriangleMesh(dragonMesh)
-        .withResolutionX(resX)
+        .withResolutionX(resolutionX)
         .makeShared();
 
     auto emitter = VolumeGridEmitter3::builder()

--- a/src/examples/smoke_sim/main.cpp
+++ b/src/examples/smoke_sim/main.cpp
@@ -329,26 +329,17 @@ void runExample3(
         .makeShared();
 
     // Build emitter
-    VertexCenteredScalarGrid3 dragonSdf;
-    std::ifstream sdfFile("dragon.sdf", std::ifstream::binary);
-    if (sdfFile) {
-        std::vector<uint8_t> buffer(
-            (std::istreambuf_iterator<char>(sdfFile)),
-            (std::istreambuf_iterator<char>()));
-        dragonSdf.deserialize(buffer);
-        sdfFile.close();
+    auto dragonMesh = TriangleMesh3::builder().makeShared();
+    std::ifstream objFile("resources/dragon.obj");
+    if (objFile) {
+        dragonMesh->readObj(&objFile);
     } else {
-        fprintf(stderr, "Cannot open dragon.sdf\n");
-        fprintf(
-            stderr,
-            "Run\nbin/obj2sdf -i resources/dragon.obj"
-            " -o dragon.sdf\nto generate the sdf file.\n");
+        fprintf(stderr, "Cannot open resources/dragon.obj\n");
         exit(EXIT_FAILURE);
     }
-
-    auto dragon = CustomImplicitSurface3::builder()
-        .withSignedDistanceFunction(dragonSdf.sampler())
-        .withResolution(solver->gridSystemData()->gridSpacing().x)
+    auto dragon = ImplicitTriangleMesh3::builder()
+        .withTriangleMesh(dragonMesh)
+        .withResolutionX(resX)
         .makeShared();
 
     auto emitter = VolumeGridEmitter3::builder()

--- a/src/jet/Jet.vcxproj
+++ b/src/jet/Jet.vcxproj
@@ -333,6 +333,7 @@ xcopy /y $(SolutionDir)include\jet $(SolutionDir)dist\$(Platform)\$(Configuratio
     <ClInclude Include="..\..\include\jet\implicit_surface3.h" />
     <ClInclude Include="..\..\include\jet\implicit_surface_set2.h" />
     <ClInclude Include="..\..\include\jet\implicit_surface_set3.h" />
+    <ClInclude Include="..\..\include\jet\implicit_triangle_mesh3.h" />
     <ClInclude Include="..\..\include\jet\iterative_level_set_solver2.h" />
     <ClInclude Include="..\..\include\jet\iterative_level_set_solver3.h" />
     <ClInclude Include="..\..\include\jet\jet.h" />
@@ -536,6 +537,7 @@ xcopy /y $(SolutionDir)include\jet $(SolutionDir)dist\$(Platform)\$(Configuratio
     <ClCompile Include="implicit_surface3.cpp" />
     <ClCompile Include="implicit_surface_set2.cpp" />
     <ClCompile Include="implicit_surface_set3.cpp" />
+    <ClCompile Include="implicit_triangle_mesh3.cpp" />
     <ClCompile Include="iterative_level_set_solver2.cpp" />
     <ClCompile Include="iterative_level_set_solver3.cpp" />
     <ClCompile Include="level_set_liquid_solver2.cpp" />

--- a/src/jet/Jet.vcxproj.filters
+++ b/src/jet/Jet.vcxproj.filters
@@ -486,6 +486,9 @@
     <ClInclude Include="..\..\include\jet\implicit_surface3.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\jet\implicit_triangle_mesh3.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\jet\iterative_level_set_solver2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1269,6 +1272,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="implicit_surface3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="implicit_triangle_mesh3.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="iterative_level_set_solver2.cpp">

--- a/src/jet/implicit_triangle_mesh3.cpp
+++ b/src/jet/implicit_triangle_mesh3.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <pch.h>
+#include <jet/implicit_triangle_mesh3.h>
+#include <jet/triangle_mesh_to_sdf.h>
+
+using namespace jet;
+
+ImplicitTriangleMesh3::ImplicitTriangleMesh3(
+    const TriangleMesh3Ptr& mesh,
+    size_t resolutionX,
+    double margin,
+    const Transform3& transform,
+    bool isNormalFlipped)
+: ImplicitSurface3(transform, isNormalFlipped)
+, _mesh(mesh) {
+    BoundingBox3D box = _mesh->boundingBox();
+    Vector3D scale(box.width(), box.height(), box.depth());
+    box.lowerCorner -= margin * scale;
+    box.upperCorner += margin * scale;
+
+    size_t resolutionY = static_cast<size_t>(
+        std::ceil(resolutionX * box.height() / box.width()));
+    size_t resolutionZ = static_cast<size_t>(
+        std::ceil(resolutionX * box.depth() / box.width()));
+
+    double dx = box.width() / resolutionX;
+
+    _grid.resize(
+        resolutionX, resolutionY, resolutionZ,
+        dx, dx, dx,
+        box.lowerCorner.x, box.lowerCorner.y, box.lowerCorner.z);
+
+    triangleMeshToSdf(*_mesh, &_grid);
+
+    _customImplicitSurface = CustomImplicitSurface3::builder()
+        .withSignedDistanceFunction([&] (const Vector3D& pt) {
+            return _grid.sample(pt);
+        })
+        .withDomain(_grid.boundingBox())
+        .withResolution(dx)
+        .makeShared();
+}
+
+ImplicitTriangleMesh3::~ImplicitTriangleMesh3() {
+}
+
+Vector3D ImplicitTriangleMesh3::closestPointLocal(
+    const Vector3D& otherPoint) const {
+    return _customImplicitSurface->closestPoint(otherPoint);
+}
+
+double ImplicitTriangleMesh3::closestDistanceLocal(
+    const Vector3D& otherPoint) const {
+    return _customImplicitSurface->closestDistance(otherPoint);
+}
+
+bool ImplicitTriangleMesh3::intersectsLocal(const Ray3D& ray) const {
+    return _customImplicitSurface->intersects(ray);
+}
+
+BoundingBox3D ImplicitTriangleMesh3::boundingBoxLocal() const {
+    return _mesh->boundingBox();
+}
+
+Vector3D ImplicitTriangleMesh3::closestNormalLocal(
+    const Vector3D& otherPoint) const {
+    return _customImplicitSurface->closestNormal(otherPoint);
+}
+
+double ImplicitTriangleMesh3::signedDistanceLocal(
+    const Vector3D& otherPoint) const {
+    return _customImplicitSurface->signedDistance(otherPoint);
+}
+
+SurfaceRayIntersection3 ImplicitTriangleMesh3::closestIntersectionLocal(
+    const Ray3D& ray) const {
+    return _customImplicitSurface->closestIntersection(ray);
+}
+
+ImplicitTriangleMesh3::Builder ImplicitTriangleMesh3::builder() {
+    return ImplicitTriangleMesh3::Builder();
+}
+
+
+ImplicitTriangleMesh3::Builder&
+ImplicitTriangleMesh3::Builder::withTriangleMesh(const TriangleMesh3Ptr& mesh) {
+    _mesh = mesh;
+    return *this;
+}
+
+ImplicitTriangleMesh3::Builder&
+ImplicitTriangleMesh3::Builder::withResolutionX(size_t resolutionX) {
+    _resolutionX = resolutionX;
+    return *this;
+}
+
+ImplicitTriangleMesh3::Builder&
+ImplicitTriangleMesh3::Builder::withMargin(double margin) {
+    _margin = margin;
+    return *this;
+}
+
+ImplicitTriangleMesh3
+ImplicitTriangleMesh3::Builder::build() const {
+    return ImplicitTriangleMesh3(
+        _mesh,
+        _resolutionX,
+        _margin,
+        _transform,
+        _isNormalFlipped);
+}
+
+ImplicitTriangleMesh3Ptr
+ImplicitTriangleMesh3::Builder::makeShared() const {
+    return std::shared_ptr<ImplicitTriangleMesh3>(
+        new ImplicitTriangleMesh3(
+            _mesh,
+            _resolutionX,
+            _margin,
+            _transform,
+            _isNormalFlipped),
+        [] (ImplicitTriangleMesh3* obj) {
+            delete obj;
+        });
+}

--- a/src/jet/surface_to_implicit3.cpp
+++ b/src/jet/surface_to_implicit3.cpp
@@ -2,6 +2,7 @@
 
 #include <pch.h>
 #include <jet/surface_to_implicit3.h>
+#include <jet/triangle_mesh3.h>
 
 using namespace jet;
 
@@ -11,6 +12,10 @@ SurfaceToImplicit3::SurfaceToImplicit3(
     bool isNormalFlipped)
 : ImplicitSurface3(transform, isNormalFlipped)
 , _surface(surface) {
+    if (std::dynamic_pointer_cast<TriangleMesh3>(surface) != nullptr) {
+        JET_WARN << "Using TriangleMesh3 with SurfaceToImplicit3 can cause "
+                 << "undefined behavior. Use ImplicitTriangleMesh3 instead.";
+    }
 }
 
 SurfaceToImplicit3::SurfaceToImplicit3(const SurfaceToImplicit3& other) :

--- a/src/tests/perf_tests/PerfTests.vcxproj
+++ b/src/tests/perf_tests/PerfTests.vcxproj
@@ -96,20 +96,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\tbb\include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
-    <LibraryPath>$(SolutionDir)external\tbb\lib\$(Platform)\vc14\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)external\src\gtest\googletest\googletest\include</IncludePath>
+    <LibraryPath>$(SolutionDir)obj\$(Platform)\$(Configuration)\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -120,7 +120,7 @@
       <DisableSpecificWarnings>4819</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;jet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;jet.lib;obj.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\PerfTests.exe --gtest_filter=%%1--gtest_output=xml:perf_tests.xml &gt; $(SolutionDir)bin\perf_tests.bat
@@ -137,7 +137,7 @@ $(Command)</Command>
       <DisableSpecificWarnings>4819</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest.lib;jet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;jet.lib;obj.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\PerfTests.exe --gtest_filter=%%1--gtest_output=xml:perf_tests.xml &gt; $(SolutionDir)bin\perf_tests.bat
@@ -158,7 +158,7 @@ $(Command)</Command>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>gtest.lib;jet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;jet.lib;obj.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\PerfTests.exe --gtest_filter=%%1--gtest_output=xml:perf_tests.xml &gt; $(SolutionDir)bin\perf_tests.bat
@@ -179,7 +179,7 @@ $(Command)</Command>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>gtest.lib;jet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest.lib;jet.lib;obj.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>echo $(SolutionDir)obj\$(Platform)\$(Configuration)\PerfTests.exe --gtest_filter=%%1--gtest_output=xml:perf_tests.xml &gt; $(SolutionDir)bin\perf_tests.bat

--- a/src/tests/perf_tests/SConscript
+++ b/src/tests/perf_tests/SConscript
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2016 Doyub Kim
+Copyright (c) 2017 Doyub Kim
 """
 
 Import('env', 'os', 'utils')
@@ -14,8 +14,8 @@ def from_build_dir(path):
 
 app_env = env.Clone()
 app_env.Append(CPPPATH = [from_root_dir('include'), from_root_dir('external/src/gtest/googletest/googletest/include'), script_dir])
-app_env.Append(LIBPATH = [from_build_dir('src/jet'), from_build_dir('external/src/gtest')])
-app_env.Prepend(LIBS = ['jet', 'gtest'])
+app_env.Append(LIBPATH = [from_build_dir('src/jet'), from_build_dir('external/src/gtest'), from_build_dir('external/src/obj')])
+app_env.Prepend(LIBS = ['jet', 'gtest', 'obj'])
 
 source_patterns = ['*.cpp']
 source = map(lambda x: os.path.relpath(x, script_dir), utils.get_all_files(script_dir, source_patterns))

--- a/src/tests/unit_tests/UnitTests.vcxproj
+++ b/src/tests/unit_tests/UnitTests.vcxproj
@@ -83,6 +83,7 @@
     <ClCompile Include="grid_system_data3_tests.cpp" />
     <ClCompile Include="implicit_surface_set2_tests.cpp" />
     <ClCompile Include="implicit_surface_set3_tests.cpp" />
+    <ClCompile Include="implicit_triangle_mesh3_tests.cpp" />
     <ClCompile Include="level_set_liquid_solvers_tests.cpp" />
     <ClCompile Include="level_set_solvers_tests.cpp" />
     <ClCompile Include="main.cpp" />

--- a/src/tests/unit_tests/UnitTests.vcxproj.filters
+++ b/src/tests/unit_tests/UnitTests.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="implicit_surface_set3_tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="implicit_triangle_mesh3_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="level_set_liquid_solvers_tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/tests/unit_tests/implicit_triangle_mesh3_tests.cpp
+++ b/src/tests/unit_tests/implicit_triangle_mesh3_tests.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Doyub Kim
+
+#include <unit_tests_utils.h>
+#include <jet/box3.h>
+#include <jet/implicit_triangle_mesh3.h>
+#include <jet/sphere3.h>
+#include <jet/surface_to_implicit3.h>
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+TEST(ImplicitTriangleMesh3, SignedDistance) {
+    auto box = Box3::builder()
+        .withLowerCorner({0, 0, 0})
+        .withUpperCorner({1, 1, 1})
+        .makeShared();
+    SurfaceToImplicit3 refSurf(box);
+
+    std::ifstream objFile("resources/cube.obj");
+    auto mesh = TriangleMesh3::builder().makeShared();
+    mesh->readObj(&objFile);
+
+    auto imesh = ImplicitTriangleMesh3::builder()
+        .withTriangleMesh(mesh)
+        .withResolutionX(20)
+        .makeShared();
+
+    for (auto sample : kSamplePoints3) {
+        auto refAns = refSurf.signedDistance(sample);
+        auto actAns = imesh->signedDistance(sample);
+
+        EXPECT_NEAR(refAns, actAns, 1.0 / 20);
+    }
+}


### PR DESCRIPTION
Existing codebase requires multiple steps to convert a TriangleMesh3 into SDF. This new class provides handy shortcut to the framework.