### PR TITLE
Fix to build error with GCC6 when compiling animation_tests.cpp

### DIFF
--- a/src/tests/unit_tests/animation_tests.cpp
+++ b/src/tests/unit_tests/animation_tests.cpp
@@ -11,7 +11,7 @@ using namespace jet;
 
 TEST(Frame, Constructors) {
     Frame frame;
-    EXPECT_EQ(0u, frame.index);
+    EXPECT_EQ(0, frame.index);
     EXPECT_DOUBLE_EQ(1.0 / 60.0, frame.timeIntervalInSeconds);
 }
 
@@ -32,15 +32,15 @@ TEST(Frame, Advance) {
         frame.advance();
     }
 
-    EXPECT_EQ(54u, frame.index);
+    EXPECT_EQ(54, frame.index);
 
     frame.advance(23);
 
-    EXPECT_EQ(77u, frame.index);
+    EXPECT_EQ(77, frame.index);
 
-    EXPECT_EQ(78u, (++frame).index);
+    EXPECT_EQ(78, (++frame).index);
 
-    EXPECT_EQ(78u, (frame++).index);
+    EXPECT_EQ(78, (frame++).index);
 
-    EXPECT_EQ(79u, frame.index);
+    EXPECT_EQ(79, frame.index);
 }


### PR DESCRIPTION
In animation_tests.cpp Frame.index (which is signed integer) is compared with integer literals with 'u' at the end, making them unsigned, GCC6.x treats such comparison as error (at least with flags set in CMakeLists.txt). This patch just removes 'u' from literals, allowing the build to pass with GCC6.