### PR TITLE
Fix compilation on gcc 5.4.

### DIFF
--- a/src/tests/unit_tests/point_kdtree_searcher2_tests.cpp
+++ b/src/tests/unit_tests/point_kdtree_searcher2_tests.cpp
@@ -50,7 +50,7 @@ TEST(PointKdTreeSearcher2, Serialization) {
     std::vector<uint8_t> buffer;
     searcher.serialize(&buffer);
 
-    EXPECT_GT(buffer.size(), 0);
+    EXPECT_GT(buffer.size(), 0U);
 
     PointKdTreeSearcher2 searcher2;
     searcher2.deserialize(buffer);


### PR DESCRIPTION
This PR fixes the following compilation error on gcc5.4(Ubuntu 16.04)

```
/home/syoyo/work/fluid-engine-dev/external/googletest/googletest/include/gtest/gtest.h:1530:28: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
 GTEST_IMPL_CMP_HELPER_(GT, >);
                            ^
```