### PR TITLE
Do not skip pressure solver step for the rotation tests

### DIFF
--- a/src/tests/manual_tests/apic_solver2_tests.cpp
+++ b/src/tests/manual_tests/apic_solver2_tests.cpp
@@ -53,7 +53,6 @@ JET_BEGIN_TEST_F(ApicSolver2, Rotation) {
                       .makeShared();
 
     solver->setGravity({0, 0});
-    solver->setPressureSolver(nullptr);
 
     // Build emitter
     auto box =

--- a/src/tests/manual_tests/flip_solver2_tests.cpp
+++ b/src/tests/manual_tests/flip_solver2_tests.cpp
@@ -53,7 +53,6 @@ JET_BEGIN_TEST_F(FlipSolver2, Rotation) {
         .makeShared();
 
     solver->setGravity({0, 0});
-    solver->setPressureSolver(nullptr);
 
     // Build emitter
     auto box = Sphere2::builder()

--- a/src/tests/manual_tests/pic_solver2_tests.cpp
+++ b/src/tests/manual_tests/pic_solver2_tests.cpp
@@ -53,7 +53,6 @@ JET_BEGIN_TEST_F(PicSolver2, Rotation) {
         .makeShared();
 
     solver->setGravity({0, 0});
-    solver->setPressureSolver(nullptr);
 
     // Build emitter
     auto box = Sphere2::builder()


### PR DESCRIPTION
Skipping the pressure solver step can cause numerical dissipation due to the projection error. Removing the null-setting codes and let tests run with normal version of the solvers.