### PR TITLE
Fix error in argv interpretation.

### DIFF
--- a/scripts/visualize_xyz.py
+++ b/scripts/visualize_xyz.py
@@ -25,7 +25,7 @@ def render_frame(num, data, line):
 
 # Simulation Path
 path = sys.argv[1]
-output_name = sys.argv[2] if len(sys.argv) >= 2 else 'result.mp4'
+output_name = sys.argv[2] if len(sys.argv) > 2 else 'result.mp4'
 files = utils.get_all_files(path, "*.xyz")
 size_files = len(files)
 


### PR DESCRIPTION
Fix error when no filename is provided to visualize_xyz.py

```
python visualize_xyz.py . 
Traceback (most recent call last): 
  File "visualize_xyz.py", line 28, in <module> 
    output_name = sys.argv[2] if len(sys.argv) >= 2 else 'result.mp4' 
IndexError: list index out of range
```