### PR TITLE
Fix out-of-bound issue for CustomImplicitSurface types

### DIFF
--- a/src/jet/custom_implicit_surface2.cpp
+++ b/src/jet/custom_implicit_surface2.cpp
@@ -26,7 +26,7 @@ CustomImplicitSurface2::~CustomImplicitSurface2() {
 
 Vector2D CustomImplicitSurface2::closestPointLocal(
     const Vector2D& otherPoint) const {
-    Vector2D pt = otherPoint;
+    Vector2D pt = clamp(otherPoint, _domain.lowerCorner, _domain.upperCorner);
     for (unsigned int iter = 0; iter < _maxNumOfIterations; ++iter) {
         double sdf = signedDistanceLocal(pt);
         if (std::fabs(sdf) < kEpsilonD) {

--- a/src/jet/custom_implicit_surface3.cpp
+++ b/src/jet/custom_implicit_surface3.cpp
@@ -26,7 +26,7 @@ CustomImplicitSurface3::~CustomImplicitSurface3() {
 
 Vector3D CustomImplicitSurface3::closestPointLocal(
     const Vector3D& otherPoint) const {
-    Vector3D pt = otherPoint;
+    Vector3D pt = clamp(otherPoint, _domain.lowerCorner, _domain.upperCorner);
     for (unsigned int iter = 0; iter < _maxNumOfIterations; ++iter) {
         double sdf = signedDistanceLocal(pt);
         if (std::fabs(sdf) < kEpsilonD) {


### PR DESCRIPTION
When evaluating closest point, out-of-bound point without clamping can
cause a convergence problem.