### PR TITLE
Compressed linear system solver for FDM solvers

### DIFF
--- a/include/jet/detail/matrix_csr-inl.h
+++ b/include/jet/detail/matrix_csr-inl.h
@@ -130,6 +130,14 @@ MatrixCsr<T>::MatrixCsr(MatrixCsr&& other) {
 }
 
 template <typename T>
+void MatrixCsr<T>::clear() {
+    _size = {0, 0};
+    _nonZeros.clear();
+    _rowPointers.clear();
+    _columnIndices.clear();
+}
+
+template <typename T>
 void MatrixCsr<T>::set(const T& s) {
     std::fill(_nonZeros.begin(), _nonZeros.end(), s);
 }

--- a/include/jet/detail/matrix_csr-inl.h
+++ b/include/jet/detail/matrix_csr-inl.h
@@ -104,7 +104,7 @@ MatrixCsr<T>::Element::Element(size_t i_, size_t j_, const T& value_)
 
 template <typename T>
 MatrixCsr<T>::MatrixCsr() {
-    _rowPointers.push_back(0);
+    clear();
 }
 
 template <typename T>
@@ -135,6 +135,7 @@ void MatrixCsr<T>::clear() {
     _nonZeros.clear();
     _rowPointers.clear();
     _columnIndices.clear();
+    _rowPointers.push_back(0);
 }
 
 template <typename T>

--- a/include/jet/detail/vector_n-inl.h
+++ b/include/jet/detail/vector_n-inl.h
@@ -50,6 +50,11 @@ void VectorN<T>::resize(size_t n, const T& val) {
 }
 
 template <typename T>
+void VectorN<T>::clear() {
+    _elements.clear();
+}
+
+template <typename T>
 void VectorN<T>::set(const T& s) {
     parallelFill(begin(), end(), s);
 }
@@ -68,6 +73,11 @@ void VectorN<T>::set(const VectorExpression<T, E>& other) {
     // Parallel evaluation of the expression
     const E& expression = other();
     parallelForEachIndex([&](size_t i) { _elements[i] = expression[i]; });
+}
+
+template <typename T>
+void VectorN<T>::append(const T& val) {
+    _elements.push_back(val);
 }
 
 template <typename T>

--- a/include/jet/fdm_cg_solver2.h
+++ b/include/jet/fdm_cg_solver2.h
@@ -21,6 +21,9 @@ class FdmCgSolver2 final : public FdmLinearSystemSolver2 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem2* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem2* system) override;
+
     //! Returns the max number of CG iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -39,10 +42,17 @@ class FdmCgSolver2 final : public FdmLinearSystemSolver2 {
     double _tolerance;
     double _lastResidual;
 
+    // Uncompressed vectors
     FdmVector2 _r;
     FdmVector2 _d;
     FdmVector2 _q;
     FdmVector2 _s;
+
+    // Compressed vectors
+    VectorND _rComp;
+    VectorND _dComp;
+    VectorND _qComp;
+    VectorND _sComp;
 };
 
 //! Shared pointer type for the FdmCgSolver2.

--- a/include/jet/fdm_cg_solver2.h
+++ b/include/jet/fdm_cg_solver2.h
@@ -53,6 +53,9 @@ class FdmCgSolver2 final : public FdmLinearSystemSolver2 {
     VectorND _dComp;
     VectorND _qComp;
     VectorND _sComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmCgSolver2.

--- a/include/jet/fdm_cg_solver3.h
+++ b/include/jet/fdm_cg_solver3.h
@@ -21,6 +21,9 @@ class FdmCgSolver3 final : public FdmLinearSystemSolver3 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem3* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem3* system) override;
+
     //! Returns the max number of CG iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -39,10 +42,20 @@ class FdmCgSolver3 final : public FdmLinearSystemSolver3 {
     double _tolerance;
     double _lastResidual;
 
+    // Uncompressed vectors
     FdmVector3 _r;
     FdmVector3 _d;
     FdmVector3 _q;
     FdmVector3 _s;
+
+    // Compressed vectors
+    VectorND _rComp;
+    VectorND _dComp;
+    VectorND _qComp;
+    VectorND _sComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmCgSolver3.

--- a/include/jet/fdm_gauss_seidel_solver2.h
+++ b/include/jet/fdm_gauss_seidel_solver2.h
@@ -24,6 +24,9 @@ class FdmGaussSeidelSolver2 final : public FdmLinearSystemSolver2 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem2* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem2* system) override;
+
     //! Returns the max number of Gauss-Seidel iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -46,9 +49,20 @@ class FdmGaussSeidelSolver2 final : public FdmLinearSystemSolver2 {
     static void relax(const FdmMatrix2& A, const FdmVector2& b,
                       double sorFactor, FdmVector2* x);
 
+    //! \brief Performs single natural Gauss-Seidel relaxation step for
+    //!        compressed sys.
+    static void relax(const MatrixCsrD& A, const VectorND& b, double sorFactor,
+                      VectorND* x);
+
     //! Performs single Red-Black Gauss-Seidel relaxation step.
     static void relaxRedBlack(const FdmMatrix2& A, const FdmVector2& b,
                               double sorFactor, FdmVector2* x);
+
+    //! \brief Performs single Red-Black Gauss-Seidel relaxation step for
+    //!        compressed sys.
+    static void relaxRedBlack(const MatrixCsrD& A, const VectorND& b,
+                              const Array1<Point2UI>& indexToCoord,
+                              double sorFactor, VectorND* x);
 
  private:
     unsigned int _maxNumberOfIterations;
@@ -59,7 +73,11 @@ class FdmGaussSeidelSolver2 final : public FdmLinearSystemSolver2 {
     double _sorFactor;
     bool _useRedBlackOrdering;
 
+    // Uncompressed vectors
     FdmVector2 _residual;
+
+    // Compressed vectors
+    VectorND _residualComp;
 };
 
 //! Shared pointer type for the FdmGaussSeidelSolver2.

--- a/include/jet/fdm_gauss_seidel_solver2.h
+++ b/include/jet/fdm_gauss_seidel_solver2.h
@@ -58,12 +58,6 @@ class FdmGaussSeidelSolver2 final : public FdmLinearSystemSolver2 {
     static void relaxRedBlack(const FdmMatrix2& A, const FdmVector2& b,
                               double sorFactor, FdmVector2* x);
 
-    //! \brief Performs single Red-Black Gauss-Seidel relaxation step for
-    //!        compressed sys.
-    static void relaxRedBlack(const MatrixCsrD& A, const VectorND& b,
-                              const Array1<Point2UI>& indexToCoord,
-                              double sorFactor, VectorND* x);
-
  private:
     unsigned int _maxNumberOfIterations;
     unsigned int _lastNumberOfIterations;

--- a/include/jet/fdm_gauss_seidel_solver2.h
+++ b/include/jet/fdm_gauss_seidel_solver2.h
@@ -78,6 +78,9 @@ class FdmGaussSeidelSolver2 final : public FdmLinearSystemSolver2 {
 
     // Compressed vectors
     VectorND _residualComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmGaussSeidelSolver2.

--- a/include/jet/fdm_gauss_seidel_solver3.h
+++ b/include/jet/fdm_gauss_seidel_solver3.h
@@ -58,12 +58,6 @@ class FdmGaussSeidelSolver3 final : public FdmLinearSystemSolver3 {
     static void relaxRedBlack(const FdmMatrix3& A, const FdmVector3& b,
                               double sorFactor, FdmVector3* x);
 
-    //! \brief Performs single Red-Black Gauss-Seidel relaxation step for
-    //!        compressed sys.
-    static void relaxRedBlack(const MatrixCsrD& A, const VectorND& b,
-                              const Array1<Point3UI>& indexToCoord,
-                              double sorFactor, VectorND* x);
-
  private:
     unsigned int _maxNumberOfIterations;
     unsigned int _lastNumberOfIterations;

--- a/include/jet/fdm_gauss_seidel_solver3.h
+++ b/include/jet/fdm_gauss_seidel_solver3.h
@@ -24,6 +24,9 @@ class FdmGaussSeidelSolver3 final : public FdmLinearSystemSolver3 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem3* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem3* system) override;
+
     //! Returns the max number of Gauss-Seidel iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -46,9 +49,20 @@ class FdmGaussSeidelSolver3 final : public FdmLinearSystemSolver3 {
     static void relax(const FdmMatrix3& A, const FdmVector3& b,
                       double sorFactor, FdmVector3* x);
 
+    //! \brief Performs single natural Gauss-Seidel relaxation step for
+    //!        compressed sys.
+    static void relax(const MatrixCsrD& A, const VectorND& b, double sorFactor,
+                      VectorND* x);
+
     //! Performs single Red-Black Gauss-Seidel relaxation step.
     static void relaxRedBlack(const FdmMatrix3& A, const FdmVector3& b,
                               double sorFactor, FdmVector3* x);
+
+    //! \brief Performs single Red-Black Gauss-Seidel relaxation step for
+    //!        compressed sys.
+    static void relaxRedBlack(const MatrixCsrD& A, const VectorND& b,
+                              const Array1<Point3UI>& indexToCoord,
+                              double sorFactor, VectorND* x);
 
  private:
     unsigned int _maxNumberOfIterations;
@@ -59,7 +73,14 @@ class FdmGaussSeidelSolver3 final : public FdmLinearSystemSolver3 {
     double _sorFactor;
     bool _useRedBlackOrdering;
 
+    // Uncompressed vectors
     FdmVector3 _residual;
+
+    // Compressed vectors
+    VectorND _residualComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmGaussSeidelSolver3.

--- a/include/jet/fdm_iccg_solver2.h
+++ b/include/jet/fdm_iccg_solver2.h
@@ -23,6 +23,9 @@ class FdmIccgSolver2 final : public FdmLinearSystemSolver2 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem2* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem2* system) override;
+
     //! Returns the max number of Jacobi iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -46,16 +49,34 @@ class FdmIccgSolver2 final : public FdmLinearSystemSolver2 {
         void solve(const FdmVector2& b, FdmVector2* x);
     };
 
+    struct PreconditionerCompressed final {
+        const MatrixCsrD* A;
+        VectorND d;
+        VectorND y;
+
+        void build(const MatrixCsrD& matrix);
+
+        void solve(const VectorND& b, VectorND* x);
+    };
+
     unsigned int _maxNumberOfIterations;
     unsigned int _lastNumberOfIterations;
     double _tolerance;
     double _lastResidualNorm;
 
+    // Uncompressed vectors and preconditioner
     FdmVector2 _r;
     FdmVector2 _d;
     FdmVector2 _q;
     FdmVector2 _s;
     Preconditioner _precond;
+
+    // Compressed vectors and preconditioner
+    VectorND _rComp;
+    VectorND _dComp;
+    VectorND _qComp;
+    VectorND _sComp;
+    PreconditionerCompressed _precondComp;
 };
 
 //! Shared pointer type for the FdmIccgSolver2.

--- a/include/jet/fdm_iccg_solver2.h
+++ b/include/jet/fdm_iccg_solver2.h
@@ -77,6 +77,9 @@ class FdmIccgSolver2 final : public FdmLinearSystemSolver2 {
     VectorND _qComp;
     VectorND _sComp;
     PreconditionerCompressed _precondComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmIccgSolver2.

--- a/include/jet/fdm_iccg_solver3.h
+++ b/include/jet/fdm_iccg_solver3.h
@@ -23,6 +23,9 @@ class FdmIccgSolver3 final : public FdmLinearSystemSolver3 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem3* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem3* system) override;
+
     //! Returns the max number of ICCG iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -43,9 +46,17 @@ class FdmIccgSolver3 final : public FdmLinearSystemSolver3 {
 
         void build(const FdmMatrix3& matrix);
 
-        void solve(
-            const FdmVector3& b,
-            FdmVector3* x);
+        void solve(const FdmVector3& b, FdmVector3* x);
+    };
+
+    struct PreconditionerCompressed final {
+        const MatrixCsrD* A;
+        VectorND d;
+        VectorND y;
+
+        void build(const MatrixCsrD& matrix);
+
+        void solve(const VectorND& b, VectorND* x);
     };
 
     unsigned int _maxNumberOfIterations;
@@ -53,11 +64,22 @@ class FdmIccgSolver3 final : public FdmLinearSystemSolver3 {
     double _tolerance;
     double _lastResidualNorm;
 
+    // Uncompressed vectors and preconditioner
     FdmVector3 _r;
     FdmVector3 _d;
     FdmVector3 _q;
     FdmVector3 _s;
     Preconditioner _precond;
+
+    // Compressed vectors and preconditioner
+    VectorND _rComp;
+    VectorND _dComp;
+    VectorND _qComp;
+    VectorND _sComp;
+    PreconditionerCompressed _precondComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmIccgSolver3.

--- a/include/jet/fdm_jacobi_solver2.h
+++ b/include/jet/fdm_jacobi_solver2.h
@@ -21,6 +21,9 @@ class FdmJacobiSolver2 final : public FdmLinearSystemSolver2 {
     //! Solves the given linear system.
     bool solve(FdmLinearSystem2* system) override;
 
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem2* system) override;
+
     //! Returns the max number of Jacobi iterations.
     unsigned int maxNumberOfIterations() const;
 
@@ -37,6 +40,10 @@ class FdmJacobiSolver2 final : public FdmLinearSystemSolver2 {
     static void relax(const FdmMatrix2& A, const FdmVector2& b, FdmVector2* x,
                       FdmVector2* xTemp);
 
+    //! Performs single Jacobi relaxation step for compressed sys.
+    static void relax(const MatrixCsrD& A, const VectorND& b, VectorND* x,
+                      VectorND* xTemp);
+
  private:
     unsigned int _maxNumberOfIterations;
     unsigned int _lastNumberOfIterations;
@@ -44,8 +51,13 @@ class FdmJacobiSolver2 final : public FdmLinearSystemSolver2 {
     double _tolerance;
     double _lastResidual;
 
+    // Uncompressed vectors
     FdmVector2 _xTemp;
     FdmVector2 _residual;
+
+    // Compressed vectors
+    VectorND _xTempComp;
+    VectorND _residualComp;
 };
 
 //! Shared pointer type for the FdmJacobiSolver2.

--- a/include/jet/fdm_jacobi_solver2.h
+++ b/include/jet/fdm_jacobi_solver2.h
@@ -58,6 +58,9 @@ class FdmJacobiSolver2 final : public FdmLinearSystemSolver2 {
     // Compressed vectors
     VectorND _xTempComp;
     VectorND _residualComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmJacobiSolver2.

--- a/include/jet/fdm_jacobi_solver3.h
+++ b/include/jet/fdm_jacobi_solver3.h
@@ -15,13 +15,14 @@ namespace jet {
 class FdmJacobiSolver3 final : public FdmLinearSystemSolver3 {
  public:
     //! Constructs the solver with given parameters.
-    FdmJacobiSolver3(
-        unsigned int maxNumberOfIterations,
-        unsigned int residualCheckInterval,
-        double tolerance);
+    FdmJacobiSolver3(unsigned int maxNumberOfIterations,
+                     unsigned int residualCheckInterval, double tolerance);
 
     //! Solves the given linear system.
     bool solve(FdmLinearSystem3* system) override;
+
+    //! Solves the given compressed linear system.
+    bool solveCompressed(FdmCompressedLinearSystem3* system) override;
 
     //! Returns the max number of Jacobi iterations.
     unsigned int maxNumberOfIterations() const;
@@ -39,6 +40,10 @@ class FdmJacobiSolver3 final : public FdmLinearSystemSolver3 {
     static void relax(const FdmMatrix3& A, const FdmVector3& b, FdmVector3* x,
                       FdmVector3* xTemp);
 
+    //! Performs single Jacobi relaxation step for compressed sys.
+    static void relax(const MatrixCsrD& A, const VectorND& b, VectorND* x,
+                      VectorND* xTemp);
+
  private:
     unsigned int _maxNumberOfIterations;
     unsigned int _lastNumberOfIterations;
@@ -46,8 +51,16 @@ class FdmJacobiSolver3 final : public FdmLinearSystemSolver3 {
     double _tolerance;
     double _lastResidual;
 
+    // Uncompressed vectors
     FdmVector3 _xTemp;
     FdmVector3 _residual;
+
+    // Compressed vectors
+    VectorND _xTempComp;
+    VectorND _residualComp;
+
+    void clearUncompressedVectors();
+    void clearCompressedVectors();
 };
 
 //! Shared pointer type for the FdmJacobiSolver3.

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -8,6 +8,8 @@
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM2_H_
 
 #include <jet/array2.h>
+#include <jet/matrix_csr.h>
+#include <jet/vector_n.h>
 
 namespace jet {
 
@@ -35,6 +37,21 @@ struct FdmLinearSystem2 {
     FdmVector2 x, b;
 
     void clear();
+
+    void resize(const Size2& size);
+};
+
+//! Compressed linear system (Ax=b) for 2-D finite differencing.
+struct FdmCompressedLinearSystem2 {
+    MatrixCsrD A;
+    VectorND x, b;
+    Array2<size_t> coordToIndex;
+
+    void clear();
+
+    void resize(const Size2& size);
+
+    void decompressSolution(FdmVector2* xDecomp);
 };
 
 //! BLAS operator wrapper for 2-D finite differencing.
@@ -44,41 +61,79 @@ struct FdmBlas2 {
     typedef FdmMatrix2 MatrixType;
 
     //! Sets entire element of given vector \p result with scalar \p s.
-    static void set(double s, FdmVector2* result);
+    static void set(ScalarType s, VectorType* result);
 
     //! Copies entire element of given vector \p result with other vector \p v.
-    static void set(const FdmVector2& v, FdmVector2* result);
+    static void set(const VectorType& v, VectorType* result);
 
     //! Sets entire element of given matrix \p result with scalar \p s.
-    static void set(double s, FdmMatrix2* result);
+    static void set(ScalarType s, MatrixType* result);
 
     //! Copies entire element of given matrix \p result with other matrix \p v.
-    static void set(const FdmMatrix2& m, FdmMatrix2* result);
+    static void set(const MatrixType& m, MatrixType* result);
 
     //! Performs dot product with vector \p a and \p b.
-    static double dot(const FdmVector2& a, const FdmVector2& b);
+    static double dot(const VectorType& a, const VectorType& b);
 
     //! Performs ax + y operation where \p a is a matrix and \p x and \p y are
     //! vectors.
-    static void axpy(
-        double a, const FdmVector2& x, const FdmVector2& y, FdmVector2* result);
+    static void axpy(double a, const VectorType& x, const VectorType& y,
+                     VectorType* result);
 
     //! Performs matrix-vector multiplication.
-    static void mvm(
-        const FdmMatrix2& m, const FdmVector2& v, FdmVector2* result);
+    static void mvm(const MatrixType& m, const VectorType& v,
+                    VectorType* result);
 
     //! Computes residual vector (b - ax).
-    static void residual(
-        const FdmMatrix2& a,
-        const FdmVector2& x,
-        const FdmVector2& b,
-        FdmVector2* result);
+    static void residual(const MatrixType& a, const VectorType& x,
+                         const VectorType& b, VectorType* result);
 
     //! Returns L2-norm of the given vector \p v.
-    static double l2Norm(const FdmVector2& v);
+    static ScalarType l2Norm(const VectorType& v);
 
     //! Returns Linf-norm of the given vector \p v.
-    static double lInfNorm(const FdmVector2& v);
+    static ScalarType lInfNorm(const VectorType& v);
+};
+
+//! BLAS operator wrapper for compressed 2-D finite differencing.
+struct FdmCompressedBlas2 {
+    typedef double ScalarType;
+    typedef VectorND VectorType;
+    typedef MatrixCsrD MatrixType;
+
+    //! Sets entire element of given vector \p result with scalar \p s.
+    static void set(ScalarType s, VectorType* result);
+
+    //! Copies entire element of given vector \p result with other vector \p v.
+    static void set(const VectorType& v, VectorType* result);
+
+    //! Sets entire element of given matrix \p result with scalar \p s.
+    static void set(ScalarType s, MatrixType* result);
+
+    //! Copies entire element of given matrix \p result with other matrix \p v.
+    static void set(const MatrixType& m, MatrixType* result);
+
+    //! Performs dot product with vector \p a and \p b.
+    static double dot(const VectorType& a, const VectorType& b);
+
+    //! Performs ax + y operation where \p a is a matrix and \p x and \p y are
+    //! vectors.
+    static void axpy(double a, const VectorType& x, const VectorType& y,
+                     VectorType* result);
+
+    //! Performs matrix-vector multiplication.
+    static void mvm(const MatrixType& m, const VectorType& v,
+                    VectorType* result);
+
+    //! Computes residual vector (b - ax).
+    static void residual(const MatrixType& a, const VectorType& x,
+                         const VectorType& b, VectorType* result);
+
+    //! Returns L2-norm of the given vector \p v.
+    static ScalarType l2Norm(const VectorType& v);
+
+    //! Returns Linf-norm of the given vector \p v.
+    static ScalarType lInfNorm(const VectorType& v);
 };
 
 }  // namespace jet

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -7,6 +7,7 @@
 #ifndef INCLUDE_JET_FDM_LINEAR_SYSTEM2_H_
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM2_H_
 
+#include <jet/array1.h>
 #include <jet/array2.h>
 #include <jet/matrix_csr.h>
 #include <jet/vector_n.h>
@@ -46,6 +47,7 @@ struct FdmCompressedLinearSystem2 {
     MatrixCsrD A;
     VectorND x, b;
     Array2<size_t> coordToIndex;
+    Array1<Point2UI> indexToCoord;
 
     void clear();
 

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -61,20 +61,8 @@ struct FdmCompressedLinearSystem2 {
     //! RHS vector.
     VectorND b;
 
-    //! Mapping from grid coordinates to row index.
-    Array2<size_t> coordToIndex;
-
-    //! Mapping from row index to grid coordinate.
-    Array1<Point2UI> indexToCoord;
-
     //! Clears all the data.
     void clear();
-
-    //! Resizes 2-D arrays with given grid size.
-    void resize(const Size2& size);
-
-    //! Decompresses the solution vector to the given FDM vector.
-    void decompressSolution(FdmVector2* xDecomp, double blankValue = 0.0);
 };
 
 //! BLAS operator wrapper for 2-D finite differencing.

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -34,25 +34,46 @@ typedef Array2<FdmMatrixRow2> FdmMatrix2;
 
 //! Linear system (Ax=b) for 2-D finite differencing.
 struct FdmLinearSystem2 {
+    //! System matrix.
     FdmMatrix2 A;
-    FdmVector2 x, b;
 
+    //! Solution vector.
+    FdmVector2 x;
+
+    //! RHS vector.
+    FdmVector2 b;
+
+    //! Clears all the data.
     void clear();
 
+    //! Resizes the arrays with given grid size.
     void resize(const Size2& size);
 };
 
 //! Compressed linear system (Ax=b) for 2-D finite differencing.
 struct FdmCompressedLinearSystem2 {
+    //! System matrix.
     MatrixCsrD A;
-    VectorND x, b;
+
+    //! Solution vector.
+    VectorND x;
+
+    //! RHS vector.
+    VectorND b;
+
+    //! Mapping from grid coordinates to row index.
     Array2<size_t> coordToIndex;
+
+    //! Mapping from row index to grid coordinate.
     Array1<Point2UI> indexToCoord;
 
+    //! Clears all the data.
     void clear();
 
+    //! Resizes 2-D arrays with given grid size.
     void resize(const Size2& size);
 
+    //! Decompresses the solution vector to the given FDM vector.
     void decompressSolution(FdmVector2* xDecomp);
 };
 

--- a/include/jet/fdm_linear_system2.h
+++ b/include/jet/fdm_linear_system2.h
@@ -74,7 +74,7 @@ struct FdmCompressedLinearSystem2 {
     void resize(const Size2& size);
 
     //! Decompresses the solution vector to the given FDM vector.
-    void decompressSolution(FdmVector2* xDecomp);
+    void decompressSolution(FdmVector2* xDecomp, double blankValue = 0.0);
 };
 
 //! BLAS operator wrapper for 2-D finite differencing.

--- a/include/jet/fdm_linear_system3.h
+++ b/include/jet/fdm_linear_system3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Doyub Kim
+// Copyright (c) 3017 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -7,7 +7,10 @@
 #ifndef INCLUDE_JET_FDM_LINEAR_SYSTEM3_H_
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM3_H_
 
+#include <jet/array1.h>
 #include <jet/array3.h>
+#include <jet/matrix_csr.h>
+#include <jet/vector_n.h>
 
 namespace jet {
 
@@ -34,10 +37,47 @@ typedef Array3<FdmMatrixRow3> FdmMatrix3;
 
 //! Linear system (Ax=b) for 3-D finite differencing.
 struct FdmLinearSystem3 {
+    //! System matrix.
     FdmMatrix3 A;
-    FdmVector3 x, b;
 
+    //! Solution vector.
+    FdmVector3 x;
+
+    //! RHS vector.
+    FdmVector3 b;
+
+    //! Clears all the data.
     void clear();
+
+    //! Resizes the arrays with given grid size.
+    void resize(const Size3& size);
+};
+
+//! Compressed linear system (Ax=b) for 3-D finite differencing.
+struct FdmCompressedLinearSystem3 {
+    //! System matrix.
+    MatrixCsrD A;
+
+    //! Solution vector.
+    VectorND x;
+
+    //! RHS vector.
+    VectorND b;
+
+    //! Mapping from grid coordinates to row index.
+    Array3<size_t> coordToIndex;
+
+    //! Mapping from row index to grid coordinate.
+    Array1<Point3UI> indexToCoord;
+
+    //! Clears all the data.
+    void clear();
+
+    //! Resizes 3-D arrays with given grid size.
+    void resize(const Size3& size);
+
+    //! Decompresses the solution vector to the given FDM vector.
+    void decompressSolution(FdmVector3* xDecomp, double blankValue = 0.0);
 };
 
 //! BLAS operator wrapper for 3-D finite differencing.
@@ -47,41 +87,79 @@ struct FdmBlas3 {
     typedef FdmMatrix3 MatrixType;
 
     //! Sets entire element of given vector \p result with scalar \p s.
-    static void set(double s, FdmVector3* result);
+    static void set(ScalarType s, VectorType* result);
 
     //! Copies entire element of given vector \p result with other vector \p v.
-    static void set(const FdmVector3& v, FdmVector3* result);
+    static void set(const VectorType& v, VectorType* result);
 
     //! Sets entire element of given matrix \p result with scalar \p s.
-    static void set(double s, FdmMatrix3* result);
+    static void set(ScalarType s, MatrixType* result);
 
     //! Copies entire element of given matrix \p result with other matrix \p v.
-    static void set(const FdmMatrix3& m, FdmMatrix3* result);
+    static void set(const MatrixType& m, MatrixType* result);
 
     //! Performs dot product with vector \p a and \p b.
-    static double dot(const FdmVector3& a, const FdmVector3& b);
+    static double dot(const VectorType& a, const VectorType& b);
 
     //! Performs ax + y operation where \p a is a matrix and \p x and \p y are
     //! vectors.
-    static void axpy(
-        double a, const FdmVector3& x, const FdmVector3& y, FdmVector3* result);
+    static void axpy(double a, const VectorType& x, const VectorType& y,
+                     VectorType* result);
 
     //! Performs matrix-vector multiplication.
-    static void mvm(
-        const FdmMatrix3& m, const FdmVector3& v, FdmVector3* result);
+    static void mvm(const MatrixType& m, const VectorType& v,
+                    VectorType* result);
 
     //! Computes residual vector (b - ax).
-    static void residual(
-        const FdmMatrix3& a,
-        const FdmVector3& x,
-        const FdmVector3& b,
-        FdmVector3* result);
+    static void residual(const MatrixType& a, const VectorType& x,
+                         const VectorType& b, VectorType* result);
 
     //! Returns L2-norm of the given vector \p v.
-    static double l2Norm(const FdmVector3& v);
+    static ScalarType l2Norm(const VectorType& v);
 
     //! Returns Linf-norm of the given vector \p v.
-    static double lInfNorm(const FdmVector3& v);
+    static ScalarType lInfNorm(const VectorType& v);
+};
+
+//! BLAS operator wrapper for compressed 3-D finite differencing.
+struct FdmCompressedBlas3 {
+    typedef double ScalarType;
+    typedef VectorND VectorType;
+    typedef MatrixCsrD MatrixType;
+
+    //! Sets entire element of given vector \p result with scalar \p s.
+    static void set(ScalarType s, VectorType* result);
+
+    //! Copies entire element of given vector \p result with other vector \p v.
+    static void set(const VectorType& v, VectorType* result);
+
+    //! Sets entire element of given matrix \p result with scalar \p s.
+    static void set(ScalarType s, MatrixType* result);
+
+    //! Copies entire element of given matrix \p result with other matrix \p v.
+    static void set(const MatrixType& m, MatrixType* result);
+
+    //! Performs dot product with vector \p a and \p b.
+    static double dot(const VectorType& a, const VectorType& b);
+
+    //! Performs ax + y operation where \p a is a matrix and \p x and \p y are
+    //! vectors.
+    static void axpy(double a, const VectorType& x, const VectorType& y,
+                     VectorType* result);
+
+    //! Performs matrix-vector multiplication.
+    static void mvm(const MatrixType& m, const VectorType& v,
+                    VectorType* result);
+
+    //! Computes residual vector (b - ax).
+    static void residual(const MatrixType& a, const VectorType& x,
+                         const VectorType& b, VectorType* result);
+
+    //! Returns L2-norm of the given vector \p v.
+    static ScalarType l2Norm(const VectorType& v);
+
+    //! Returns Linf-norm of the given vector \p v.
+    static ScalarType lInfNorm(const VectorType& v);
 };
 
 }  // namespace jet

--- a/include/jet/fdm_linear_system3.h
+++ b/include/jet/fdm_linear_system3.h
@@ -64,20 +64,8 @@ struct FdmCompressedLinearSystem3 {
     //! RHS vector.
     VectorND b;
 
-    //! Mapping from grid coordinates to row index.
-    Array3<size_t> coordToIndex;
-
-    //! Mapping from row index to grid coordinate.
-    Array1<Point3UI> indexToCoord;
-
     //! Clears all the data.
     void clear();
-
-    //! Resizes 3-D arrays with given grid size.
-    void resize(const Size3& size);
-
-    //! Decompresses the solution vector to the given FDM vector.
-    void decompressSolution(FdmVector3* xDecomp, double blankValue = 0.0);
 };
 
 //! BLAS operator wrapper for 3-D finite differencing.

--- a/include/jet/fdm_linear_system_solver2.h
+++ b/include/jet/fdm_linear_system_solver2.h
@@ -17,6 +17,9 @@ class FdmLinearSystemSolver2 {
  public:
     //! Solves the given linear system.
     virtual bool solve(FdmLinearSystem2* system) = 0;
+
+    //! Solves the given compressed linear system.
+    virtual bool solveCompressed(FdmCompressedLinearSystem2*) { return false; }
 };
 
 //! Shared pointer type for the FdmLinearSystemSolver2.

--- a/include/jet/fdm_linear_system_solver3.h
+++ b/include/jet/fdm_linear_system_solver3.h
@@ -17,6 +17,9 @@ class FdmLinearSystemSolver3 {
  public:
     //! Solves the given linear system.
     virtual bool solve(FdmLinearSystem3* system) = 0;
+
+    //! Solves the given compressed linear system.
+    virtual bool solveCompressed(FdmCompressedLinearSystem3*) { return false; }
 };
 
 //! Shared pointer type for the FdmLinearSystemSolver3.

--- a/include/jet/grid_fluid_solver2.h
+++ b/include/jet/grid_fluid_solver2.h
@@ -10,10 +10,10 @@
 #include <jet/advection_solver2.h>
 #include <jet/cell_centered_scalar_grid2.h>
 #include <jet/collider2.h>
-#include <jet/grid_emitter2.h>
 #include <jet/face_centered_grid2.h>
 #include <jet/grid_boundary_condition_solver2.h>
 #include <jet/grid_diffusion_solver2.h>
+#include <jet/grid_emitter2.h>
 #include <jet/grid_pressure_solver2.h>
 #include <jet/grid_system_data2.h>
 #include <jet/physics_animation.h>
@@ -39,10 +39,8 @@ class GridFluidSolver2 : public PhysicsAnimation {
     GridFluidSolver2();
 
     //! Constructs solver with initial grid size.
-    GridFluidSolver2(
-        const Size2& resolution,
-        const Vector2D& gridSpacing,
-        const Vector2D& gridOrigin);
+    GridFluidSolver2(const Size2& resolution, const Vector2D& gridSpacing,
+                     const Vector2D& gridOrigin);
 
     //! Default destructor.
     virtual ~GridFluidSolver2();
@@ -79,6 +77,12 @@ class GridFluidSolver2 : public PhysicsAnimation {
 
     //! Sets the max allowed CFL number.
     void setMaxCfl(double newCfl);
+
+    //! Returns true if the solver is using compressed linear system.
+    bool useCompressedLinearSystem() const;
+
+    //! Sets whether the solver should use compressed linear system.
+    void setUseCompressedLinearSystem(bool onoff);
 
     //! Returns the advection solver instance.
     const AdvectionSolver2Ptr& advectionSolver() const;
@@ -127,10 +131,8 @@ class GridFluidSolver2 : public PhysicsAnimation {
     //! \param[in] newGridSpacing The new grid spacing.
     //! \param[in] newGridOrigin  The new grid origin.
     //!
-    void resizeGrid(
-        const Size2& newSize,
-        const Vector2D& newGridSpacing,
-        const Vector2D& newGridOrigin);
+    void resizeGrid(const Size2& newSize, const Vector2D& newGridSpacing,
+                    const Vector2D& newGridOrigin);
 
     //!
     //! \brief Returns the resolution of the grid system data.
@@ -267,6 +269,7 @@ class GridFluidSolver2 : public PhysicsAnimation {
     Vector2D _gravity = Vector2D(0.0, -9.8);
     double _viscosityCoefficient = 0.0;
     double _maxCfl = 5.0;
+    bool _useCompressedLinearSys = false;
     int _closedDomainBoundaryFlag = kDirectionAll;
 
     GridSystemData2Ptr _grids;
@@ -289,7 +292,6 @@ class GridFluidSolver2 : public PhysicsAnimation {
 
 //! Shared pointer type for the GridFluidSolver2.
 typedef std::shared_ptr<GridFluidSolver2> GridFluidSolver2Ptr;
-
 
 //!
 //! \brief Base class for grid-based fluid solver builder.
@@ -382,10 +384,8 @@ class GridFluidSolver2::Builder final
 
     //! Builds shared pointer of GridFluidSolver2 instance.
     GridFluidSolver2Ptr makeShared() const {
-        return std::make_shared<GridFluidSolver2>(
-            _resolution,
-            getGridSpacing(),
-            _gridOrigin);
+        return std::make_shared<GridFluidSolver2>(_resolution, getGridSpacing(),
+                                                  _gridOrigin);
     }
 };
 

--- a/include/jet/grid_fluid_solver3.h
+++ b/include/jet/grid_fluid_solver3.h
@@ -10,10 +10,10 @@
 #include <jet/advection_solver3.h>
 #include <jet/cell_centered_scalar_grid3.h>
 #include <jet/collider3.h>
-#include <jet/grid_emitter3.h>
 #include <jet/face_centered_grid3.h>
 #include <jet/grid_boundary_condition_solver3.h>
 #include <jet/grid_diffusion_solver3.h>
+#include <jet/grid_emitter3.h>
 #include <jet/grid_pressure_solver3.h>
 #include <jet/grid_system_data3.h>
 #include <jet/physics_animation.h>
@@ -39,10 +39,8 @@ class GridFluidSolver3 : public PhysicsAnimation {
     GridFluidSolver3();
 
     //! Constructs solver with initial grid size.
-    GridFluidSolver3(
-        const Size3& resolution,
-        const Vector3D& gridSpacing,
-        const Vector3D& gridOrigin);
+    GridFluidSolver3(const Size3& resolution, const Vector3D& gridSpacing,
+                     const Vector3D& gridOrigin);
 
     //! Default destructor.
     virtual ~GridFluidSolver3();
@@ -79,6 +77,12 @@ class GridFluidSolver3 : public PhysicsAnimation {
 
     //! Sets the max allowed CFL number.
     void setMaxCfl(double newCfl);
+
+    //! Returns true if the solver is using compressed linear system.
+    bool useCompressedLinearSystem() const;
+
+    //! Sets whether the solver should use compressed linear system.
+    void setUseCompressedLinearSystem(bool onoff);
 
     //! Returns the advection solver instance.
     const AdvectionSolver3Ptr& advectionSolver() const;
@@ -127,10 +131,8 @@ class GridFluidSolver3 : public PhysicsAnimation {
     //! \param[in] newGridSpacing The new grid spacing.
     //! \param[in] newGridOrigin  The new grid origin.
     //!
-    void resizeGrid(
-        const Size3& newSize,
-        const Vector3D& newGridSpacing,
-        const Vector3D& newGridOrigin);
+    void resizeGrid(const Size3& newSize, const Vector3D& newGridSpacing,
+                    const Vector3D& newGridOrigin);
 
     //!
     //! \brief Returns the resolution of the grid system data.
@@ -267,6 +269,7 @@ class GridFluidSolver3 : public PhysicsAnimation {
     Vector3D _gravity = Vector3D(0.0, -9.8, 0.0);
     double _viscosityCoefficient = 0.0;
     double _maxCfl = 5.0;
+    bool _useCompressedLinearSys = false;
     int _closedDomainBoundaryFlag = kDirectionAll;
 
     GridSystemData3Ptr _grids;
@@ -289,7 +292,6 @@ class GridFluidSolver3 : public PhysicsAnimation {
 
 //! Shared pointer type for the GridFluidSolver3.
 typedef std::shared_ptr<GridFluidSolver3> GridFluidSolver3Ptr;
-
 
 //!
 //! \brief Base class for grid-based fluid solver builder.
@@ -383,10 +385,8 @@ class GridFluidSolver3::Builder final
 
     //! Builds shared pointer of GridFluidSolver3 instance.
     GridFluidSolver3Ptr makeShared() const {
-        return std::make_shared<GridFluidSolver3>(
-            _resolution,
-            getGridSpacing(),
-            _gridOrigin);
+        return std::make_shared<GridFluidSolver3>(_resolution, getGridSpacing(),
+                                                  _gridOrigin);
     }
 };
 

--- a/include/jet/grid_fractional_single_phase_pressure_solver2.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver2.h
@@ -71,13 +71,15 @@ class GridFractionalSinglePhasePressureSolver2 final
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
-    void solve(
-        const FaceCenteredGrid2& input, double timeIntervalInSeconds,
-        FaceCenteredGrid2* output,
-        const ScalarField2& boundarySdf = ConstantScalarField2(kMaxD),
-        const VectorField2& boundaryVelocity = ConstantVectorField2({0, 0}),
-        const ScalarField2& fluidSdf = ConstantScalarField2(-kMaxD)) override;
+    void solve(const FaceCenteredGrid2& input, double timeIntervalInSeconds,
+               FaceCenteredGrid2* output,
+               const ScalarField2& boundarySdf = ConstantScalarField2(kMaxD),
+               const VectorField2& boundaryVelocity = ConstantVectorField2({0,
+                                                                            0}),
+               const ScalarField2& fluidSdf = ConstantScalarField2(-kMaxD),
+               bool useCompressed = false) override;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -102,6 +104,7 @@ class GridFractionalSinglePhasePressureSolver2 final
 
  private:
     FdmLinearSystem2 _system;
+    FdmCompressedLinearSystem2 _compSystem;
     FdmLinearSystemSolver2Ptr _systemSolver;
 
     FdmMgLinearSystem2 _mgSystem;
@@ -118,7 +121,8 @@ class GridFractionalSinglePhasePressureSolver2 final
                       const VectorField2& boundaryVelocity,
                       const ScalarField2& fluidSdf);
 
-    virtual void buildSystem(const FaceCenteredGrid2& input);
+    virtual void buildSystem(const FaceCenteredGrid2& input,
+                             bool useCompressed);
 
     virtual void applyPressureGradient(const FaceCenteredGrid2& input,
                                        FaceCenteredGrid2* output);

--- a/include/jet/grid_fractional_single_phase_pressure_solver2.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver2.h
@@ -121,6 +121,8 @@ class GridFractionalSinglePhasePressureSolver2 final
                       const VectorField2& boundaryVelocity,
                       const ScalarField2& fluidSdf);
 
+    void decompressSolution();
+
     virtual void buildSystem(const FaceCenteredGrid2& input,
                              bool useCompressed);
 

--- a/include/jet/grid_fractional_single_phase_pressure_solver3.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver3.h
@@ -119,6 +119,8 @@ class GridFractionalSinglePhasePressureSolver3 : public GridPressureSolver3 {
                       const VectorField3& boundaryVelocity,
                       const ScalarField3& fluidSdf);
 
+    void decompressSolution();
+
     virtual void buildSystem(const FaceCenteredGrid3& input,
                              bool useCompressed);
 

--- a/include/jet/grid_fractional_single_phase_pressure_solver3.h
+++ b/include/jet/grid_fractional_single_phase_pressure_solver3.h
@@ -68,13 +68,15 @@ class GridFractionalSinglePhasePressureSolver3 : public GridPressureSolver3 {
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
     void solve(
         const FaceCenteredGrid3& input, double timeIntervalInSeconds,
         FaceCenteredGrid3* output,
         const ScalarField3& boundarySdf = ConstantScalarField3(kMaxD),
         const VectorField3& boundaryVelocity = ConstantVectorField3({0, 0, 0}),
-        const ScalarField3& fluidSdf = ConstantScalarField3(-kMaxD)) override;
+        const ScalarField3& fluidSdf = ConstantScalarField3(-kMaxD),
+        bool useCompressed = false) override;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -99,6 +101,7 @@ class GridFractionalSinglePhasePressureSolver3 : public GridPressureSolver3 {
 
  private:
     FdmLinearSystem3 _system;
+    FdmCompressedLinearSystem3 _compSystem;
     FdmLinearSystemSolver3Ptr _systemSolver;
 
     FdmMgLinearSystem3 _mgSystem;
@@ -116,7 +119,8 @@ class GridFractionalSinglePhasePressureSolver3 : public GridPressureSolver3 {
                       const VectorField3& boundaryVelocity,
                       const ScalarField3& fluidSdf);
 
-    virtual void buildSystem(const FaceCenteredGrid3& input);
+    virtual void buildSystem(const FaceCenteredGrid3& input,
+                             bool useCompressed);
 
     virtual void applyPressureGradient(const FaceCenteredGrid3& input,
                                        FaceCenteredGrid3* output);

--- a/include/jet/grid_pressure_solver2.h
+++ b/include/jet/grid_pressure_solver2.h
@@ -53,17 +53,15 @@ class GridPressureSolver2 {
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
     virtual void solve(
-        const FaceCenteredGrid2& input,
-        double timeIntervalInSeconds,
+        const FaceCenteredGrid2& input, double timeIntervalInSeconds,
         FaceCenteredGrid2* output,
-        const ScalarField2& boundarySdf
-            = ConstantScalarField2(kMaxD),
-        const VectorField2& boundaryVelocity
-            = ConstantVectorField2({0, 0}),
-        const ScalarField2& fluidSdf
-            = ConstantScalarField2(-kMaxD)) = 0;
+        const ScalarField2& boundarySdf = ConstantScalarField2(kMaxD),
+        const VectorField2& boundaryVelocity = ConstantVectorField2({0, 0}),
+        const ScalarField2& fluidSdf = ConstantScalarField2(-kMaxD),
+        bool useCompressed = false) = 0;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -72,8 +70,8 @@ class GridPressureSolver2 {
     //! with this pressure solver. Depending on the pressure solver
     //! implementation, different boundary condition solver might be used.
     //!
-    virtual GridBoundaryConditionSolver2Ptr
-        suggestedBoundaryConditionSolver() const = 0;
+    virtual GridBoundaryConditionSolver2Ptr suggestedBoundaryConditionSolver()
+        const = 0;
 };
 
 //! Shared pointer type for the GridPressureSolver2.

--- a/include/jet/grid_pressure_solver3.h
+++ b/include/jet/grid_pressure_solver3.h
@@ -53,17 +53,15 @@ class GridPressureSolver3 {
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
     virtual void solve(
-        const FaceCenteredGrid3& input,
-        double timeIntervalInSeconds,
+        const FaceCenteredGrid3& input, double timeIntervalInSeconds,
         FaceCenteredGrid3* output,
-        const ScalarField3& boundarySdf
-            = ConstantScalarField3(kMaxD),
-        const VectorField3& boundaryVelocity
-            = ConstantVectorField3({0, 0, 0}),
-        const ScalarField3& fluidSdf
-            = ConstantScalarField3(-kMaxD)) = 0;
+        const ScalarField3& boundarySdf = ConstantScalarField3(kMaxD),
+        const VectorField3& boundaryVelocity = ConstantVectorField3({0, 0, 0}),
+        const ScalarField3& fluidSdf = ConstantScalarField3(-kMaxD),
+        bool useCompressed = false) = 0;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -72,8 +70,8 @@ class GridPressureSolver3 {
     //! with this pressure solver. Depending on the pressure solver
     //! implementation, different boundary condition solver might be used.
     //!
-    virtual GridBoundaryConditionSolver3Ptr
-        suggestedBoundaryConditionSolver() const = 0;
+    virtual GridBoundaryConditionSolver3Ptr suggestedBoundaryConditionSolver()
+        const = 0;
 };
 
 //! Shared pointer type for the GridPressureSolver3.

--- a/include/jet/grid_single_phase_pressure_solver2.h
+++ b/include/jet/grid_single_phase_pressure_solver2.h
@@ -58,13 +58,15 @@ class GridSinglePhasePressureSolver2 : public GridPressureSolver2 {
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
-    void solve(
-        const FaceCenteredGrid2& input, double timeIntervalInSeconds,
-        FaceCenteredGrid2* output,
-        const ScalarField2& boundarySdf = ConstantScalarField2(kMaxD),
-        const VectorField2& boundaryVelocity = ConstantVectorField2({0, 0}),
-        const ScalarField2& fluidSdf = ConstantScalarField2(-kMaxD)) override;
+    void solve(const FaceCenteredGrid2& input, double timeIntervalInSeconds,
+               FaceCenteredGrid2* output,
+               const ScalarField2& boundarySdf = ConstantScalarField2(kMaxD),
+               const VectorField2& boundaryVelocity = ConstantVectorField2({0,
+                                                                            0}),
+               const ScalarField2& fluidSdf = ConstantScalarField2(-kMaxD),
+               bool useCompressed = false) override;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -90,6 +92,7 @@ class GridSinglePhasePressureSolver2 : public GridPressureSolver2 {
 
  private:
     FdmLinearSystem2 _system;
+    FdmCompressedLinearSystem2 _compSystem;
     FdmLinearSystemSolver2Ptr _systemSolver;
 
     FdmMgLinearSystem2 _mgSystem;
@@ -102,7 +105,8 @@ class GridSinglePhasePressureSolver2 : public GridPressureSolver2 {
                       const ScalarField2& boundarySdf,
                       const ScalarField2& fluidSdf);
 
-    virtual void buildSystem(const FaceCenteredGrid2& input);
+    virtual void buildSystem(const FaceCenteredGrid2& input,
+                             bool useCompressed);
 
     virtual void applyPressureGradient(const FaceCenteredGrid2& input,
                                        FaceCenteredGrid2* output);

--- a/include/jet/grid_single_phase_pressure_solver2.h
+++ b/include/jet/grid_single_phase_pressure_solver2.h
@@ -105,6 +105,8 @@ class GridSinglePhasePressureSolver2 : public GridPressureSolver2 {
                       const ScalarField2& boundarySdf,
                       const ScalarField2& fluidSdf);
 
+    void decompressSolution();
+
     virtual void buildSystem(const FaceCenteredGrid2& input,
                              bool useCompressed);
 

--- a/include/jet/grid_single_phase_pressure_solver3.h
+++ b/include/jet/grid_single_phase_pressure_solver3.h
@@ -105,6 +105,8 @@ class GridSinglePhasePressureSolver3 : public GridPressureSolver3 {
         const std::function<Vector3D(size_t, size_t, size_t)>& pos,
         const ScalarField3& boundarySdf, const ScalarField3& fluidSdf);
 
+    void decompressSolution();
+
     virtual void buildSystem(const FaceCenteredGrid3& input,
                              bool useCompressed);
 

--- a/include/jet/grid_single_phase_pressure_solver3.h
+++ b/include/jet/grid_single_phase_pressure_solver3.h
@@ -58,13 +58,15 @@ class GridSinglePhasePressureSolver3 : public GridPressureSolver3 {
     //! \param[inout] output                The output velocity field.
     //! \param[in]    boundarySdf           The SDF of the boundary.
     //! \param[in]    fluidSdf              The SDF of the fluid/atmosphere.
+    //! \param[in]    useCompressed         True if it uses compressed system.
     //!
     void solve(
         const FaceCenteredGrid3& input, double timeIntervalInSeconds,
         FaceCenteredGrid3* output,
         const ScalarField3& boundarySdf = ConstantScalarField3(kMaxD),
         const VectorField3& boundaryVelocity = ConstantVectorField3({0, 0, 0}),
-        const ScalarField3& fluidSdf = ConstantScalarField3(-kMaxD)) override;
+        const ScalarField3& fluidSdf = ConstantScalarField3(-kMaxD),
+        bool useCompressed = false) override;
 
     //!
     //! \brief Returns the best boundary condition solver for this solver.
@@ -90,6 +92,7 @@ class GridSinglePhasePressureSolver3 : public GridPressureSolver3 {
 
  private:
     FdmLinearSystem3 _system;
+    FdmCompressedLinearSystem3 _compSystem;
     FdmLinearSystemSolver3Ptr _systemSolver;
 
     FdmMgLinearSystem3 _mgSystem;
@@ -102,7 +105,8 @@ class GridSinglePhasePressureSolver3 : public GridPressureSolver3 {
         const std::function<Vector3D(size_t, size_t, size_t)>& pos,
         const ScalarField3& boundarySdf, const ScalarField3& fluidSdf);
 
-    virtual void buildSystem(const FaceCenteredGrid3& input);
+    virtual void buildSystem(const FaceCenteredGrid3& input,
+                             bool useCompressed);
 
     virtual void applyPressureGradient(const FaceCenteredGrid3& input,
                                        FaceCenteredGrid3* output);

--- a/include/jet/matrix_csr.h
+++ b/include/jet/matrix_csr.h
@@ -164,6 +164,9 @@ class MatrixCsr final : public MatrixExpression<T, MatrixCsr<T>> {
 
     // MARK: Basic setters
 
+    //! Clears the matrix and make it zero-dimensional.
+    void clear();
+
     //! Sets whole matrix with input scalar.
     void set(const T& s);
 

--- a/include/jet/vector_n.h
+++ b/include/jet/vector_n.h
@@ -61,6 +61,9 @@ class VectorN final : public VectorExpression<T, VectorN<T>> {
     //! Resizes to \p n dimensional vector with initial value \p val.
     void resize(size_t n, const T& val = 0);
 
+    //! Clears the vector and make it zero-dimensional.
+    void clear();
+
     //! Sets all elements to \p s.
     void set(const T& s);
 
@@ -71,6 +74,9 @@ class VectorN final : public VectorExpression<T, VectorN<T>> {
     //! Sets vector with expression template.
     template <typename E>
     void set(const VectorExpression<T, E>& other);
+
+    //! Adds an element.
+    void append(const T& val);
 
     //! Swaps the content of the vector with \p other vector.
     void swap(VectorN& other);

--- a/src/examples/hybrid_liquid_sim/main.cpp
+++ b/src/examples/hybrid_liquid_sim/main.cpp
@@ -232,6 +232,7 @@ void runExample3(const std::string& rootDir, size_t resolutionX,
                       .withResolution(resolution)
                       .withDomainSizeX(3.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -309,6 +310,7 @@ void runExample4(const std::string& rootDir, size_t resolutionX,
                       .withResolution(resolution)
                       .withDomainSizeX(3.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -386,6 +388,7 @@ void runExample5(const std::string& rootDir, size_t resolutionX,
                       .withResolution(resolution)
                       .withDomainSizeX(3.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -461,6 +464,7 @@ void runExample6(const std::string& rootDir, size_t resolutionX,
                       .withResolution({resolutionX, resolutionX, resolutionX})
                       .withDomainSizeX(1.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     // Build collider
     auto sphere = Sphere3::builder()
@@ -475,6 +479,7 @@ void runExample6(const std::string& rootDir, size_t resolutionX,
     solver->setCollider(collider);
 
     // Manually emit particles
+    printf("Start emitting particles...\n");
     std::mt19937 rng;
     std::uniform_real_distribution<> dist(-0.1 * solver->gridSpacing().x,
                                           0.1 * solver->gridSpacing().x);

--- a/src/examples/level_set_liquid_sim/main.cpp
+++ b/src/examples/level_set_liquid_sim/main.cpp
@@ -23,10 +23,8 @@
 
 using namespace jet;
 
-void saveTriangleMesh(
-    const TriangleMesh3& mesh,
-    const std::string& rootDir,
-    int frameCnt) {
+void saveTriangleMesh(const TriangleMesh3& mesh, const std::string& rootDir,
+                      int frameCnt) {
     char basename[256];
     snprintf(basename, sizeof(basename), "frame_%06d.obj", frameCnt);
     std::string filename = pystring::os::path::join(rootDir, basename);
@@ -38,34 +36,29 @@ void saveTriangleMesh(
     }
 }
 
-void triangulateAndSave(
-    const ScalarGrid3Ptr& sdf,
-    const std::string& rootDir,
-    int frameCnt) {
+void triangulateAndSave(const ScalarGrid3Ptr& sdf, const std::string& rootDir,
+                        int frameCnt) {
     TriangleMesh3 mesh;
     int flag = kDirectionAll & ~kDirectionDown;
-    marchingCubes(
-        sdf->constDataAccessor(),
-        sdf->gridSpacing(),
-        sdf->dataOrigin(),
-        &mesh,
-        0.0,
-        flag);
+    marchingCubes(sdf->constDataAccessor(), sdf->gridSpacing(),
+                  sdf->dataOrigin(), &mesh, 0.0, flag);
     saveTriangleMesh(mesh, rootDir, frameCnt);
 }
 
 void printUsage() {
-    printf(
-        "Usage: " APP_NAME " "
-        "-r resolution -l length -f frames -e example_num\n"
-        "   -r, --resx: grid resolution in x-axis (default is 50)\n"
-        "   -f, --frames: total number of frames (default is 100)\n"
-        "   -p, --fps: frames per second (default is 60.0)\n"
-        "   -l, --log: log filename (default is " APP_NAME ".log)\n"
-        "   -o, --output: output directory name "
-        "(default is " APP_NAME "_output)\n"
-        "   -e, --example: example number (between 1 and 4, default is 1)\n"
-        "   -h, --help: print this message\n");
+    printf("Usage: " APP_NAME
+           " "
+           "-r resolution -l length -f frames -e example_num\n"
+           "   -r, --resx: grid resolution in x-axis (default is 50)\n"
+           "   -f, --frames: total number of frames (default is 100)\n"
+           "   -p, --fps: frames per second (default is 60.0)\n"
+           "   -l, --log: log filename (default is " APP_NAME
+           ".log)\n"
+           "   -o, --output: output directory name "
+           "(default is " APP_NAME
+           "_output)\n"
+           "   -e, --example: example number (between 1 and 4, default is 1)\n"
+           "   -h, --help: print this message\n");
 }
 
 void printInfo(const LevelSetLiquidSolver3Ptr& solver) {
@@ -74,23 +67,18 @@ void printInfo(const LevelSetLiquidSolver3Ptr& solver) {
     BoundingBox3D domain = grids->boundingBox();
     Vector3D gridSpacing = grids->gridSpacing();
 
-    printf(
-        "Resolution: %zu x %zu x %zu\n",
-        resolution.x, resolution.y, resolution.z);
-    printf(
-        "Domain: [%f, %f, %f] x [%f, %f, %f]\n",
-        domain.lowerCorner.x, domain.lowerCorner.y, domain.lowerCorner.z,
-        domain.upperCorner.x, domain.upperCorner.y, domain.upperCorner.z);
-    printf(
-        "Grid spacing: [%f, %f, %f]\n",
-        gridSpacing.x, gridSpacing.y, gridSpacing.z);
+    printf("Resolution: %zu x %zu x %zu\n", resolution.x, resolution.y,
+           resolution.z);
+    printf("Domain: [%f, %f, %f] x [%f, %f, %f]\n", domain.lowerCorner.x,
+           domain.lowerCorner.y, domain.lowerCorner.z, domain.upperCorner.x,
+           domain.upperCorner.y, domain.upperCorner.z);
+    printf("Grid spacing: [%f, %f, %f]\n", gridSpacing.x, gridSpacing.y,
+           gridSpacing.z);
 }
 
-void runSimulation(
-    const std::string& rootDir,
-    const LevelSetLiquidSolver3Ptr& solver,
-    int numberOfFrames,
-    double fps) {
+void runSimulation(const std::string& rootDir,
+                   const LevelSetLiquidSolver3Ptr& solver, int numberOfFrames,
+                   double fps) {
     auto sdf = solver->signedDistanceField();
 
     for (Frame frame(0, 1.0 / fps); frame.index < numberOfFrames; ++frame) {
@@ -101,38 +89,34 @@ void runSimulation(
 }
 
 // Water-drop example
-void runExample1(
-    const std::string& rootDir,
-    size_t resX,
-    int numberOfFrames,
-    double fps) {
+void runExample1(const std::string& rootDir, size_t resX, int numberOfFrames,
+                 double fps) {
     // Build solver
     auto solver = LevelSetLiquidSolver3::builder()
-        .withResolution({resX, 2 * resX, resX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+                      .withResolution({resX, 2 * resX, resX})
+                      .withDomainSizeX(1.0)
+                      .makeShared();
 
     auto grids = solver->gridSystemData();
     BoundingBox3D domain = grids->boundingBox();
 
     // Build emitter
     auto plane = Plane3::builder()
-        .withNormal({0, 1, 0})
-        .withPoint({0, 0.25 * domain.height(), 0})
-        .makeShared();
+                     .withNormal({0, 1, 0})
+                     .withPoint({0, 0.25 * domain.height(), 0})
+                     .makeShared();
 
     auto sphere = Sphere3::builder()
-        .withCenter(domain.midPoint())
-        .withRadius(0.15 * domain.width())
-        .makeShared();
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
 
     auto surfaceSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({plane, sphere})
-        .makeShared();
+                          .withExplicitSurfaces({plane, sphere})
+                          .makeShared();
 
-    auto emitter = VolumeGridEmitter3::builder()
-        .withSourceRegion(surfaceSet)
-        .makeShared();
+    auto emitter =
+        VolumeGridEmitter3::builder().withSourceRegion(surfaceSet).makeShared();
 
     solver->setEmitter(emitter);
     emitter->addSignedDistanceTarget(solver->signedDistanceField());
@@ -146,16 +130,14 @@ void runExample1(
 }
 
 // Dam-breaking example
-void runExample2(
-    const std::string& rootDir,
-    size_t resX,
-    int numberOfFrames,
-    double fps) {
+void runExample2(const std::string& rootDir, size_t resX, int numberOfFrames,
+                 double fps) {
     // Build solver
     auto solver = LevelSetLiquidSolver3::builder()
-        .withResolution({3 * resX, 2 * resX, (3 * resX) / 2})
-        .withDomainSizeX(3.0)
-        .makeShared();
+                      .withResolution({3 * resX, 2 * resX, (3 * resX) / 2})
+                      .withDomainSizeX(3.0)
+                      .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     BoundingBox3D domain = grids->boundingBox();
@@ -163,52 +145,50 @@ void runExample2(
 
     // Build emitter
     auto box1 = Box3::builder()
-        .withLowerCorner({-0.5, -0.5, -0.5 * lz})
-        .withUpperCorner({0.5, 0.75, 0.75 * lz})
-        .makeShared();
+                    .withLowerCorner({-0.5, -0.5, -0.5 * lz})
+                    .withUpperCorner({0.5, 0.75, 0.75 * lz})
+                    .makeShared();
 
     auto box2 = Box3::builder()
-        .withLowerCorner({2.5, -0.5, 0.25 * lz})
-        .withUpperCorner({3.5, 0.75, 1.5 * lz})
-        .makeShared();
+                    .withLowerCorner({2.5, -0.5, 0.25 * lz})
+                    .withUpperCorner({3.5, 0.75, 1.5 * lz})
+                    .makeShared();
 
     auto boxSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({box1, box2})
-        .makeShared();
+                      .withExplicitSurfaces({box1, box2})
+                      .makeShared();
 
-    auto emitter = VolumeGridEmitter3::builder()
-        .withSourceRegion(boxSet)
-        .makeShared();
+    auto emitter =
+        VolumeGridEmitter3::builder().withSourceRegion(boxSet).makeShared();
 
     solver->setEmitter(emitter);
     emitter->addSignedDistanceTarget(solver->signedDistanceField());
 
     // Build collider
     auto cyl1 = Cylinder3::builder()
-        .withCenter({1, 0.375, 0.375})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1, 0.375, 0.375})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl2 = Cylinder3::builder()
-        .withCenter({1.5, 0.375, 0.75})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1.5, 0.375, 0.75})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl3 = Cylinder3::builder()
-        .withCenter({2, 0.375, 1.125})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({2, 0.375, 1.125})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cylSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({cyl1, cyl2, cyl3})
-        .makeShared();
+                      .withExplicitSurfaces({cyl1, cyl2, cyl3})
+                      .makeShared();
 
-    auto collider = RigidBodyCollider3::builder()
-        .withSurface(cylSet)
-        .makeShared();
+    auto collider =
+        RigidBodyCollider3::builder().withSurface(cylSet).makeShared();
 
     solver->setCollider(collider);
 
@@ -221,16 +201,14 @@ void runExample2(
 }
 
 // High-viscosity example (bunny-drop)
-void runExample3(
-    const std::string& rootDir,
-    size_t resX,
-    int numberOfFrames,
-    double fps) {
+void runExample3(const std::string& rootDir, size_t resX, int numberOfFrames,
+                 double fps) {
     // Build solver
     auto solver = LevelSetLiquidSolver3::builder()
-        .withResolution({resX, resX, resX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+                      .withResolution({resX, resX, resX})
+                      .withDomainSizeX(1.0)
+                      .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     solver->setViscosityCoefficient(1.0);
     solver->setIsGlobalCompensationEnabled(true);
@@ -247,13 +225,12 @@ void runExample3(
         exit(EXIT_FAILURE);
     }
     auto bunny = ImplicitTriangleMesh3::builder()
-        .withTriangleMesh(bunnyMesh)
-        .withResolutionX(resX)
-        .makeShared();
+                     .withTriangleMesh(bunnyMesh)
+                     .withResolutionX(resX)
+                     .makeShared();
 
-    auto emitter = VolumeGridEmitter3::builder()
-        .withSourceRegion(bunny)
-        .makeShared();
+    auto emitter =
+        VolumeGridEmitter3::builder().withSourceRegion(bunny).makeShared();
 
     solver->setEmitter(emitter);
     emitter->addSignedDistanceTarget(solver->signedDistanceField());
@@ -267,16 +244,14 @@ void runExample3(
 }
 
 // Low-viscosity example (bunny-drop)
-void runExample4(
-    const std::string& rootDir,
-    size_t resX,
-    int numberOfFrames,
-    double fps) {
+void runExample4(const std::string& rootDir, size_t resX, int numberOfFrames,
+                 double fps) {
     // Build solver
     auto solver = LevelSetLiquidSolver3::builder()
-        .withResolution({resX, resX, resX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+                      .withResolution({resX, resX, resX})
+                      .withDomainSizeX(1.0)
+                      .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     solver->setViscosityCoefficient(0.0);
     solver->setIsGlobalCompensationEnabled(true);
@@ -293,13 +268,12 @@ void runExample4(
         exit(EXIT_FAILURE);
     }
     auto bunny = ImplicitTriangleMesh3::builder()
-        .withTriangleMesh(bunnyMesh)
-        .withResolutionX(resX)
-        .makeShared();
+                     .withTriangleMesh(bunnyMesh)
+                     .withResolutionX(resX)
+                     .makeShared();
 
-    auto emitter = VolumeGridEmitter3::builder()
-        .withSourceRegion(bunny)
-        .makeShared();
+    auto emitter =
+        VolumeGridEmitter3::builder().withSourceRegion(bunny).makeShared();
 
     solver->setEmitter(emitter);
     emitter->addSignedDistanceTarget(solver->signedDistanceField());
@@ -322,20 +296,19 @@ int main(int argc, char* argv[]) {
 
     // Parse options
     static struct option longOptions[] = {
-        {"resx",      optional_argument, 0, 'r'},
-        {"frames",    optional_argument, 0, 'f'},
-        {"fps",       optional_argument, 0, 'p'},
-        {"example",   optional_argument, 0, 'e'},
-        {"log",       optional_argument, 0, 'l'},
+        {"resx", optional_argument, 0, 'r'},
+        {"frames", optional_argument, 0, 'f'},
+        {"fps", optional_argument, 0, 'p'},
+        {"example", optional_argument, 0, 'e'},
+        {"log", optional_argument, 0, 'l'},
         {"outputDir", optional_argument, 0, 'o'},
-        {"help",      optional_argument, 0, 'h'},
-        {0,           0,                 0,  0 }
-    };
+        {"help", optional_argument, 0, 'h'},
+        {0, 0, 0, 0}};
 
     int opt = 0;
     int long_index = 0;
-    while ((opt = getopt_long(
-        argc, argv, "r:f:p:e:l:o:h", longOptions, &long_index)) != -1) {
+    while ((opt = getopt_long(argc, argv, "r:f:p:e:l:o:h", longOptions,
+                              &long_index)) != -1) {
         switch (opt) {
             case 'r':
                 resX = static_cast<size_t>(atoi(optarg));

--- a/src/jet/fdm_cg_solver2.cpp
+++ b/src/jet/fdm_cg_solver2.cpp
@@ -5,19 +5,18 @@
 // property of any third parties.
 
 #include <pch.h>
-#include <jet/constants.h>
+
 #include <jet/cg.h>
+#include <jet/constants.h>
 #include <jet/fdm_cg_solver2.h>
 
 using namespace jet;
 
-FdmCgSolver2::FdmCgSolver2(
-    unsigned int maxNumberOfIterations, double tolerance) :
-    _maxNumberOfIterations(maxNumberOfIterations),
-    _lastNumberOfIterations(0),
-    _tolerance(tolerance),
-    _lastResidual(kMaxD) {
-}
+FdmCgSolver2::FdmCgSolver2(unsigned int maxNumberOfIterations, double tolerance)
+    : _maxNumberOfIterations(maxNumberOfIterations),
+      _lastNumberOfIterations(0),
+      _tolerance(tolerance),
+      _lastResidual(kMaxD) {}
 
 bool FdmCgSolver2::solve(FdmLinearSystem2* system) {
     FdmMatrix2& matrix = system->A;
@@ -39,21 +38,36 @@ bool FdmCgSolver2::solve(FdmLinearSystem2* system) {
     _q.set(0.0);
     _s.set(0.0);
 
-    cg<FdmBlas2>(
-        matrix,
-        rhs,
-        _maxNumberOfIterations,
-        _tolerance,
-        &solution,
-        &_r,
-        &_d,
-        &_q,
-        &_s,
-        &_lastNumberOfIterations,
-        &_lastResidual);
+    cg<FdmBlas2>(matrix, rhs, _maxNumberOfIterations, _tolerance, &solution,
+                 &_r, &_d, &_q, &_s, &_lastNumberOfIterations, &_lastResidual);
 
-    return _lastResidual <= _tolerance
-        || _lastNumberOfIterations < _maxNumberOfIterations;
+    return _lastResidual <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
+}
+
+bool FdmCgSolver2::solveCompressed(FdmCompressedLinearSystem2* system) {
+    MatrixCsrD& matrix = system->A;
+    VectorND& solution = system->x;
+    VectorND& rhs = system->b;
+
+    size_t size = solution.size();
+    _rComp.resize(size);
+    _dComp.resize(size);
+    _qComp.resize(size);
+    _sComp.resize(size);
+
+    system->x.set(0.0);
+    _rComp.set(0.0);
+    _dComp.set(0.0);
+    _qComp.set(0.0);
+    _sComp.set(0.0);
+
+    cg<FdmCompressedBlas2>(matrix, rhs, _maxNumberOfIterations, _tolerance,
+                           &solution, &_rComp, &_dComp, &_qComp, &_sComp,
+                           &_lastNumberOfIterations, &_lastResidual);
+
+    return _lastResidual <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
 }
 
 unsigned int FdmCgSolver2::maxNumberOfIterations() const {
@@ -64,10 +78,6 @@ unsigned int FdmCgSolver2::lastNumberOfIterations() const {
     return _lastNumberOfIterations;
 }
 
-double FdmCgSolver2::tolerance() const {
-    return _tolerance;
-}
+double FdmCgSolver2::tolerance() const { return _tolerance; }
 
-double FdmCgSolver2::lastResidual() const {
-    return _lastResidual;
-}
+double FdmCgSolver2::lastResidual() const { return _lastResidual; }

--- a/src/jet/fdm_cg_solver2.cpp
+++ b/src/jet/fdm_cg_solver2.cpp
@@ -26,6 +26,8 @@ bool FdmCgSolver2::solve(FdmLinearSystem2* system) {
     JET_ASSERT(matrix.size() == rhs.size());
     JET_ASSERT(matrix.size() == solution.size());
 
+    clearCompressedVectors();
+
     Size2 size = matrix.size();
     _r.resize(size);
     _d.resize(size);
@@ -49,6 +51,8 @@ bool FdmCgSolver2::solveCompressed(FdmCompressedLinearSystem2* system) {
     MatrixCsrD& matrix = system->A;
     VectorND& solution = system->x;
     VectorND& rhs = system->b;
+
+    clearUncompressedVectors();
 
     size_t size = solution.size();
     _rComp.resize(size);
@@ -81,3 +85,17 @@ unsigned int FdmCgSolver2::lastNumberOfIterations() const {
 double FdmCgSolver2::tolerance() const { return _tolerance; }
 
 double FdmCgSolver2::lastResidual() const { return _lastResidual; }
+
+void FdmCgSolver2::clearUncompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
+}
+
+void FdmCgSolver2::clearCompressedVectors() {
+    _rComp.clear();
+    _dComp.clear();
+    _qComp.clear();
+    _sComp.clear();
+}

--- a/src/jet/fdm_cg_solver3.cpp
+++ b/src/jet/fdm_cg_solver3.cpp
@@ -4,20 +4,18 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <pch.h>
-#include <jet/constants.h>
 #include <jet/cg.h>
+#include <jet/constants.h>
 #include <jet/fdm_cg_solver3.h>
+#include <pch.h>
 
 using namespace jet;
 
-FdmCgSolver3::FdmCgSolver3(
-    unsigned int maxNumberOfIterations, double tolerance) :
-    _maxNumberOfIterations(maxNumberOfIterations),
-    _lastNumberOfIterations(0),
-    _tolerance(tolerance),
-    _lastResidual(kMaxD) {
-}
+FdmCgSolver3::FdmCgSolver3(unsigned int maxNumberOfIterations, double tolerance)
+    : _maxNumberOfIterations(maxNumberOfIterations),
+      _lastNumberOfIterations(0),
+      _tolerance(tolerance),
+      _lastResidual(kMaxD) {}
 
 bool FdmCgSolver3::solve(FdmLinearSystem3* system) {
     FdmMatrix3& matrix = system->A;
@@ -26,6 +24,8 @@ bool FdmCgSolver3::solve(FdmLinearSystem3* system) {
 
     JET_ASSERT(matrix.size() == rhs.size());
     JET_ASSERT(matrix.size() == solution.size());
+
+    clearCompressedVectors();
 
     Size3 size = matrix.size();
     _r.resize(size);
@@ -39,21 +39,38 @@ bool FdmCgSolver3::solve(FdmLinearSystem3* system) {
     _q.set(0.0);
     _s.set(0.0);
 
-    cg<FdmBlas3>(
-        matrix,
-        rhs,
-        _maxNumberOfIterations,
-        _tolerance,
-        &solution,
-        &_r,
-        &_d,
-        &_q,
-        &_s,
-        &_lastNumberOfIterations,
-        &_lastResidual);
+    cg<FdmBlas3>(matrix, rhs, _maxNumberOfIterations, _tolerance, &solution,
+                 &_r, &_d, &_q, &_s, &_lastNumberOfIterations, &_lastResidual);
 
-    return _lastResidual <= _tolerance
-        || _lastNumberOfIterations < _maxNumberOfIterations;
+    return _lastResidual <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
+}
+
+bool FdmCgSolver3::solveCompressed(FdmCompressedLinearSystem3* system) {
+    MatrixCsrD& matrix = system->A;
+    VectorND& solution = system->x;
+    VectorND& rhs = system->b;
+
+    clearUncompressedVectors();
+
+    size_t size = solution.size();
+    _rComp.resize(size);
+    _dComp.resize(size);
+    _qComp.resize(size);
+    _sComp.resize(size);
+
+    system->x.set(0.0);
+    _rComp.set(0.0);
+    _dComp.set(0.0);
+    _qComp.set(0.0);
+    _sComp.set(0.0);
+
+    cg<FdmCompressedBlas3>(matrix, rhs, _maxNumberOfIterations, _tolerance,
+                           &solution, &_rComp, &_dComp, &_qComp, &_sComp,
+                           &_lastNumberOfIterations, &_lastResidual);
+
+    return _lastResidual <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
 }
 
 unsigned int FdmCgSolver3::maxNumberOfIterations() const {
@@ -64,10 +81,20 @@ unsigned int FdmCgSolver3::lastNumberOfIterations() const {
     return _lastNumberOfIterations;
 }
 
-double FdmCgSolver3::tolerance() const {
-    return _tolerance;
+double FdmCgSolver3::tolerance() const { return _tolerance; }
+
+double FdmCgSolver3::lastResidual() const { return _lastResidual; }
+
+void FdmCgSolver3::clearUncompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
 }
 
-double FdmCgSolver3::lastResidual() const {
-    return _lastResidual;
+void FdmCgSolver3::clearCompressedVectors() {
+    _rComp.clear();
+    _dComp.clear();
+    _qComp.clear();
+    _sComp.clear();
 }

--- a/src/jet/fdm_gauss_seidel_solver2.cpp
+++ b/src/jet/fdm_gauss_seidel_solver2.cpp
@@ -141,7 +141,7 @@ void FdmGaussSeidelSolver2::relax(const MatrixCsrD& A, const VectorND& b,
             }
         }
 
-        x[i] = (b[i] - r) / diag;
+        x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
     });
 }
 
@@ -222,7 +222,7 @@ void FdmGaussSeidelSolver2::relaxRedBlack(const MatrixCsrD& A,
             }
         }
 
-        x[i] = (b[i] - r) / diag;
+        x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
     });
 
     // Red update
@@ -247,6 +247,6 @@ void FdmGaussSeidelSolver2::relaxRedBlack(const MatrixCsrD& A,
             }
         }
 
-        x[i] = (b[i] - r) / diag;
+        x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
     });
 }

--- a/src/jet/fdm_gauss_seidel_solver2.cpp
+++ b/src/jet/fdm_gauss_seidel_solver2.cpp
@@ -24,6 +24,8 @@ FdmGaussSeidelSolver2::FdmGaussSeidelSolver2(unsigned int maxNumberOfIterations,
       _useRedBlackOrdering(useRedBlackOrdering) {}
 
 bool FdmGaussSeidelSolver2::solve(FdmLinearSystem2* system) {
+    clearCompressedVectors();
+
     _residual.resize(system->x.size());
 
     _lastNumberOfIterations = _maxNumberOfIterations;
@@ -53,6 +55,8 @@ bool FdmGaussSeidelSolver2::solve(FdmLinearSystem2* system) {
 
 bool FdmGaussSeidelSolver2::solveCompressed(
     FdmCompressedLinearSystem2* system) {
+    clearUncompressedVectors();
+
     _residualComp.resize(system->x.size());
 
     _lastNumberOfIterations = _maxNumberOfIterations;
@@ -250,3 +254,7 @@ void FdmGaussSeidelSolver2::relaxRedBlack(const MatrixCsrD& A,
         x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
     });
 }
+
+void FdmGaussSeidelSolver2::clearUncompressedVectors() { _residual.clear(); }
+
+void FdmGaussSeidelSolver2::clearCompressedVectors() { _residualComp.clear(); }

--- a/src/jet/fdm_gauss_seidel_solver3.cpp
+++ b/src/jet/fdm_gauss_seidel_solver3.cpp
@@ -58,12 +58,7 @@ bool FdmGaussSeidelSolver3::solveCompressed(
     _lastNumberOfIterations = _maxNumberOfIterations;
 
     for (unsigned int iter = 0; iter < _maxNumberOfIterations; ++iter) {
-        if (_useRedBlackOrdering) {
-            relaxRedBlack(system->A, system->b, system->indexToCoord,
-                          _sorFactor, &system->x);
-        } else {
-            relax(system->A, system->b, _sorFactor, &system->x);
-        }
+        relax(system->A, system->b, _sorFactor, &system->x);
 
         if (iter != 0 && iter % _residualCheckInterval == 0) {
             FdmCompressedBlas3::residual(system->A, system->x, system->b,
@@ -219,67 +214,6 @@ void FdmGaussSeidelSolver3::relaxRedBlack(const FdmMatrix3& A,
                 }
             }
         });
-}
-
-void FdmGaussSeidelSolver3::relaxRedBlack(const MatrixCsrD& A,
-                                          const VectorND& b,
-                                          const Array1<Point3UI>& indexToCoord,
-                                          double sorFactor, VectorND* x_) {
-    const auto rp = A.rowPointersBegin();
-    const auto ci = A.columnIndicesBegin();
-    const auto nnz = A.nonZeroBegin();
-
-    VectorND& x = *x_;
-
-    // Red update
-    b.parallelForEachIndex([&](size_t i) {
-        const auto pt = indexToCoord[i];
-        if ((pt.x + pt.y + pt.z) % 2 != 0) {
-            return;
-        }
-
-        const size_t rowBegin = rp[i];
-        const size_t rowEnd = rp[i + 1];
-
-        double r = 0.0;
-        double diag = 1.0;
-        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
-            size_t j = ci[jj];
-
-            if (i == j) {
-                diag = nnz[jj];
-            } else {
-                r += nnz[jj] * x[j];
-            }
-        }
-
-        x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
-    });
-
-    // Red update
-    b.parallelForEachIndex([&](size_t i) {
-        const auto pt = indexToCoord[i];
-        if ((pt.x + pt.y + pt.z) % 2 == 0) {
-            return;
-        }
-
-        const size_t rowBegin = rp[i];
-        const size_t rowEnd = rp[i + 1];
-
-        double r = 0.0;
-        double diag = 1.0;
-        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
-            size_t j = ci[jj];
-
-            if (i == j) {
-                diag = nnz[jj];
-            } else {
-                r += nnz[jj] * x[j];
-            }
-        }
-
-        x[i] = (1.0 - sorFactor) * x[i] + sorFactor * (b[i] - r) / diag;
-    });
 }
 
 void FdmGaussSeidelSolver3::clearUncompressedVectors() { _residual.clear(); }

--- a/src/jet/fdm_iccg_solver2.cpp
+++ b/src/jet/fdm_iccg_solver2.cpp
@@ -54,6 +54,85 @@ void FdmIccgSolver2::Preconditioner::solve(const FdmVector2& b, FdmVector2* x) {
     }
 }
 
+//
+
+void FdmIccgSolver2::PreconditionerCompressed::build(const MatrixCsrD& matrix) {
+    size_t size = matrix.cols();
+    A = &matrix;
+
+    d.resize(size, 0.0);
+    y.resize(size, 0.0);
+
+    const auto rp = A->rowPointersBegin();
+    const auto ci = A->columnIndicesBegin();
+    const auto nnz = A->nonZeroBegin();
+
+    d.forEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double denom = 0.0;
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+
+            if (j == i) {
+                denom += nnz[jj];
+            } else if (j < i) {
+                denom -= square(nnz[jj]) * d[j];
+            }
+        }
+
+        if (std::fabs(denom) > 0.0) {
+            d[i] = 1.0 / denom;
+        } else {
+            d[i] = 0.0;
+        }
+    });
+}
+
+void FdmIccgSolver2::PreconditionerCompressed::solve(const VectorND& b,
+                                                     VectorND* x) {
+    const ssize_t size = static_cast<ssize_t>(b.size());
+
+    const auto rp = A->rowPointersBegin();
+    const auto ci = A->columnIndicesBegin();
+    const auto nnz = A->nonZeroBegin();
+
+    b.forEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = b[i];
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+
+            if (j < i) {
+                sum -= nnz[jj] * y[j];
+            }
+        }
+
+        y[i] = sum * d[i];
+    });
+
+    for (ssize_t i = size - 1; i >= 0; --i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = y[i];
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+
+            if (j > i) {
+                sum -= nnz[jj] * (*x)[j];
+            }
+        }
+
+        (*x)[i] = sum * d[i];
+    }
+}
+
+//
+
 FdmIccgSolver2::FdmIccgSolver2(unsigned int maxNumberOfIterations,
                                double tolerance)
     : _maxNumberOfIterations(maxNumberOfIterations),
@@ -86,6 +165,37 @@ bool FdmIccgSolver2::solve(FdmLinearSystem2* system) {
     pcg<FdmBlas2, Preconditioner>(
         matrix, rhs, _maxNumberOfIterations, _tolerance, &_precond, &solution,
         &_r, &_d, &_q, &_s, &_lastNumberOfIterations, &_lastResidualNorm);
+
+    JET_INFO << "Residual after solving ICCG: " << _lastResidualNorm
+             << " Number of ICCG iterations: " << _lastNumberOfIterations;
+
+    return _lastResidualNorm <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
+}
+
+bool FdmIccgSolver2::solveCompressed(FdmCompressedLinearSystem2* system) {
+    MatrixCsrD& matrix = system->A;
+    VectorND& solution = system->x;
+    VectorND& rhs = system->b;
+
+    size_t size = solution.size();
+    _rComp.resize(size);
+    _dComp.resize(size);
+    _qComp.resize(size);
+    _sComp.resize(size);
+
+    system->x.set(0.0);
+    _rComp.set(0.0);
+    _dComp.set(0.0);
+    _qComp.set(0.0);
+    _sComp.set(0.0);
+
+    _precondComp.build(matrix);
+
+    pcg<FdmCompressedBlas2, PreconditionerCompressed>(
+        matrix, rhs, _maxNumberOfIterations, _tolerance, &_precondComp,
+        &solution, &_rComp, &_dComp, &_qComp, &_sComp, &_lastNumberOfIterations,
+        &_lastResidualNorm);
 
     JET_INFO << "Residual after solving ICCG: " << _lastResidualNorm
              << " Number of ICCG iterations: " << _lastNumberOfIterations;

--- a/src/jet/fdm_iccg_solver2.cpp
+++ b/src/jet/fdm_iccg_solver2.cpp
@@ -120,7 +120,7 @@ void FdmIccgSolver2::PreconditionerCompressed::solve(const VectorND& b,
 
         double sum = y[i];
         for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
-            size_t j = ci[jj];
+            ssize_t j = static_cast<ssize_t>(ci[jj]);
 
             if (j > i) {
                 sum -= nnz[jj] * (*x)[j];

--- a/src/jet/fdm_iccg_solver2.cpp
+++ b/src/jet/fdm_iccg_solver2.cpp
@@ -148,6 +148,8 @@ bool FdmIccgSolver2::solve(FdmLinearSystem2* system) {
     JET_ASSERT(matrix.size() == rhs.size());
     JET_ASSERT(matrix.size() == solution.size());
 
+    clearCompressedVectors();
+
     Size2 size = matrix.size();
     _r.resize(size);
     _d.resize(size);
@@ -177,6 +179,8 @@ bool FdmIccgSolver2::solveCompressed(FdmCompressedLinearSystem2* system) {
     MatrixCsrD& matrix = system->A;
     VectorND& solution = system->x;
     VectorND& rhs = system->b;
+
+    clearUncompressedVectors();
 
     size_t size = solution.size();
     _rComp.resize(size);
@@ -215,3 +219,16 @@ unsigned int FdmIccgSolver2::lastNumberOfIterations() const {
 double FdmIccgSolver2::tolerance() const { return _tolerance; }
 
 double FdmIccgSolver2::lastResidual() const { return _lastResidualNorm; }
+
+void FdmIccgSolver2::clearUncompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
+}
+void FdmIccgSolver2::clearCompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
+}

--- a/src/jet/fdm_iccg_solver3.cpp
+++ b/src/jet/fdm_iccg_solver3.cpp
@@ -4,10 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <pch.h>
-#include <jet/constants.h>
 #include <jet/cg.h>
+#include <jet/constants.h>
 #include <jet/fdm_iccg_solver3.h>
+#include <pch.h>
 
 using namespace jet;
 
@@ -19,14 +19,13 @@ void FdmIccgSolver3::Preconditioner::build(const FdmMatrix3& matrix) {
     y.resize(size, 0.0);
 
     matrix.forEachIndex([&](size_t i, size_t j, size_t k) {
-        double denom
-            = matrix(i, j, k).center
-            - ((i > 0) ?
-                square(matrix(i - 1, j, k).right) * d(i - 1, j, k) : 0.0)
-            - ((j > 0) ?
-                square(matrix(i, j - 1, k).up)    * d(i, j - 1, k) : 0.0)
-            - ((k > 0) ?
-                square(matrix(i, j, k - 1).front) * d(i, j, k - 1) : 0.0);
+        double denom =
+            matrix(i, j, k).center -
+            ((i > 0) ? square(matrix(i - 1, j, k).right) * d(i - 1, j, k)
+                     : 0.0) -
+            ((j > 0) ? square(matrix(i, j - 1, k).up) * d(i, j - 1, k) : 0.0) -
+            ((k > 0) ? square(matrix(i, j, k - 1).front) * d(i, j, k - 1)
+                     : 0.0);
 
         if (std::fabs(denom) > 0.0) {
             d(i, j, k) = 1.0 / denom;
@@ -36,48 +35,121 @@ void FdmIccgSolver3::Preconditioner::build(const FdmMatrix3& matrix) {
     });
 }
 
-void FdmIccgSolver3::Preconditioner::solve(
-    const FdmVector3& b,
-    FdmVector3* x) {
+void FdmIccgSolver3::Preconditioner::solve(const FdmVector3& b, FdmVector3* x) {
     Size3 size = b.size();
     ssize_t sx = static_cast<ssize_t>(size.x);
     ssize_t sy = static_cast<ssize_t>(size.y);
     ssize_t sz = static_cast<ssize_t>(size.z);
 
     b.forEachIndex([&](size_t i, size_t j, size_t k) {
-        y(i, j, k)
-            = (b(i, j, k)
-            - ((i > 0) ? A(i - 1, j, k).right * y(i - 1, j, k) : 0.0)
-            - ((j > 0) ? A(i, j - 1, k).up    * y(i, j - 1, k) : 0.0)
-            - ((k > 0) ? A(i, j, k - 1).front * y(i, j, k - 1) : 0.0))
-            * d(i, j, k);
+        y(i, j, k) = (b(i, j, k) -
+                      ((i > 0) ? A(i - 1, j, k).right * y(i - 1, j, k) : 0.0) -
+                      ((j > 0) ? A(i, j - 1, k).up * y(i, j - 1, k) : 0.0) -
+                      ((k > 0) ? A(i, j, k - 1).front * y(i, j, k - 1) : 0.0)) *
+                     d(i, j, k);
     });
 
     for (ssize_t k = sz - 1; k >= 0; --k) {
         for (ssize_t j = sy - 1; j >= 0; --j) {
             for (ssize_t i = sx - 1; i >= 0; --i) {
-                (*x)(i, j, k)
-                    = (y(i, j, k)
-                    - ((i + 1 < sx) ?
-                        A(i, j, k).right * (*x)(i + 1, j, k) : 0.0)
-                    - ((j + 1 < sy) ?
-                        A(i, j, k).up    * (*x)(i, j + 1, k) : 0.0)
-                    - ((k + 1 < sz) ?
-                        A(i, j, k).front * (*x)(i, j, k + 1) : 0.0))
-                    * d(i, j, k);
+                (*x)(i, j, k) =
+                    (y(i, j, k) -
+                     ((i + 1 < sx) ? A(i, j, k).right * (*x)(i + 1, j, k)
+                                   : 0.0) -
+                     ((j + 1 < sy) ? A(i, j, k).up * (*x)(i, j + 1, k) : 0.0) -
+                     ((k + 1 < sz) ? A(i, j, k).front * (*x)(i, j, k + 1)
+                                   : 0.0)) *
+                    d(i, j, k);
             }
         }
     }
 }
 
-FdmIccgSolver3::FdmIccgSolver3(
-    unsigned int maxNumberOfIterations,
-    double tolerance) :
-    _maxNumberOfIterations(maxNumberOfIterations),
-    _lastNumberOfIterations(0),
-    _tolerance(tolerance),
-    _lastResidualNorm(kMaxD) {
+//
+
+void FdmIccgSolver3::PreconditionerCompressed::build(const MatrixCsrD& matrix) {
+    size_t size = matrix.cols();
+    A = &matrix;
+
+    d.resize(size, 0.0);
+    y.resize(size, 0.0);
+
+    const auto rp = A->rowPointersBegin();
+    const auto ci = A->columnIndicesBegin();
+    const auto nnz = A->nonZeroBegin();
+
+    d.forEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double denom = 0.0;
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+
+            if (j == i) {
+                denom += nnz[jj];
+            } else if (j < i) {
+                denom -= square(nnz[jj]) * d[j];
+            }
+        }
+
+        if (std::fabs(denom) > 0.0) {
+            d[i] = 1.0 / denom;
+        } else {
+            d[i] = 0.0;
+        }
+    });
 }
+
+void FdmIccgSolver3::PreconditionerCompressed::solve(const VectorND& b,
+                                                     VectorND* x) {
+    const ssize_t size = static_cast<ssize_t>(b.size());
+
+    const auto rp = A->rowPointersBegin();
+    const auto ci = A->columnIndicesBegin();
+    const auto nnz = A->nonZeroBegin();
+
+    b.forEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = b[i];
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+
+            if (j < i) {
+                sum -= nnz[jj] * y[j];
+            }
+        }
+
+        y[i] = sum * d[i];
+    });
+
+    for (ssize_t i = size - 1; i >= 0; --i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = y[i];
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            ssize_t j = static_cast<ssize_t>(ci[jj]);
+
+            if (j > i) {
+                sum -= nnz[jj] * (*x)[j];
+            }
+        }
+
+        (*x)[i] = sum * d[i];
+    }
+}
+
+//
+
+FdmIccgSolver3::FdmIccgSolver3(unsigned int maxNumberOfIterations,
+                               double tolerance)
+    : _maxNumberOfIterations(maxNumberOfIterations),
+      _lastNumberOfIterations(0),
+      _tolerance(tolerance),
+      _lastResidualNorm(kMaxD) {}
 
 bool FdmIccgSolver3::solve(FdmLinearSystem3* system) {
     FdmMatrix3& matrix = system->A;
@@ -86,6 +158,8 @@ bool FdmIccgSolver3::solve(FdmLinearSystem3* system) {
 
     JET_ASSERT(matrix.size() == rhs.size());
     JET_ASSERT(matrix.size() == solution.size());
+
+    clearCompressedVectors();
 
     Size3 size = matrix.size();
     _r.resize(size);
@@ -102,24 +176,47 @@ bool FdmIccgSolver3::solve(FdmLinearSystem3* system) {
     _precond.build(matrix);
 
     pcg<FdmBlas3, Preconditioner>(
-        matrix,
-        rhs,
-        _maxNumberOfIterations,
-        _tolerance,
-        &_precond,
-        &solution,
-        &_r,
-        &_d,
-        &_q,
-        &_s,
-        &_lastNumberOfIterations,
-        &_lastResidualNorm);
+        matrix, rhs, _maxNumberOfIterations, _tolerance, &_precond, &solution,
+        &_r, &_d, &_q, &_s, &_lastNumberOfIterations, &_lastResidualNorm);
 
     JET_INFO << "Residual norm after solving ICCG: " << _lastResidualNorm
              << " Number of ICCG iterations: " << _lastNumberOfIterations;
 
-    return _lastResidualNorm <= _tolerance
-        || _lastNumberOfIterations < _maxNumberOfIterations;
+    return _lastResidualNorm <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
+}
+
+bool FdmIccgSolver3::solveCompressed(FdmCompressedLinearSystem3* system) {
+    MatrixCsrD& matrix = system->A;
+    VectorND& solution = system->x;
+    VectorND& rhs = system->b;
+
+    clearUncompressedVectors();
+
+    size_t size = solution.size();
+    _rComp.resize(size);
+    _dComp.resize(size);
+    _qComp.resize(size);
+    _sComp.resize(size);
+
+    system->x.set(0.0);
+    _rComp.set(0.0);
+    _dComp.set(0.0);
+    _qComp.set(0.0);
+    _sComp.set(0.0);
+
+    _precondComp.build(matrix);
+
+    pcg<FdmCompressedBlas3, PreconditionerCompressed>(
+        matrix, rhs, _maxNumberOfIterations, _tolerance, &_precondComp,
+        &solution, &_rComp, &_dComp, &_qComp, &_sComp, &_lastNumberOfIterations,
+        &_lastResidualNorm);
+
+    JET_INFO << "Residual after solving ICCG: " << _lastResidualNorm
+             << " Number of ICCG iterations: " << _lastNumberOfIterations;
+
+    return _lastResidualNorm <= _tolerance ||
+           _lastNumberOfIterations < _maxNumberOfIterations;
 }
 
 unsigned int FdmIccgSolver3::maxNumberOfIterations() const {
@@ -130,10 +227,19 @@ unsigned int FdmIccgSolver3::lastNumberOfIterations() const {
     return _lastNumberOfIterations;
 }
 
-double FdmIccgSolver3::tolerance() const {
-    return _tolerance;
-}
+double FdmIccgSolver3::tolerance() const { return _tolerance; }
 
-double FdmIccgSolver3::lastResidual() const {
-    return _lastResidualNorm;
+double FdmIccgSolver3::lastResidual() const { return _lastResidualNorm; }
+
+void FdmIccgSolver3::clearUncompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
+}
+void FdmIccgSolver3::clearCompressedVectors() {
+    _r.clear();
+    _d.clear();
+    _q.clear();
+    _s.clear();
 }

--- a/src/jet/fdm_jacobi_solver2.cpp
+++ b/src/jet/fdm_jacobi_solver2.cpp
@@ -21,6 +21,8 @@ FdmJacobiSolver2::FdmJacobiSolver2(unsigned int maxNumberOfIterations,
       _lastResidual(kMaxD) {}
 
 bool FdmJacobiSolver2::solve(FdmLinearSystem2* system) {
+    clearCompressedVectors();
+
     _xTemp.resize(system->x.size());
     _residual.resize(system->x.size());
 
@@ -48,6 +50,8 @@ bool FdmJacobiSolver2::solve(FdmLinearSystem2* system) {
 }
 
 bool FdmJacobiSolver2::solveCompressed(FdmCompressedLinearSystem2* system) {
+    clearUncompressedVectors();
+
     _xTempComp.resize(system->x.size());
     _residualComp.resize(system->x.size());
 
@@ -113,7 +117,7 @@ void FdmJacobiSolver2::relax(const MatrixCsrD& A, const VectorND& b,
     VectorND& x = *x_;
     VectorND& xTemp = *xTemp_;
 
-    b.forEachIndex([&](size_t i) {
+    b.parallelForEachIndex([&](size_t i) {
         const size_t rowBegin = rp[i];
         const size_t rowEnd = rp[i + 1];
 
@@ -131,4 +135,14 @@ void FdmJacobiSolver2::relax(const MatrixCsrD& A, const VectorND& b,
 
         xTemp[i] = (b[i] - r) / diag;
     });
+}
+
+void FdmJacobiSolver2::clearUncompressedVectors() {
+    _xTempComp.clear();
+    _residualComp.clear();
+}
+
+void FdmJacobiSolver2::clearCompressedVectors() {
+    _xTemp.clear();
+    _residual.clear();
 }

--- a/src/jet/fdm_linear_system2.cpp
+++ b/src/jet/fdm_linear_system2.cpp
@@ -31,6 +31,7 @@ void FdmCompressedLinearSystem2::clear() {
     x.clear();
     b.clear();
     coordToIndex.clear();
+    indexToCoord.clear();
 }
 
 void FdmCompressedLinearSystem2::resize(const Size2& size) {

--- a/src/jet/fdm_linear_system2.cpp
+++ b/src/jet/fdm_linear_system2.cpp
@@ -38,11 +38,12 @@ void FdmCompressedLinearSystem2::resize(const Size2& size) {
     coordToIndex.resize(size);
 }
 
-void FdmCompressedLinearSystem2::decompressSolution(FdmVector2* xDecomp) {
+void FdmCompressedLinearSystem2::decompressSolution(FdmVector2* xDecomp,
+                                                    double blankValue) {
     xDecomp->resize(coordToIndex.size());
     xDecomp->parallelForEachIndex([&](size_t i, size_t j) {
         const size_t idx = coordToIndex(i, j);
-        (*xDecomp)(i, j) = (idx == kMaxSize) ? 0.0 : x[idx];
+        (*xDecomp)(i, j) = (idx == kMaxSize) ? blankValue : x[idx];
     });
 }
 

--- a/src/jet/fdm_linear_system2.cpp
+++ b/src/jet/fdm_linear_system2.cpp
@@ -30,21 +30,6 @@ void FdmCompressedLinearSystem2::clear() {
     A.clear();
     x.clear();
     b.clear();
-    coordToIndex.clear();
-    indexToCoord.clear();
-}
-
-void FdmCompressedLinearSystem2::resize(const Size2& size) {
-    coordToIndex.resize(size);
-}
-
-void FdmCompressedLinearSystem2::decompressSolution(FdmVector2* xDecomp,
-                                                    double blankValue) {
-    xDecomp->resize(coordToIndex.size());
-    xDecomp->parallelForEachIndex([&](size_t i, size_t j) {
-        const size_t idx = coordToIndex(i, j);
-        (*xDecomp)(i, j) = (idx == kMaxSize) ? blankValue : x[idx];
-    });
 }
 
 //

--- a/src/jet/fdm_linear_system3.cpp
+++ b/src/jet/fdm_linear_system3.cpp
@@ -18,15 +18,40 @@ void FdmLinearSystem3::clear() {
     b.clear();
 }
 
+void FdmLinearSystem3::resize(const Size3& size) {
+    A.resize(size);
+    x.resize(size);
+    b.resize(size);
+}
+
 //
 
-void FdmBlas3::set(double s, FdmVector3* result) {
-    result->set(s);
+void FdmCompressedLinearSystem3::clear() {
+    A.clear();
+    x.clear();
+    b.clear();
+    coordToIndex.clear();
+    indexToCoord.clear();
 }
 
-void FdmBlas3::set(const FdmVector3& v, FdmVector3* result) {
-    result->set(v);
+void FdmCompressedLinearSystem3::resize(const Size3& size) {
+    coordToIndex.resize(size);
 }
+
+void FdmCompressedLinearSystem3::decompressSolution(FdmVector3* xDecomp,
+                                                    double blankValue) {
+    xDecomp->resize(coordToIndex.size());
+    xDecomp->parallelForEachIndex([&](size_t i, size_t j, size_t k) {
+        const size_t idx = coordToIndex(i, j, k);
+        (*xDecomp)(i, j, k) = (idx == kMaxSize) ? blankValue : x[idx];
+    });
+}
+
+//
+
+void FdmBlas3::set(double s, FdmVector3* result) { result->set(s); }
+
+void FdmBlas3::set(const FdmVector3& v, FdmVector3* result) { result->set(v); }
 
 void FdmBlas3::set(double s, FdmMatrix3* result) {
     FdmMatrixRow3 row;
@@ -34,9 +59,7 @@ void FdmBlas3::set(double s, FdmMatrix3* result) {
     result->set(row);
 }
 
-void FdmBlas3::set(const FdmMatrix3& m, FdmMatrix3* result) {
-    result->set(m);
-}
+void FdmBlas3::set(const FdmMatrix3& m, FdmMatrix3* result) { result->set(m); }
 
 double FdmBlas3::dot(const FdmVector3& a, const FdmVector3& b) {
     Size3 size = a.size();
@@ -56,11 +79,8 @@ double FdmBlas3::dot(const FdmVector3& a, const FdmVector3& b) {
     return result;
 }
 
-void FdmBlas3::axpy(
-    double a,
-    const FdmVector3& x,
-    const FdmVector3& y,
-    FdmVector3* result) {
+void FdmBlas3::axpy(double a, const FdmVector3& x, const FdmVector3& y,
+                    FdmVector3* result) {
     Size3 size = x.size();
 
     JET_THROW_INVALID_ARG_IF(size != y.size());
@@ -71,32 +91,27 @@ void FdmBlas3::axpy(
     });
 }
 
-void FdmBlas3::mvm(
-    const FdmMatrix3& m,
-    const FdmVector3& v,
-    FdmVector3* result) {
+void FdmBlas3::mvm(const FdmMatrix3& m, const FdmVector3& v,
+                   FdmVector3* result) {
     Size3 size = m.size();
 
     JET_THROW_INVALID_ARG_IF(size != v.size());
     JET_THROW_INVALID_ARG_IF(size != result->size());
 
     m.parallelForEachIndex([&](size_t i, size_t j, size_t k) {
-        (*result)(i, j, k)
-            = m(i, j, k).center * v(i, j, k)
-            + ((i > 0) ? m(i - 1, j, k).right * v(i - 1, j, k) : 0.0)
-            + ((i + 1 < size.x) ? m(i, j, k).right * v(i + 1, j, k) : 0.0)
-            + ((j > 0) ? m(i, j - 1, k).up * v(i, j - 1, k) : 0.0)
-            + ((j + 1 < size.y) ? m(i, j, k).up * v(i, j + 1, k) : 0.0)
-            + ((k > 0) ? m(i, j, k - 1).front * v(i, j, k - 1) : 0.0)
-            + ((k + 1 < size.z) ? m(i, j, k).front * v(i, j, k + 1) : 0.0);
+        (*result)(i, j, k) =
+            m(i, j, k).center * v(i, j, k) +
+            ((i > 0) ? m(i - 1, j, k).right * v(i - 1, j, k) : 0.0) +
+            ((i + 1 < size.x) ? m(i, j, k).right * v(i + 1, j, k) : 0.0) +
+            ((j > 0) ? m(i, j - 1, k).up * v(i, j - 1, k) : 0.0) +
+            ((j + 1 < size.y) ? m(i, j, k).up * v(i, j + 1, k) : 0.0) +
+            ((k > 0) ? m(i, j, k - 1).front * v(i, j, k - 1) : 0.0) +
+            ((k + 1 < size.z) ? m(i, j, k).front * v(i, j, k + 1) : 0.0);
     });
 }
 
-void FdmBlas3::residual(
-    const FdmMatrix3& a,
-    const FdmVector3& x,
-    const FdmVector3& b,
-    FdmVector3* result) {
+void FdmBlas3::residual(const FdmMatrix3& a, const FdmVector3& x,
+                        const FdmVector3& b, FdmVector3* result) {
     Size3 size = a.size();
 
     JET_THROW_INVALID_ARG_IF(size != x.size());
@@ -104,21 +119,18 @@ void FdmBlas3::residual(
     JET_THROW_INVALID_ARG_IF(size != result->size());
 
     a.parallelForEachIndex([&](size_t i, size_t j, size_t k) {
-        (*result)(i, j, k)
-            = b(i, j, k)
-            - a(i, j, k).center * x(i, j, k)
-            - ((i > 0) ? a(i - 1, j, k).right * x(i - 1, j, k) : 0.0)
-            - ((i + 1 < size.x) ? a(i, j, k).right * x(i + 1, j, k) : 0.0)
-            - ((j > 0) ? a(i, j - 1, k).up * x(i, j - 1, k) : 0.0)
-            - ((j + 1 < size.y) ? a(i, j, k).up * x(i, j + 1, k) : 0.0)
-            - ((k > 0) ? a(i, j, k - 1).front * x(i, j, k - 1) : 0.0)
-            - ((k + 1 < size.z) ? a(i, j, k).front * x(i, j, k + 1) : 0.0);
+        (*result)(i, j, k) =
+            b(i, j, k) - a(i, j, k).center * x(i, j, k) -
+            ((i > 0) ? a(i - 1, j, k).right * x(i - 1, j, k) : 0.0) -
+            ((i + 1 < size.x) ? a(i, j, k).right * x(i + 1, j, k) : 0.0) -
+            ((j > 0) ? a(i, j - 1, k).up * x(i, j - 1, k) : 0.0) -
+            ((j + 1 < size.y) ? a(i, j, k).up * x(i, j + 1, k) : 0.0) -
+            ((k > 0) ? a(i, j, k - 1).front * x(i, j, k - 1) : 0.0) -
+            ((k + 1 < size.z) ? a(i, j, k).front * x(i, j, k + 1) : 0.0);
     });
 }
 
-double FdmBlas3::l2Norm(const FdmVector3& v) {
-    return std::sqrt(dot(v, v));
-}
+double FdmBlas3::l2Norm(const FdmVector3& v) { return std::sqrt(dot(v, v)); }
 
 double FdmBlas3::lInfNorm(const FdmVector3& v) {
     Size3 size = v.size();
@@ -134,4 +146,77 @@ double FdmBlas3::lInfNorm(const FdmVector3& v) {
     }
 
     return std::fabs(result);
+}
+
+//
+
+void FdmCompressedBlas3::set(double s, VectorND* result) { result->set(s); }
+
+void FdmCompressedBlas3::set(const VectorND& v, VectorND* result) {
+    result->set(v);
+}
+
+void FdmCompressedBlas3::set(double s, MatrixCsrD* result) { result->set(s); }
+
+void FdmCompressedBlas3::set(const MatrixCsrD& m, MatrixCsrD* result) {
+    result->set(m);
+}
+
+double FdmCompressedBlas3::dot(const VectorND& a, const VectorND& b) {
+    return a.dot(b);
+}
+
+void FdmCompressedBlas3::axpy(double a, const VectorND& x, const VectorND& y,
+                              VectorND* result) {
+    *result = a * x + y;
+}
+
+void FdmCompressedBlas3::mvm(const MatrixCsrD& m, const VectorND& v,
+                             VectorND* result) {
+    const auto rp = m.rowPointersBegin();
+    const auto ci = m.columnIndicesBegin();
+    const auto nnz = m.nonZeroBegin();
+
+    v.parallelForEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = 0.0;
+
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+            sum += nnz[jj] * v[j];
+        }
+
+        (*result)[i] = sum;
+    });
+}
+
+void FdmCompressedBlas3::residual(const MatrixCsrD& a, const VectorND& x,
+                                  const VectorND& b, VectorND* result) {
+    const auto rp = a.rowPointersBegin();
+    const auto ci = a.columnIndicesBegin();
+    const auto nnz = a.nonZeroBegin();
+
+    x.parallelForEachIndex([&](size_t i) {
+        const size_t rowBegin = rp[i];
+        const size_t rowEnd = rp[i + 1];
+
+        double sum = 0.0;
+
+        for (size_t jj = rowBegin; jj < rowEnd; ++jj) {
+            size_t j = ci[jj];
+            sum += nnz[jj] * x[j];
+        }
+
+        (*result)[i] = b[i] - sum;
+    });
+}
+
+double FdmCompressedBlas3::l2Norm(const VectorND& v) {
+    return std::sqrt(v.dot(v));
+}
+
+double FdmCompressedBlas3::lInfNorm(const VectorND& v) {
+    return std::fabs(v.absmax());
 }

--- a/src/jet/fdm_linear_system3.cpp
+++ b/src/jet/fdm_linear_system3.cpp
@@ -30,21 +30,6 @@ void FdmCompressedLinearSystem3::clear() {
     A.clear();
     x.clear();
     b.clear();
-    coordToIndex.clear();
-    indexToCoord.clear();
-}
-
-void FdmCompressedLinearSystem3::resize(const Size3& size) {
-    coordToIndex.resize(size);
-}
-
-void FdmCompressedLinearSystem3::decompressSolution(FdmVector3* xDecomp,
-                                                    double blankValue) {
-    xDecomp->resize(coordToIndex.size());
-    xDecomp->parallelForEachIndex([&](size_t i, size_t j, size_t k) {
-        const size_t idx = coordToIndex(i, j, k);
-        (*xDecomp)(i, j, k) = (idx == kMaxSize) ? blankValue : x[idx];
-    });
 }
 
 //

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -204,6 +204,7 @@ void buildSingleSystem(FdmMatrix2* A, FdmVector2* b,
 
 void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
                        Array2<size_t>* coordToIndex,
+                       Array1<Point2UI>* indexToCoord,
                        const Array2<float>& fluidSdf,
                        const Array2<float>& uWeights,
                        const Array2<float>& vWeights,
@@ -229,6 +230,8 @@ void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
 
         if (isInsideSdf(centerPhi)) {
             (*coordToIndex)[cIdx] = b->size();
+            indexToCoord->append({i, j});
+
             double bij = 0.0;
 
             std::vector<double> row(1, 0.0);
@@ -509,7 +512,8 @@ void GridFractionalSinglePhasePressureSolver2::buildSystem(
     if (_mgSystemSolver == nullptr) {
         if (useCompressed) {
             buildSingleSystem(&_compSystem.A, &_compSystem.x, &_compSystem.b,
-                              &_compSystem.coordToIndex, _fluidSdf[0],
+                              &_compSystem.coordToIndex,
+                              &_compSystem.indexToCoord, _fluidSdf[0],
                               _uWeights[0], _vWeights[0], _boundaryVel, *finer);
         } else {
             buildSingleSystem(&_system.A, &_system.b, _fluidSdf[0],

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -201,7 +201,138 @@ void buildSingleSystem(FdmMatrix2* A, FdmVector2* b,
         }
     });
 }
+
+void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
+                       Array2<size_t>* coordToIndex,
+                       const Array2<float>& fluidSdf,
+                       const Array2<float>& uWeights,
+                       const Array2<float>& vWeights,
+                       std::function<Vector2D(const Vector2D&)> boundaryVel,
+                       const FaceCenteredGrid2& input) {
+    const Size2 size = input.resolution();
+    const auto uPos = input.uPosition();
+    const auto vPos = input.vPosition();
+
+    const Vector2D invH = 1.0 / input.gridSpacing();
+    const Vector2D invHSqr = invH * invH;
+
+    const auto fluidSdfAcc = fluidSdf.constAccessor();
+
+    fluidSdf.forEachIndex([&](size_t i, size_t j) {
+        const size_t cIdx = fluidSdfAcc.index(i, j);
+        const size_t lIdx = fluidSdfAcc.index(i - 1, j);
+        const size_t rIdx = fluidSdfAcc.index(i + 1, j);
+        const size_t dIdx = fluidSdfAcc.index(i, j - 1);
+        const size_t uIdx = fluidSdfAcc.index(i, j + 1);
+
+        const double centerPhi = fluidSdf(i, j);
+
+        if (isInsideSdf(centerPhi)) {
+            (*coordToIndex)[cIdx] = b->size();
+            double bij = 0.0;
+
+            std::vector<double> row(1, 0.0);
+            std::vector<size_t> colIdx(1, cIdx);
+
+            double term;
+
+            if (i + 1 < size.x) {
+                term = uWeights(i + 1, j) * invHSqr.x;
+                const double rightPhi = fluidSdf(i + 1, j);
+                if (isInsideSdf(rightPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back(rIdx);
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, rightPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bij += uWeights(i + 1, j) * input.u(i + 1, j) * invH.x;
+            } else {
+                bij += input.u(i + 1, j) * invH.x;
+            }
+
+            if (i > 0) {
+                term = uWeights(i, j) * invHSqr.x;
+                const double leftPhi = fluidSdf(i - 1, j);
+                if (isInsideSdf(leftPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back(lIdx);
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, leftPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bij -= uWeights(i, j) * input.u(i, j) * invH.x;
+            } else {
+                bij -= input.u(i, j) * invH.x;
+            }
+
+            if (j + 1 < size.y) {
+                term = vWeights(i, j + 1) * invHSqr.y;
+                const double upPhi = fluidSdf(i, j + 1);
+                if (isInsideSdf(upPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back(uIdx);
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, upPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bij += vWeights(i, j + 1) * input.v(i, j + 1) * invH.y;
+            } else {
+                bij += input.v(i, j + 1) * invH.y;
+            }
+
+            if (j > 0) {
+                term = vWeights(i, j) * invHSqr.y;
+                const double downPhi = fluidSdf(i, j - 1);
+                if (isInsideSdf(downPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back(dIdx);
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, downPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bij -= vWeights(i, j) * input.v(i, j) * invH.y;
+            } else {
+                bij -= input.v(i, j) * invH.y;
+            }
+
+            // Accumulate contributions from the moving boundary
+            const double boundaryContribution =
+                (1.0 - uWeights(i + 1, j)) * boundaryVel(uPos(i + 1, j)).x *
+                    invH.x -
+                (1.0 - uWeights(i, j)) * boundaryVel(uPos(i, j)).x * invH.x +
+                (1.0 - vWeights(i, j + 1)) * boundaryVel(vPos(i, j + 1)).y *
+                    invH.y -
+                (1.0 - vWeights(i, j)) * boundaryVel(vPos(i, j)).y * invH.y;
+            bij += boundaryContribution;
+
+            // If row.center is near-zero, the cell is likely inside a solid
+            // boundary.
+            if (row[0] < kEpsilonD) {
+                row[0] = 1.0;
+                bij = 0.0;
+            }
+
+            A->addRow(row, colIdx);
+            b->append(bij);
+        } else {
+            (*coordToIndex)[cIdx] = kMaxSize;
+        }
+
+    });
+
+    x->resize(b->size(), 0.0);
 }
+
+}  // namespace
 
 GridFractionalSinglePhasePressureSolver2::
     GridFractionalSinglePhasePressureSolver2() {
@@ -214,16 +345,22 @@ GridFractionalSinglePhasePressureSolver2::
 void GridFractionalSinglePhasePressureSolver2::solve(
     const FaceCenteredGrid2& input, double timeIntervalInSeconds,
     FaceCenteredGrid2* output, const ScalarField2& boundarySdf,
-    const VectorField2& boundaryVelocity, const ScalarField2& fluidSdf) {
+    const VectorField2& boundaryVelocity, const ScalarField2& fluidSdf,
+    bool useCompressed) {
     UNUSED_VARIABLE(timeIntervalInSeconds);
 
     buildWeights(input, boundarySdf, boundaryVelocity, fluidSdf);
-    buildSystem(input);
+    buildSystem(input, useCompressed);
 
     if (_systemSolver != nullptr) {
         // Solve the system
         if (_mgSystemSolver == nullptr) {
-            _systemSolver->solve(&_system);
+            if (useCompressed) {
+                _systemSolver->solveCompressed(&_compSystem);
+                _compSystem.decompressSolution(&_system.x);
+            } else {
+                _systemSolver->solve(&_system);
+            }
         } else {
             _mgSystemSolver->solve(&_mgSystem);
         }
@@ -344,18 +481,16 @@ void GridFractionalSinglePhasePressureSolver2::buildWeights(
 }
 
 void GridFractionalSinglePhasePressureSolver2::buildSystem(
-    const FaceCenteredGrid2& input) {
+    const FaceCenteredGrid2& input, bool useCompressed) {
     Size2 size = input.resolution();
     size_t numLevels = 1;
-    FdmMatrix2* A;
-    FdmVector2* b;
 
     if (_mgSystemSolver == nullptr) {
-        _system.A.resize(size);
-        _system.x.resize(size);
-        _system.b.resize(size);
-        A = &_system.A;
-        b = &_system.b;
+        if (useCompressed) {
+            _compSystem.resize(size);
+        } else {
+            _system.resize(size);
+        }
     } else {
         // Build levels
         size_t maxLevels = _mgSystemSolver->params().maxNumberOfLevels;
@@ -365,16 +500,26 @@ void GridFractionalSinglePhasePressureSolver2::buildSystem(
                                            &_mgSystem.x.levels);
         FdmMgUtils2::resizeArrayWithFinest(size, maxLevels,
                                            &_mgSystem.b.levels);
-        A = &_mgSystem.A.levels.front();
-        b = &_mgSystem.b.levels.front();
 
         numLevels = _mgSystem.A.levels.size();
     }
 
     // Build top level
     const FaceCenteredGrid2* finer = &input;
-    buildSingleSystem(A, b, _fluidSdf[0], _uWeights[0], _vWeights[0],
-                      _boundaryVel, *finer);
+    if (_mgSystemSolver == nullptr) {
+        if (useCompressed) {
+            buildSingleSystem(&_compSystem.A, &_compSystem.x, &_compSystem.b,
+                              &_compSystem.coordToIndex, _fluidSdf[0],
+                              _uWeights[0], _vWeights[0], _boundaryVel, *finer);
+        } else {
+            buildSingleSystem(&_system.A, &_system.b, _fluidSdf[0],
+                              _uWeights[0], _vWeights[0], _boundaryVel, *finer);
+        }
+    } else {
+        buildSingleSystem(&_mgSystem.A.levels.front(),
+                          &_mgSystem.b.levels.front(), _fluidSdf[0],
+                          _uWeights[0], _vWeights[0], _boundaryVel, *finer);
+    }
 
     // Build sub-levels
     FaceCenteredGrid2 coarser;
@@ -390,9 +535,8 @@ void GridFractionalSinglePhasePressureSolver2::buildSystem(
         coarser.resize(res, h, o);
         coarser.fill(finer->sampler());
 
-        A = &_mgSystem.A.levels[l];
-        b = &_mgSystem.b.levels[l];
-        buildSingleSystem(A, b, _fluidSdf[l], _uWeights[l], _vWeights[l],
+        buildSingleSystem(&_mgSystem.A.levels[l], &_mgSystem.b.levels[l],
+                          _fluidSdf[l], _uWeights[l], _vWeights[l],
                           _boundaryVel, coarser);
 
         finer = &coarser;

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -361,9 +361,11 @@ void GridFractionalSinglePhasePressureSolver2::solve(
         // Solve the system
         if (_mgSystemSolver == nullptr) {
             if (useCompressed) {
+                _system.clear();
                 _systemSolver->solveCompressed(&_compSystem);
                 decompressSolution();
             } else {
+                _compSystem.clear();
                 _systemSolver->solve(&_system);
             }
         } else {

--- a/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver2.cpp
@@ -219,6 +219,10 @@ void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
 
     const auto fluidSdfAcc = fluidSdf.constAccessor();
 
+    A->clear();
+    b->clear();
+    indexToCoord->clear();
+
     fluidSdf.forEachIndex([&](size_t i, size_t j) {
         const size_t cIdx = fluidSdfAcc.index(i, j);
         const size_t lIdx = fluidSdfAcc.index(i - 1, j);
@@ -395,6 +399,7 @@ void GridFractionalSinglePhasePressureSolver2::setLinearSystemSolver(
     } else {
         // In case of mg system, use multi-level structure.
         _system.clear();
+        _compSystem.clear();
     }
 }
 

--- a/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
@@ -19,8 +19,6 @@
 #include <jet/grid_fractional_single_phase_pressure_solver3.h>
 #include <jet/level_set_utils.h>
 
-#include <algorithm>
-
 using namespace jet;
 
 const double kDefaultTolerance = 1e-6;
@@ -267,7 +265,190 @@ void buildSingleSystem(FdmMatrix3* A, FdmVector3* b,
         }
     });
 }
+
+void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
+                       Array3<size_t>* coordToIndex,
+                       Array1<Point3UI>* indexToCoord,
+                       const Array3<float>& fluidSdf,
+                       const Array3<float>& uWeights,
+                       const Array3<float>& vWeights,
+                       const Array3<float>& wWeights,
+                       std::function<Vector3D(const Vector3D&)> boundaryVel,
+                       const FaceCenteredGrid3& input) {
+    const Size3 size = input.resolution();
+    const auto uPos = input.uPosition();
+    const auto vPos = input.vPosition();
+    const auto wPos = input.wPosition();
+
+    const Vector3D invH = 1.0 / input.gridSpacing();
+    const Vector3D invHSqr = invH * invH;
+
+    const auto fluidSdfAcc = fluidSdf.constAccessor();
+
+    A->clear();
+    b->clear();
+    indexToCoord->clear();
+
+    size_t numRows = 0;
+    fluidSdf.forEachIndex([&](size_t i, size_t j, size_t k) {
+        const size_t cIdx = fluidSdfAcc.index(i, j, k);
+        const double centerPhi = fluidSdf[cIdx];
+
+        if (isInsideSdf(centerPhi)) {
+            (*coordToIndex)[cIdx] = numRows++;
+            indexToCoord->append({i, j, k});
+        } else {
+            (*coordToIndex)[cIdx] = kMaxSize;
+        }
+    });
+
+    fluidSdf.forEachIndex([&](size_t i, size_t j, size_t k) {
+        const size_t cIdx = fluidSdfAcc.index(i, j, k);
+
+        const double centerPhi = fluidSdf[cIdx];
+
+        if (isInsideSdf(centerPhi)) {
+            double bijk = 0.0;
+
+            std::vector<double> row(1, 0.0);
+            std::vector<size_t> colIdx(1, (*coordToIndex)[cIdx]);
+
+            double term;
+
+            if (i + 1 < size.x) {
+                term = uWeights(i + 1, j, k) * invHSqr.x;
+                const double rightPhi = fluidSdf(i + 1, j, k);
+                if (isInsideSdf(rightPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i + 1, j, k));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, rightPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk += uWeights(i + 1, j, k) * input.u(i + 1, j, k) * invH.x;
+            } else {
+                bijk += input.u(i + 1, j, k) * invH.x;
+            }
+
+            if (i > 0) {
+                term = uWeights(i, j, k) * invHSqr.x;
+                const double leftPhi = fluidSdf(i - 1, j, k);
+                if (isInsideSdf(leftPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i - 1, j, k));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, leftPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk -= uWeights(i, j, k) * input.u(i, j, k) * invH.x;
+            } else {
+                bijk -= input.u(i, j, k) * invH.x;
+            }
+
+            if (j + 1 < size.y) {
+                term = vWeights(i, j + 1, k) * invHSqr.y;
+                const double upPhi = fluidSdf(i, j + 1, k);
+                if (isInsideSdf(upPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i, j + 1, k));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, upPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk += vWeights(i, j + 1, k) * input.v(i, j + 1, k) * invH.y;
+            } else {
+                bijk += input.v(i, j + 1, k) * invH.y;
+            }
+
+            if (j > 0) {
+                term = vWeights(i, j, k) * invHSqr.y;
+                const double downPhi = fluidSdf(i, j - 1, k);
+                if (isInsideSdf(downPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i, j - 1, k));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, downPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk -= vWeights(i, j, k) * input.v(i, j, k) * invH.y;
+            } else {
+                bijk -= input.v(i, j, k) * invH.y;
+            }
+
+            if (k + 1 < size.z) {
+                term = wWeights(i, j, k + 1) * invHSqr.z;
+                const double frontPhi = fluidSdf(i, j, k + 1);
+                if (isInsideSdf(frontPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i, j, k + 1));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, frontPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk += wWeights(i, j, k + 1) * input.w(i, j, k + 1) * invH.z;
+            } else {
+                bijk += input.w(i, j, k + 1) * invH.z;
+            }
+
+            if (k > 0) {
+                term = wWeights(i, j, k) * invHSqr.z;
+                const double backPhi = fluidSdf(i, j, k - 1);
+                if (isInsideSdf(backPhi)) {
+                    row[0] += term;
+                    row.push_back(-term);
+                    colIdx.push_back((*coordToIndex)(i, j, k - 1));
+                } else {
+                    double theta = fractionInsideSdf(centerPhi, backPhi);
+                    theta = std::max(theta, 0.01);
+                    row[0] += term / theta;
+                }
+                bijk -= wWeights(i, j, k) * input.w(i, j, k) * invH.z;
+            } else {
+                bijk -= input.w(i, j, k) * invH.z;
+            }
+
+            // Accumulate contributions from the moving boundary
+            double boundaryContribution =
+                (1.0 - uWeights(i + 1, j, k)) *
+                    boundaryVel(uPos(i + 1, j, k)).x * invH.x -
+                (1.0 - uWeights(i, j, k)) * boundaryVel(uPos(i, j, k)).x *
+                    invH.x +
+                (1.0 - vWeights(i, j + 1, k)) *
+                    boundaryVel(vPos(i, j + 1, k)).y * invH.y -
+                (1.0 - vWeights(i, j, k)) * boundaryVel(vPos(i, j, k)).y *
+                    invH.y +
+                (1.0 - wWeights(i, j, k + 1)) *
+                    boundaryVel(wPos(i, j, k + 1)).z * invH.z -
+                (1.0 - wWeights(i, j, k)) * boundaryVel(wPos(i, j, k)).z *
+                    invH.z;
+            bijk += boundaryContribution;
+
+            // If row.center is near-zero, the cell is likely inside a solid
+            // boundary.
+            if (row[0] < kEpsilonD) {
+                row[0] = 1.0;
+                bijk = 0.0;
+            }
+
+            A->addRow(row, colIdx);
+            b->append(bijk);
+        }
+    });
+
+    x->resize(b->size(), 0.0);
 }
+
+}  // namespace
 
 GridFractionalSinglePhasePressureSolver3::
     GridFractionalSinglePhasePressureSolver3() {
@@ -280,16 +461,22 @@ GridFractionalSinglePhasePressureSolver3::
 void GridFractionalSinglePhasePressureSolver3::solve(
     const FaceCenteredGrid3& input, double timeIntervalInSeconds,
     FaceCenteredGrid3* output, const ScalarField3& boundarySdf,
-    const VectorField3& boundaryVelocity, const ScalarField3& fluidSdf) {
+    const VectorField3& boundaryVelocity, const ScalarField3& fluidSdf,
+    bool useCompressed) {
     UNUSED_VARIABLE(timeIntervalInSeconds);
 
     buildWeights(input, boundarySdf, boundaryVelocity, fluidSdf);
-    buildSystem(input);
+    buildSystem(input, useCompressed);
 
     if (_systemSolver != nullptr) {
         // Solve the system
         if (_mgSystemSolver == nullptr) {
-            _systemSolver->solve(&_system);
+            if (useCompressed) {
+                _systemSolver->solveCompressed(&_compSystem);
+                _compSystem.decompressSolution(&_system.x);
+            } else {
+                _systemSolver->solve(&_system);
+            }
         } else {
             _mgSystemSolver->solve(&_mgSystem);
         }
@@ -321,6 +508,7 @@ void GridFractionalSinglePhasePressureSolver3::setLinearSystemSolver(
     } else {
         // In case of mg system, use multi-level structure.
         _system.clear();
+        _compSystem.clear();
     }
 }
 
@@ -451,18 +639,16 @@ void GridFractionalSinglePhasePressureSolver3::buildWeights(
 }
 
 void GridFractionalSinglePhasePressureSolver3::buildSystem(
-    const FaceCenteredGrid3& input) {
+    const FaceCenteredGrid3& input, bool useCompressed) {
     Size3 size = input.resolution();
     size_t numLevels = 1;
-    FdmMatrix3* A;
-    FdmVector3* b;
 
     if (_mgSystemSolver == nullptr) {
-        _system.A.resize(size);
-        _system.x.resize(size);
-        _system.b.resize(size);
-        A = &_system.A;
-        b = &_system.b;
+        if (useCompressed) {
+            _compSystem.resize(size);
+        } else {
+            _system.resize(size);
+        }
     } else {
         // Build levels
         size_t maxLevels = _mgSystemSolver->params().maxNumberOfLevels;
@@ -473,16 +659,29 @@ void GridFractionalSinglePhasePressureSolver3::buildSystem(
         FdmMgUtils3::resizeArrayWithFinest(size, maxLevels,
                                            &_mgSystem.b.levels);
 
-        A = &_mgSystem.A.levels.front();
-        b = &_mgSystem.b.levels.front();
-
         numLevels = _mgSystem.A.levels.size();
     }
 
     // Build top level
     const FaceCenteredGrid3* finer = &input;
-    buildSingleSystem(A, b, _fluidSdf[0], _uWeights[0], _vWeights[0],
-                      _wWeights[0], _boundaryVel, *finer);
+    if (_mgSystemSolver == nullptr) {
+        if (useCompressed) {
+            buildSingleSystem(&_compSystem.A, &_compSystem.x, &_compSystem.b,
+                              &_compSystem.coordToIndex,
+                              &_compSystem.indexToCoord, _fluidSdf[0],
+                              _uWeights[0], _vWeights[0], _wWeights[0],
+                              _boundaryVel, *finer);
+        } else {
+            buildSingleSystem(&_system.A, &_system.b, _fluidSdf[0],
+                              _uWeights[0], _vWeights[0], _wWeights[0],
+                              _boundaryVel, *finer);
+        }
+    } else {
+        buildSingleSystem(&_mgSystem.A.levels.front(),
+                          &_mgSystem.b.levels.front(), _fluidSdf[0],
+                          _uWeights[0], _vWeights[0], _wWeights[0],
+                          _boundaryVel, *finer);
+    }
 
     // Build sub-levels
     FaceCenteredGrid3 coarser;
@@ -499,9 +698,8 @@ void GridFractionalSinglePhasePressureSolver3::buildSystem(
         coarser.resize(res, h, o);
         coarser.fill(finer->sampler());
 
-        A = &_mgSystem.A.levels[l];
-        b = &_mgSystem.b.levels[l];
-        buildSingleSystem(A, b, _fluidSdf[l], _uWeights[l], _vWeights[l],
+        buildSingleSystem(&_mgSystem.A.levels[l], &_mgSystem.b.levels[l],
+                          _fluidSdf[l], _uWeights[l], _vWeights[l],
                           _wWeights[l], _boundaryVel, coarser);
 
         finer = &coarser;

--- a/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_fractional_single_phase_pressure_solver3.cpp
@@ -467,9 +467,11 @@ void GridFractionalSinglePhasePressureSolver3::solve(
         // Solve the system
         if (_mgSystemSolver == nullptr) {
             if (useCompressed) {
+                _system.clear();
                 _systemSolver->solveCompressed(&_compSystem);
                 decompressSolution();
             } else {
+                _compSystem.clear();
                 _systemSolver->solve(&_system);
             }
         } else {

--- a/src/jet/grid_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_single_phase_pressure_solver2.cpp
@@ -68,6 +68,7 @@ void buildSingleSystem(FdmMatrix2* A, FdmVector2* b,
 
 void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
                        Array2<size_t>* coordToIndex,
+                       Array1<Point2UI>* indexToCoord,
                        const Array2<char>& markers,
                        const FaceCenteredGrid2& input) {
     Size2 size = input.resolution();
@@ -85,6 +86,7 @@ void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
 
         if (markerAcc[cIdx] == kFluid) {
             (*coordToIndex)[cIdx] = b->size();
+            indexToCoord->append({i, j});
             b->append(input.divergenceAtCellCenter(i, j));
 
             std::vector<double> row(1, 0.0);
@@ -300,7 +302,8 @@ void GridSinglePhasePressureSolver2::buildSystem(const FaceCenteredGrid2& input,
     if (_mgSystemSolver == nullptr) {
         if (useCompressed) {
             buildSingleSystem(&_compSystem.A, &_compSystem.x, &_compSystem.b,
-                              &_compSystem.coordToIndex, _markers[0], *finer);
+                              &_compSystem.coordToIndex,
+                              &_compSystem.indexToCoord, _markers[0], *finer);
         } else {
             buildSingleSystem(&_system.A, &_system.b, _markers[0], *finer);
         }

--- a/src/jet/grid_single_phase_pressure_solver2.cpp
+++ b/src/jet/grid_single_phase_pressure_solver2.cpp
@@ -166,9 +166,11 @@ void GridSinglePhasePressureSolver2::solve(const FaceCenteredGrid2& input,
         // Solve the system
         if (_mgSystemSolver == nullptr) {
             if (useCompressed) {
+                _system.clear();
                 _systemSolver->solveCompressed(&_compSystem);
                 decompressSolution();
             } else {
+                _compSystem.clear();
                 _systemSolver->solve(&_system);
             }
         } else {

--- a/src/jet/grid_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_single_phase_pressure_solver3.cpp
@@ -196,9 +196,11 @@ void GridSinglePhasePressureSolver3::solve(const FaceCenteredGrid3& input,
         // Solve the system
         if (_mgSystemSolver == nullptr) {
             if (useCompressed) {
+                _system.clear();
                 _systemSolver->solveCompressed(&_compSystem);
                 decompressSolution();
             } else {
+                _compSystem.clear();
                 _systemSolver->solve(&_system);
             }
         } else {

--- a/src/jet/grid_single_phase_pressure_solver3.cpp
+++ b/src/jet/grid_single_phase_pressure_solver3.cpp
@@ -77,7 +77,105 @@ void buildSingleSystem(FdmMatrix3* A, FdmVector3* b,
         }
     });
 }
+
+void buildSingleSystem(MatrixCsrD* A, VectorND* x, VectorND* b,
+                       Array3<size_t>* coordToIndex,
+                       Array1<Point3UI>* indexToCoord,
+                       const Array3<char>& markers,
+                       const FaceCenteredGrid3& input) {
+    Size3 size = input.resolution();
+    Vector3D invH = 1.0 / input.gridSpacing();
+    Vector3D invHSqr = invH * invH;
+
+    const auto markerAcc = markers.constAccessor();
+
+    A->clear();
+    b->clear();
+    indexToCoord->clear();
+
+    size_t numRows = 0;
+    markers.forEachIndex([&](size_t i, size_t j, size_t k) {
+        const size_t cIdx = markerAcc.index(i, j, k);
+
+        if (markerAcc[cIdx] == kFluid) {
+            (*coordToIndex)[cIdx] = numRows++;
+            indexToCoord->append({i, j, k});
+        } else {
+            (*coordToIndex)[cIdx] = kMaxSize;
+        }
+    });
+
+    markers.forEachIndex([&](size_t i, size_t j, size_t k) {
+        const size_t cIdx = markerAcc.index(i, j, k);
+        const size_t lIdx = markerAcc.index(i - 1, j, k);
+        const size_t rIdx = markerAcc.index(i + 1, j, k);
+        const size_t dIdx = markerAcc.index(i, j - 1, k);
+        const size_t uIdx = markerAcc.index(i, j + 1, k);
+        const size_t bIdx = markerAcc.index(i, j, k - 1);
+        const size_t fIdx = markerAcc.index(i, j, k + 1);
+
+        if (markerAcc[cIdx] == kFluid) {
+            b->append(input.divergenceAtCellCenter(i, j, k));
+
+            std::vector<double> row(1, 0.0);
+            std::vector<size_t> colIdx(1, (*coordToIndex)[cIdx]);
+
+            if (i + 1 < size.x && markers[rIdx] != kBoundary) {
+                row[0] += invHSqr.x;
+                if (markers[rIdx] == kFluid) {
+                    row.push_back(-invHSqr.x);
+                    colIdx.push_back((*coordToIndex)[rIdx]);
+                }
+            }
+
+            if (i > 0 && markers[lIdx] != kBoundary) {
+                row[0] += invHSqr.x;
+                if (markers[lIdx] == kFluid) {
+                    row.push_back(-invHSqr.x);
+                    colIdx.push_back((*coordToIndex)[lIdx]);
+                }
+            }
+
+            if (j + 1 < size.y && markers[uIdx] != kBoundary) {
+                row[0] += invHSqr.y;
+                if (markers[uIdx] == kFluid) {
+                    row.push_back(-invHSqr.y);
+                    colIdx.push_back((*coordToIndex)[uIdx]);
+                }
+            }
+
+            if (j > 0 && markers[dIdx] != kBoundary) {
+                row[0] += invHSqr.y;
+                if (markers[dIdx] == kFluid) {
+                    row.push_back(-invHSqr.y);
+                    colIdx.push_back((*coordToIndex)[dIdx]);
+                }
+            }
+
+            if (k + 1 < size.z && markers[fIdx] != kBoundary) {
+                row[0] += invHSqr.z;
+                if (markers[fIdx] == kFluid) {
+                    row.push_back(-invHSqr.z);
+                    colIdx.push_back((*coordToIndex)[fIdx]);
+                }
+            }
+
+            if (k > 0 && markers[bIdx] != kBoundary) {
+                row[0] += invHSqr.z;
+                if (markers[bIdx] == kFluid) {
+                    row.push_back(-invHSqr.z);
+                    colIdx.push_back((*coordToIndex)[bIdx]);
+                }
+            }
+
+            A->addRow(row, colIdx);
+        }
+    });
+
+    x->resize(b->size(), 0.0);
 }
+
+}  // namespace
 
 GridSinglePhasePressureSolver3::GridSinglePhasePressureSolver3() {
     _systemSolver = std::make_shared<FdmIccgSolver3>(100, kDefaultTolerance);
@@ -90,18 +188,24 @@ void GridSinglePhasePressureSolver3::solve(const FaceCenteredGrid3& input,
                                            FaceCenteredGrid3* output,
                                            const ScalarField3& boundarySdf,
                                            const VectorField3& boundaryVelocity,
-                                           const ScalarField3& fluidSdf) {
+                                           const ScalarField3& fluidSdf,
+                                           bool useCompressed) {
     UNUSED_VARIABLE(timeIntervalInSeconds);
     UNUSED_VARIABLE(boundaryVelocity);
 
     auto pos = input.cellCenterPosition();
     buildMarkers(input.resolution(), pos, boundarySdf, fluidSdf);
-    buildSystem(input);
+    buildSystem(input, useCompressed);
 
     if (_systemSolver != nullptr) {
         // Solve the system
         if (_mgSystemSolver == nullptr) {
-            _systemSolver->solve(&_system);
+            if (useCompressed) {
+                _systemSolver->solveCompressed(&_compSystem);
+                _compSystem.decompressSolution(&_system.x);
+            } else {
+                _systemSolver->solve(&_system);
+            }
         } else {
             _mgSystemSolver->solve(&_mgSystem);
         }
@@ -132,6 +236,7 @@ void GridSinglePhasePressureSolver3::setLinearSystemSolver(
     } else {
         // In case of mg system, use multi-level structure.
         _system.clear();
+        _compSystem.clear();
     }
 }
 
@@ -225,19 +330,17 @@ void GridSinglePhasePressureSolver3::buildMarkers(
     }
 }
 
-void GridSinglePhasePressureSolver3::buildSystem(
-    const FaceCenteredGrid3& input) {
+void GridSinglePhasePressureSolver3::buildSystem(const FaceCenteredGrid3& input,
+                                                 bool useCompressed) {
     Size3 size = input.resolution();
     size_t numLevels = 1;
-    FdmMatrix3* A;
-    FdmVector3* b;
 
     if (_mgSystemSolver == nullptr) {
-        _system.A.resize(size);
-        _system.x.resize(size);
-        _system.b.resize(size);
-        A = &_system.A;
-        b = &_system.b;
+        if (useCompressed) {
+            _compSystem.resize(size);
+        } else {
+            _system.resize(size);
+        }
     } else {
         // Build levels
         size_t maxLevels = _mgSystemSolver->params().maxNumberOfLevels;
@@ -247,15 +350,24 @@ void GridSinglePhasePressureSolver3::buildSystem(
                                            &_mgSystem.x.levels);
         FdmMgUtils3::resizeArrayWithFinest(size, maxLevels,
                                            &_mgSystem.b.levels);
-        A = &_mgSystem.A.levels.front();
-        b = &_mgSystem.b.levels.front();
 
         numLevels = _mgSystem.A.levels.size();
     }
 
     // Build top level
     const FaceCenteredGrid3* finer = &input;
-    buildSingleSystem(A, b, _markers[0], *finer);
+    if (_mgSystemSolver == nullptr) {
+        if (useCompressed) {
+            buildSingleSystem(&_compSystem.A, &_compSystem.x, &_compSystem.b,
+                              &_compSystem.coordToIndex,
+                              &_compSystem.indexToCoord, _markers[0], *finer);
+        } else {
+            buildSingleSystem(&_system.A, &_system.b, _markers[0], *finer);
+        }
+    } else {
+        buildSingleSystem(&_mgSystem.A.levels.front(),
+                          &_mgSystem.b.levels.front(), _markers[0], *finer);
+    }
 
     // Build sub-levels
     FaceCenteredGrid3 coarser;
@@ -272,9 +384,8 @@ void GridSinglePhasePressureSolver3::buildSystem(
         coarser.resize(res, h, o);
         coarser.fill(finer->sampler());
 
-        A = &_mgSystem.A.levels[l];
-        b = &_mgSystem.b.levels[l];
-        buildSingleSystem(A, b, _markers[l], coarser);
+        buildSingleSystem(&_mgSystem.A.levels[l], &_mgSystem.b.levels[l],
+                          _markers[l], coarser);
 
         finer = &coarser;
     }

--- a/src/python/grid_fluid_solver.cpp
+++ b/src/python/grid_fluid_solver.cpp
@@ -48,6 +48,11 @@ void addGridFluidSolver2(py::module& m) {
         .def_property("maxCfl", &GridFluidSolver2::maxCfl,
                       &GridFluidSolver2::setMaxCfl,
                       R"pbdoc(The max allowed CFL number.)pbdoc")
+        .def_property(
+            "useCompressedLinearSystem",
+            &GridFluidSolver2::useCompressedLinearSystem,
+            &GridFluidSolver2::setUseCompressedLinearSystem,
+            R"pbdoc(True if the solver is using compressed linear system.)pbdoc")
         .def_property("advectionSolver", &GridFluidSolver2::advectionSolver,
                       &GridFluidSolver2::setAdvectionSolver,
                       R"pbdoc(The advection solver.)pbdoc")
@@ -179,6 +184,11 @@ void addGridFluidSolver3(py::module& m) {
         .def_property("maxCfl", &GridFluidSolver3::maxCfl,
                       &GridFluidSolver3::setMaxCfl,
                       R"pbdoc(The max allowed CFL number.)pbdoc")
+        .def_property(
+            "useCompressedLinearSystem",
+            &GridFluidSolver3::useCompressedLinearSystem,
+            &GridFluidSolver3::setUseCompressedLinearSystem,
+            R"pbdoc(True if the solver is using compressed linear system.)pbdoc")
         .def_property("advectionSolver", &GridFluidSolver3::advectionSolver,
                       &GridFluidSolver3::setAdvectionSolver,
                       R"pbdoc(The advection solver.)pbdoc")

--- a/src/tests/manual_tests/apic_solver3_tests.cpp
+++ b/src/tests/manual_tests/apic_solver3_tests.cpp
@@ -100,6 +100,7 @@ JET_BEGIN_TEST_F(ApicSolver3, DamBreakingWithCollider) {
                       .withResolution(resolution)
                       .withDomainSizeX(3.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -175,6 +176,7 @@ JET_BEGIN_TEST_F(ApicSolver3, Spherical) {
                       .withResolution({30, 30, 30})
                       .withDomainSizeX(1.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     // Build collider
     auto sphere = Sphere3::builder()
@@ -213,6 +215,7 @@ JET_BEGIN_TEST_F(ApicSolver3, SphericalNonVariational) {
                       .withResolution({30, 30, 30})
                       .withDomainSizeX(1.0)
                       .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     solver->setPressureSolver(
         std::make_shared<GridSinglePhasePressureSolver3>());

--- a/src/tests/manual_tests/flip_solver3_tests.cpp
+++ b/src/tests/manual_tests/flip_solver3_tests.cpp
@@ -9,10 +9,10 @@
 #include <jet/box3.h>
 #include <jet/cylinder3.h>
 #include <jet/flip_solver3.h>
-#include <jet/grid_point_generator3.h>
 #include <jet/grid_fractional_single_phase_pressure_solver3.h>
-#include <jet/level_set_utils.h>
+#include <jet/grid_point_generator3.h>
 #include <jet/implicit_surface_set3.h>
+#include <jet/level_set_utils.h>
 #include <jet/particle_emitter_set3.h>
 #include <jet/plane3.h>
 #include <jet/rigid_body_collider3.h>
@@ -32,10 +32,11 @@ JET_BEGIN_TEST_F(FlipSolver3, WaterDrop) {
     size_t resolutionX = 32;
 
     // Build solver
-    auto solver = FlipSolver3::builder()
-        .withResolution({resolutionX, 2 * resolutionX, resolutionX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+    auto solver =
+        FlipSolver3::builder()
+            .withResolution({resolutionX, 2 * resolutionX, resolutionX})
+            .withDomainSizeX(1.0)
+            .makeShared();
 
     auto grids = solver->gridSystemData();
     auto particles = solver->particleSystemData();
@@ -46,34 +47,34 @@ JET_BEGIN_TEST_F(FlipSolver3, WaterDrop) {
 
     // Build emitter
     auto plane = Plane3::builder()
-        .withNormal({0, 1, 0})
-        .withPoint({0, 0.25 * domain.height(), 0})
-        .makeShared();
+                     .withNormal({0, 1, 0})
+                     .withPoint({0, 0.25 * domain.height(), 0})
+                     .makeShared();
 
     auto sphere = Sphere3::builder()
-        .withCenter(domain.midPoint())
-        .withRadius(0.15 * domain.width())
-        .makeShared();
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
 
     auto emitter1 = VolumeParticleEmitter3::builder()
-        .withSurface(plane)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(plane)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter1->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitter2 = VolumeParticleEmitter3::builder()
-        .withSurface(sphere)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(sphere)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter2->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitterSet = ParticleEmitterSet3::builder()
-        .withEmitters({emitter1, emitter2})
-        .makeShared();
+                          .withEmitters({emitter1, emitter2})
+                          .makeShared();
 
     solver->setParticleEmitter(emitterSet);
 
@@ -89,10 +90,11 @@ JET_BEGIN_TEST_F(FlipSolver3, WaterDropWithBlending) {
     size_t resolutionX = 32;
 
     // Build solver
-    auto solver = FlipSolver3::builder()
-        .withResolution({resolutionX, 2 * resolutionX, resolutionX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+    auto solver =
+        FlipSolver3::builder()
+            .withResolution({resolutionX, 2 * resolutionX, resolutionX})
+            .withDomainSizeX(1.0)
+            .makeShared();
 
     solver->setPicBlendingFactor(0.05);
 
@@ -105,34 +107,34 @@ JET_BEGIN_TEST_F(FlipSolver3, WaterDropWithBlending) {
 
     // Build emitter
     auto plane = Plane3::builder()
-        .withNormal({0, 1, 0})
-        .withPoint({0, 0.25 * domain.height(), 0})
-        .makeShared();
+                     .withNormal({0, 1, 0})
+                     .withPoint({0, 0.25 * domain.height(), 0})
+                     .makeShared();
 
     auto sphere = Sphere3::builder()
-        .withCenter(domain.midPoint())
-        .withRadius(0.15 * domain.width())
-        .makeShared();
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
 
     auto emitter1 = VolumeParticleEmitter3::builder()
-        .withSurface(plane)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(plane)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter1->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitter2 = VolumeParticleEmitter3::builder()
-        .withSurface(sphere)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(sphere)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter2->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitterSet = ParticleEmitterSet3::builder()
-        .withEmitters({emitter1, emitter2})
-        .makeShared();
+                          .withEmitters({emitter1, emitter2})
+                          .makeShared();
 
     solver->setParticleEmitter(emitterSet);
 
@@ -154,9 +156,10 @@ JET_BEGIN_TEST_F(FlipSolver3, DamBreakingWithCollider) {
     // Build solver
     Size3 resolution{3 * resolutionX, 2 * resolutionX, (3 * resolutionX) / 2};
     auto solver = FlipSolver3::builder()
-        .withResolution(resolution)
-        .withDomainSizeX(3.0)
-        .makeShared();
+                      .withResolution(resolution)
+                      .withDomainSizeX(3.0)
+                      .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -164,55 +167,56 @@ JET_BEGIN_TEST_F(FlipSolver3, DamBreakingWithCollider) {
     double lz = domain.depth();
 
     // Build emitter
-    auto box1 = Box3::builder()
-        .withLowerCorner({0, 0, 0})
-        .withUpperCorner({0.5 + 0.001, 0.75 + 0.001, 0.75 * lz + 0.001})
-        .makeShared();
+    auto box1 =
+        Box3::builder()
+            .withLowerCorner({0, 0, 0})
+            .withUpperCorner({0.5 + 0.001, 0.75 + 0.001, 0.75 * lz + 0.001})
+            .makeShared();
 
-    auto box2 = Box3::builder()
-        .withLowerCorner({2.5 - 0.001, 0, 0.25 * lz - 0.001})
-        .withUpperCorner({3.5 + 0.001, 0.75 + 0.001, 1.5 * lz + 0.001})
-        .makeShared();
+    auto box2 =
+        Box3::builder()
+            .withLowerCorner({2.5 - 0.001, 0, 0.25 * lz - 0.001})
+            .withUpperCorner({3.5 + 0.001, 0.75 + 0.001, 1.5 * lz + 0.001})
+            .makeShared();
 
     auto boxSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({box1, box2})
-        .makeShared();
+                      .withExplicitSurfaces({box1, box2})
+                      .makeShared();
 
     auto emitter = VolumeParticleEmitter3::builder()
-        .withSurface(boxSet)
-        .withMaxRegion(domain)
-        .withSpacing(0.5 * dx)
-        .makeShared();
+                       .withSurface(boxSet)
+                       .withMaxRegion(domain)
+                       .withSpacing(0.5 * dx)
+                       .makeShared();
 
     emitter->setPointGenerator(std::make_shared<GridPointGenerator3>());
     solver->setParticleEmitter(emitter);
 
     // Build collider
     auto cyl1 = Cylinder3::builder()
-        .withCenter({1, 0.375, 0.375})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1, 0.375, 0.375})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl2 = Cylinder3::builder()
-        .withCenter({1.5, 0.375, 0.75})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1.5, 0.375, 0.75})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl3 = Cylinder3::builder()
-        .withCenter({2, 0.375, 1.125})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({2, 0.375, 1.125})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cylSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({cyl1, cyl2, cyl3})
-        .makeShared();
+                      .withExplicitSurfaces({cyl1, cyl2, cyl3})
+                      .makeShared();
 
-    auto collider = RigidBodyCollider3::builder()
-        .withSurface(cylSet)
-        .makeShared();
+    auto collider =
+        RigidBodyCollider3::builder().withSurface(cylSet).makeShared();
 
     solver->setCollider(collider);
 
@@ -228,39 +232,39 @@ JET_END_TEST_F
 JET_BEGIN_TEST_F(FlipSolver3, RotatingTank) {
     // Build solver
     auto solver = FlipSolver3::builder()
-        .withResolution({32, 32, 32})
-        .withDomainSizeX(1.0)
-        .makeShared();
+                      .withResolution({32, 32, 32})
+                      .withDomainSizeX(1.0)
+                      .makeShared();
 
     // Build emitter
     auto box = Box3::builder()
-        .withLowerCorner({0.25, 0.25, 0.25})
-        .withUpperCorner({0.75, 0.50, 0.75})
-        .makeShared();
+                   .withLowerCorner({0.25, 0.25, 0.25})
+                   .withUpperCorner({0.75, 0.50, 0.75})
+                   .makeShared();
 
     auto emitter = VolumeParticleEmitter3::builder()
-        .withSurface(box)
-        .withSpacing(1.0 / 64.0)
-        .withIsOneShot(true)
-        .makeShared();
+                       .withSurface(box)
+                       .withSpacing(1.0 / 64.0)
+                       .withIsOneShot(true)
+                       .makeShared();
 
     solver->setParticleEmitter(emitter);
 
     // Build collider
     auto tank = Box3::builder()
-        .withLowerCorner({-0.25, -0.25, -0.25})
-        .withUpperCorner({ 0.25,  0.25,  0.25})
-        .withTranslation({0.5, 0.5, 0.5})
-        .withOrientation({{0, 0, 1}, 0.0})
-        .withIsNormalFlipped(true)
-        .makeShared();
+                    .withLowerCorner({-0.25, -0.25, -0.25})
+                    .withUpperCorner({0.25, 0.25, 0.25})
+                    .withTranslation({0.5, 0.5, 0.5})
+                    .withOrientation({{0, 0, 1}, 0.0})
+                    .withIsNormalFlipped(true)
+                    .makeShared();
 
     auto collider = RigidBodyCollider3::builder()
-        .withSurface(tank)
-        .withAngularVelocity({0, 0, 2})
-        .makeShared();
+                        .withSurface(tank)
+                        .withAngularVelocity({0, 0, 2})
+                        .makeShared();
 
-    collider->setOnBeginUpdateCallback([&] (Collider3* col, double t, double) {
+    collider->setOnBeginUpdateCallback([&](Collider3* col, double t, double) {
         if (t < 1.0) {
             col->surface()->transform.setOrientation({{0, 0, 1}, 2.0 * t});
             static_cast<RigidBodyCollider3*>(col)->angularVelocity = {0, 0, 2};

--- a/src/tests/manual_tests/pic_solver3_tests.cpp
+++ b/src/tests/manual_tests/pic_solver3_tests.cpp
@@ -8,12 +8,12 @@
 
 #include <jet/box3.h>
 #include <jet/cylinder3.h>
-#include <jet/pic_solver3.h>
-#include <jet/grid_point_generator3.h>
 #include <jet/grid_fractional_single_phase_pressure_solver3.h>
-#include <jet/level_set_utils.h>
+#include <jet/grid_point_generator3.h>
 #include <jet/implicit_surface_set3.h>
+#include <jet/level_set_utils.h>
 #include <jet/particle_emitter_set3.h>
+#include <jet/pic_solver3.h>
 #include <jet/plane3.h>
 #include <jet/rigid_body_collider3.h>
 #include <jet/sphere3.h>
@@ -32,10 +32,11 @@ JET_BEGIN_TEST_F(PicSolver3, WaterDrop) {
     size_t resolutionX = 32;
 
     // Build solver
-    auto solver = PicSolver3::builder()
-        .withResolution({resolutionX, 2 * resolutionX, resolutionX})
-        .withDomainSizeX(1.0)
-        .makeShared();
+    auto solver =
+        PicSolver3::builder()
+            .withResolution({resolutionX, 2 * resolutionX, resolutionX})
+            .withDomainSizeX(1.0)
+            .makeShared();
 
     auto grids = solver->gridSystemData();
     auto particles = solver->particleSystemData();
@@ -46,34 +47,34 @@ JET_BEGIN_TEST_F(PicSolver3, WaterDrop) {
 
     // Build emitter
     auto plane = Plane3::builder()
-        .withNormal({0, 1, 0})
-        .withPoint({0, 0.25 * domain.height(), 0})
-        .makeShared();
+                     .withNormal({0, 1, 0})
+                     .withPoint({0, 0.25 * domain.height(), 0})
+                     .makeShared();
 
     auto sphere = Sphere3::builder()
-        .withCenter(domain.midPoint())
-        .withRadius(0.15 * domain.width())
-        .makeShared();
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
 
     auto emitter1 = VolumeParticleEmitter3::builder()
-        .withSurface(plane)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(plane)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter1->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitter2 = VolumeParticleEmitter3::builder()
-        .withSurface(sphere)
-        .withSpacing(0.5 * dx)
-        .withMaxRegion(domain)
-        .withIsOneShot(true)
-        .makeShared();
+                        .withSurface(sphere)
+                        .withSpacing(0.5 * dx)
+                        .withMaxRegion(domain)
+                        .withIsOneShot(true)
+                        .makeShared();
     emitter2->setPointGenerator(std::make_shared<GridPointGenerator3>());
 
     auto emitterSet = ParticleEmitterSet3::builder()
-        .withEmitters({emitter1, emitter2})
-        .makeShared();
+                          .withEmitters({emitter1, emitter2})
+                          .makeShared();
 
     solver->setParticleEmitter(emitterSet);
 
@@ -95,9 +96,10 @@ JET_BEGIN_TEST_F(PicSolver3, DamBreakingWithCollider) {
     // Build solver
     Size3 resolution{3 * resolutionX, 2 * resolutionX, (3 * resolutionX) / 2};
     auto solver = PicSolver3::builder()
-        .withResolution(resolution)
-        .withDomainSizeX(3.0)
-        .makeShared();
+                      .withResolution(resolution)
+                      .withDomainSizeX(3.0)
+                      .makeShared();
+    solver->setUseCompressedLinearSystem(true);
 
     auto grids = solver->gridSystemData();
     double dx = grids->gridSpacing().x;
@@ -105,55 +107,56 @@ JET_BEGIN_TEST_F(PicSolver3, DamBreakingWithCollider) {
     double lz = domain.depth();
 
     // Build emitter
-    auto box1 = Box3::builder()
-        .withLowerCorner({0, 0, 0})
-        .withUpperCorner({0.5 + 0.001, 0.75 + 0.001, 0.75 * lz + 0.001})
-        .makeShared();
+    auto box1 =
+        Box3::builder()
+            .withLowerCorner({0, 0, 0})
+            .withUpperCorner({0.5 + 0.001, 0.75 + 0.001, 0.75 * lz + 0.001})
+            .makeShared();
 
-    auto box2 = Box3::builder()
-        .withLowerCorner({2.5 - 0.001, 0, 0.25 * lz - 0.001})
-        .withUpperCorner({3.5 + 0.001, 0.75 + 0.001, 1.5 * lz + 0.001})
-        .makeShared();
+    auto box2 =
+        Box3::builder()
+            .withLowerCorner({2.5 - 0.001, 0, 0.25 * lz - 0.001})
+            .withUpperCorner({3.5 + 0.001, 0.75 + 0.001, 1.5 * lz + 0.001})
+            .makeShared();
 
     auto boxSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({box1, box2})
-        .makeShared();
+                      .withExplicitSurfaces({box1, box2})
+                      .makeShared();
 
     auto emitter = VolumeParticleEmitter3::builder()
-        .withSurface(boxSet)
-        .withMaxRegion(domain)
-        .withSpacing(0.5 * dx)
-        .makeShared();
+                       .withSurface(boxSet)
+                       .withMaxRegion(domain)
+                       .withSpacing(0.5 * dx)
+                       .makeShared();
 
     emitter->setPointGenerator(std::make_shared<GridPointGenerator3>());
     solver->setParticleEmitter(emitter);
 
     // Build collider
     auto cyl1 = Cylinder3::builder()
-        .withCenter({1, 0.375, 0.375})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1, 0.375, 0.375})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl2 = Cylinder3::builder()
-        .withCenter({1.5, 0.375, 0.75})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({1.5, 0.375, 0.75})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cyl3 = Cylinder3::builder()
-        .withCenter({2, 0.375, 1.125})
-        .withRadius(0.1)
-        .withHeight(0.75)
-        .makeShared();
+                    .withCenter({2, 0.375, 1.125})
+                    .withRadius(0.1)
+                    .withHeight(0.75)
+                    .makeShared();
 
     auto cylSet = ImplicitSurfaceSet3::builder()
-        .withExplicitSurfaces({cyl1, cyl2, cyl3})
-        .makeShared();
+                      .withExplicitSurfaces({cyl1, cyl2, cyl3})
+                      .makeShared();
 
-    auto collider = RigidBodyCollider3::builder()
-        .withSurface(cylSet)
-        .makeShared();
+    auto collider =
+        RigidBodyCollider3::builder().withSurface(cylSet).makeShared();
 
     solver->setCollider(collider);
 

--- a/src/tests/mem_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "mem_perf_tests.h"
+
+#include <jet/cell_centered_scalar_grid3.h>
+#include <jet/face_centered_grid3.h>
+#include <jet/grid_fractional_single_phase_pressure_solver3.h>
+
+#include <gtest/gtest.h>
+
+using namespace jet;
+
+namespace {
+
+void runExperiment(size_t n, double height, bool compressed) {
+    FaceCenteredGrid3 vel(n, n, n);
+    CellCenteredScalarGrid3 fluidSdf(n, n, n);
+
+    vel.fill(Vector3D());
+
+    for (size_t k = 0; k < n; ++k) {
+        for (size_t j = 0; j < n + 1; ++j) {
+            for (size_t i = 0; i < n; ++i) {
+                if (j == 0 || j == n) {
+                    vel.v(i, j, k) = 0.0;
+                } else {
+                    vel.v(i, j, k) = 1.0;
+                }
+            }
+        }
+    }
+
+    fluidSdf.fill([&](const Vector3D& x) { return x.y - height * n; });
+
+    GridFractionalSinglePhasePressureSolver3 solver;
+    solver.solve(vel, 1.0, &vel, ConstantScalarField3(kMaxD),
+                 ConstantVectorField3({0, 0, 0}), fluidSdf, compressed);
+}
+
+}  // namespace
+
+TEST(GridFractionalSinglePhasePressureSolver3, FullUncompressed) {
+    const size_t mem0 = getCurrentRSS();
+
+    runExperiment(128, 1.0, false);
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
+                   msg.second.c_str());
+}
+
+TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed) {
+    const size_t mem0 = getCurrentRSS();
+
+    runExperiment(128, 1.0, true);
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
+                   msg.second.c_str());
+}
+
+TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed) {
+    const size_t mem0 = getCurrentRSS();
+
+    runExperiment(128, 0.25, false);
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
+                   msg.second.c_str());
+}
+
+TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed) {
+    const size_t mem0 = getCurrentRSS();
+
+    runExperiment(128, 0.25, true);
+
+    const size_t mem1 = getCurrentRSS();
+
+    const auto msg = makeReadableByteSize(mem1 - mem0);
+
+    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
+                   msg.second.c_str());
+}

--- a/src/tests/mem_perf_tests/main.cpp
+++ b/src/tests/mem_perf_tests/main.cpp
@@ -4,8 +4,8 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <jet/jet.h>
 #include <gtest/gtest.h>
+#include <jet/jet.h>
 #include <fstream>
 
 using namespace jet;
@@ -13,7 +13,7 @@ using namespace jet;
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
-    std::ofstream logFile("perf_tests.log");
+    std::ofstream logFile("mem_perf_tests.log");
     if (logFile) {
         Logging::setAllStream(&logFile);
     }

--- a/src/tests/time_perf_tests/fdm_linear_systems_tests.cpp
+++ b/src/tests/time_perf_tests/fdm_linear_systems_tests.cpp
@@ -80,7 +80,8 @@ class FdmCompressedBlas3 : public ::benchmark::Fixture {
         buildSystem(&system, {dim, dim, dim});
     }
 
-    void buildSystem(FdmCompressedLinearSystem3* system, const Size3& size) {
+    static void buildSystem(FdmCompressedLinearSystem3* system,
+                            const Size3& size) {
         system->clear();
 
         Array3<size_t> coordToIndex(size);

--- a/src/tests/time_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
+++ b/src/tests/time_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/cell_centered_scalar_grid3.h>
+#include <jet/face_centered_grid3.h>
+#include <jet/grid_fractional_single_phase_pressure_solver3.h>
+
+#include <benchmark/benchmark.h>
+
+using jet::kMaxD;
+using jet::Vector3D;
+using jet::FaceCenteredGrid3;
+using jet::CellCenteredScalarGrid3;
+using jet::ConstantScalarField3;
+using jet::ConstantVectorField3;
+
+class GridFractionalSinglePhasePressureSolver3 : public ::benchmark::Fixture {
+ public:
+    FaceCenteredGrid3 vel;
+    CellCenteredScalarGrid3 fluidSdf;
+    jet::GridFractionalSinglePhasePressureSolver3 solver;
+
+    void SetUp(const ::benchmark::State& state) {
+        const auto n = static_cast<size_t>(state.range(0));
+        const auto height = static_cast<double>(state.range(1));
+
+        vel.resize(n, n, n);
+        vel.fill(Vector3D());
+
+        for (size_t k = 0; k < n; ++k) {
+            for (size_t j = 0; j < n + 1; ++j) {
+                for (size_t i = 0; i < n; ++i) {
+                    if (j == 0 || j == n) {
+                        vel.v(i, j, k) = 0.0;
+                    } else {
+                        vel.v(i, j, k) = 1.0;
+                    }
+                }
+            }
+        }
+
+        fluidSdf.resize(n, n, n);
+        fluidSdf.fill([&](const Vector3D& x) { return x.y - height; });
+    }
+};
+
+BENCHMARK_DEFINE_F(GridFractionalSinglePhasePressureSolver3, Solve)
+(benchmark::State& state) {
+    bool compressed = state.range(2) == 1;
+    while (state.KeepRunning()) {
+        solver.solve(vel, 1.0, &vel, ConstantScalarField3(kMaxD),
+                     ConstantVectorField3({0, 0, 0}), fluidSdf, compressed);
+    }
+}
+
+BENCHMARK_REGISTER_F(GridFractionalSinglePhasePressureSolver3, Solve)
+    ->Args({128, 128, 0})
+    ->Args({128, 128, 1})
+    ->Args({128, 64, 0})
+    ->Args({128, 64, 1})
+    ->Args({128, 32, 0})
+    ->Args({128, 32, 1});

--- a/src/tests/time_perf_tests/main.cpp
+++ b/src/tests/time_perf_tests/main.cpp
@@ -4,6 +4,23 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include <jet/logging.h>
+
 #include <benchmark/benchmark.h>
 
-BENCHMARK_MAIN();
+#include <fstream>
+
+int main(int argc, char** argv) {
+    ::benchmark::Initialize(&argc, argv);
+
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv)) {
+        return 1;
+    }
+
+    std::ofstream logFile("mem_perf_tests.log");
+    if (logFile) {
+        jet::Logging::setAllStream(&logFile);
+    }
+
+    ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/src/tests/unit_tests/fdm_cg_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_cg_solver2_tests.cpp
@@ -4,42 +4,31 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "fdm_linear_system_solver_test_helper2.h"
+
 #include <jet/fdm_cg_solver2.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
 
-TEST(FdmCgSolver2, Constructors) {
+TEST(FdmCgSolver2, Solve) {
     FdmLinearSystem2 system;
-    system.A.resize(3, 3);
-    system.x.resize(3, 3);
-    system.b.resize(3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system, {3, 3});
 
     FdmCgSolver2 solver(10, 1e-9);
     solver.solve(&system);
+
+    EXPECT_GT(solver.tolerance(), solver.lastResidual());
+}
+
+TEST(FdmCgSolver2, SolveCompressed) {
+    FdmCompressedLinearSystem2 system;
+    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(&system,
+                                                                      {3, 3});
+
+    FdmCgSolver2 solver(10, 1e-9);
+    solver.solveCompressed(&system);
 
     EXPECT_GT(solver.tolerance(), solver.lastResidual());
 }

--- a/src/tests/unit_tests/fdm_cg_solver3_tests.cpp
+++ b/src/tests/unit_tests/fdm_cg_solver3_tests.cpp
@@ -4,50 +4,31 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "fdm_linear_system_solver_test_helper3.h"
+
 #include <jet/fdm_cg_solver3.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
 
-TEST(FdmCgSolver3, Constructors) {
+TEST(FdmCgSolver3, Solve) {
     FdmLinearSystem3 system;
-    system.A.resize(3, 3, 3);
-    system.x.resize(3, 3, 3);
-    system.b.resize(3, 3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j, size_t k) {
-        if (i > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j, k).center += 1.0;
-        } else {
-            system.b(i, j, k) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).up -= 1.0;
-        } else {
-            system.b(i, j, k) -= 1.0;
-        }
-
-        if (k > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (k < system.A.depth() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).front -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper3::buildTestLinearSystem(&system, {3, 3, 3});
 
     FdmCgSolver3 solver(100, 1e-9);
     solver.solve(&system);
+
+    EXPECT_GT(solver.tolerance(), solver.lastResidual());
+}
+
+TEST(FdmCgSolver3, SolveCompressed) {
+    FdmCompressedLinearSystem3 system;
+    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(
+        &system, {3, 3, 3});
+
+    FdmCgSolver3 solver(100, 1e-9);
+    solver.solveCompressed(&system);
 
     EXPECT_GT(solver.tolerance(), solver.lastResidual());
 }

--- a/src/tests/unit_tests/fdm_gauss_seidel_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_gauss_seidel_solver2_tests.cpp
@@ -109,24 +109,3 @@ TEST(FdmGaussSeidelSolver2, SolveCompressed) {
 
     EXPECT_LT(norm1, norm0);
 }
-
-TEST(FdmGaussSeidelSolver2, RelaxRedBlackCompressed) {
-    FdmCompressedLinearSystem2 system;
-    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(
-        &system, {128, 128});
-
-    auto buffer = system.x;
-    FdmCompressedBlas2::residual(system.A, system.x, system.b, &buffer);
-    double norm0 = FdmCompressedBlas2::l2Norm(buffer);
-
-    for (int i = 0; i < 200; ++i) {
-        FdmGaussSeidelSolver2::relaxRedBlack(
-            system.A, system.b, system.indexToCoord, 1.0, &system.x);
-
-        FdmCompressedBlas2::residual(system.A, system.x, system.b, &buffer);
-        double norm = FdmCompressedBlas2::l2Norm(buffer);
-        EXPECT_LT(norm, norm0);
-
-        norm0 = norm;
-    }
-}

--- a/src/tests/unit_tests/fdm_gauss_seidel_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_gauss_seidel_solver2_tests.cpp
@@ -4,39 +4,17 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "fdm_linear_system_solver_test_helper2.h"
+
 #include <jet/fdm_gauss_seidel_solver2.h>
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 
 TEST(FdmGaussSeidelSolver2, SolveLowRes) {
     FdmLinearSystem2 system;
-    system.A.resize(3, 3);
-    system.x.resize(3, 3);
-    system.b.resize(3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system, {3, 3});
 
     FdmGaussSeidelSolver2 solver(100, 10, 1e-9);
     solver.solve(&system);
@@ -46,32 +24,8 @@ TEST(FdmGaussSeidelSolver2, SolveLowRes) {
 
 TEST(FdmGaussSeidelSolver2, Solve) {
     FdmLinearSystem2 system;
-    system.A.resize(128, 128);
-    system.x.resize(128, 128);
-    system.b.resize(128, 128);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system,
+                                                            {128, 128});
 
     auto buffer = system.x;
     FdmBlas2::residual(system.A, system.x, system.b, &buffer);
@@ -88,32 +42,8 @@ TEST(FdmGaussSeidelSolver2, Solve) {
 
 TEST(FdmGaussSeidelSolver2, Relax) {
     FdmLinearSystem2 system;
-    system.A.resize(128, 128);
-    system.x.resize(128, 128);
-    system.b.resize(128, 128);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system,
+                                                            {128, 128});
 
     auto buffer = system.x;
     FdmBlas2::residual(system.A, system.x, system.b, &buffer);
@@ -132,32 +62,8 @@ TEST(FdmGaussSeidelSolver2, Relax) {
 
 TEST(FdmGaussSeidelSolver2, RelaxRedBlack) {
     FdmLinearSystem2 system;
-    system.A.resize(128, 128);
-    system.x.resize(128, 128);
-    system.b.resize(128, 128);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system,
+                                                            {128, 128});
 
     auto buffer = system.x;
     FdmBlas2::residual(system.A, system.x, system.b, &buffer);
@@ -177,57 +83,8 @@ TEST(FdmGaussSeidelSolver2, RelaxRedBlack) {
 
 TEST(FdmGaussSeidelSolver2, SolveCompressedRes) {
     FdmCompressedLinearSystem2 system;
-    system.coordToIndex.resize(3, 3);
-
-    const auto acc = system.coordToIndex.constAccessor();
-    Size2 size = acc.size();
-
-    system.coordToIndex.forEachIndex([&](size_t i, size_t j) {
-        const size_t cIdx = acc.index(i, j);
-        const size_t lIdx = acc.index(i - 1, j);
-        const size_t rIdx = acc.index(i + 1, j);
-        const size_t dIdx = acc.index(i, j - 1);
-        const size_t uIdx = acc.index(i, j + 1);
-
-        system.coordToIndex[cIdx] = system.b.size();
-        system.indexToCoord.append({i, j});
-        double bij = 0.0;
-
-        std::vector<double> row(1, 0.0);
-        std::vector<size_t> colIdx(1, cIdx);
-
-        if (i > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(lIdx);
-        }
-        if (i < size.x - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(rIdx);
-        }
-
-        if (j > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(dIdx);
-        } else {
-            bij += 1.0;
-        }
-
-        if (j < size.y - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(uIdx);
-        } else {
-            bij -= 1.0;
-        }
-
-        system.A.addRow(row, colIdx);
-        system.b.append(bij);
-    });
-
-    system.x.resize(system.b.size(), 0.0);
+    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(&system,
+                                                                      {3, 3});
 
     FdmGaussSeidelSolver2 solver(100, 10, 1e-9);
     solver.solveCompressed(&system);
@@ -237,57 +94,8 @@ TEST(FdmGaussSeidelSolver2, SolveCompressedRes) {
 
 TEST(FdmGaussSeidelSolver2, SolveCompressed) {
     FdmCompressedLinearSystem2 system;
-    system.coordToIndex.resize(128, 128);
-
-    const auto acc = system.coordToIndex.constAccessor();
-    Size2 size = acc.size();
-
-    system.coordToIndex.forEachIndex([&](size_t i, size_t j) {
-        const size_t cIdx = acc.index(i, j);
-        const size_t lIdx = acc.index(i - 1, j);
-        const size_t rIdx = acc.index(i + 1, j);
-        const size_t dIdx = acc.index(i, j - 1);
-        const size_t uIdx = acc.index(i, j + 1);
-
-        system.coordToIndex[cIdx] = system.b.size();
-        system.indexToCoord.append({i, j});
-        double bij = 0.0;
-
-        std::vector<double> row(1, 0.0);
-        std::vector<size_t> colIdx(1, cIdx);
-
-        if (i > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(lIdx);
-        }
-        if (i < size.x - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(rIdx);
-        }
-
-        if (j > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(dIdx);
-        } else {
-            bij += 1.0;
-        }
-
-        if (j < size.y - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(uIdx);
-        } else {
-            bij -= 1.0;
-        }
-
-        system.A.addRow(row, colIdx);
-        system.b.append(bij);
-    });
-
-    system.x.resize(system.b.size(), 0.0);
+    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(
+        &system, {128, 128});
 
     auto buffer = system.x;
     FdmCompressedBlas2::residual(system.A, system.x, system.b, &buffer);
@@ -304,57 +112,8 @@ TEST(FdmGaussSeidelSolver2, SolveCompressed) {
 
 TEST(FdmGaussSeidelSolver2, RelaxRedBlackCompressed) {
     FdmCompressedLinearSystem2 system;
-    system.coordToIndex.resize(128, 128);
-
-    const auto acc = system.coordToIndex.constAccessor();
-    Size2 size = acc.size();
-
-    system.coordToIndex.forEachIndex([&](size_t i, size_t j) {
-        const size_t cIdx = acc.index(i, j);
-        const size_t lIdx = acc.index(i - 1, j);
-        const size_t rIdx = acc.index(i + 1, j);
-        const size_t dIdx = acc.index(i, j - 1);
-        const size_t uIdx = acc.index(i, j + 1);
-
-        system.coordToIndex[cIdx] = system.b.size();
-        system.indexToCoord.append({i, j});
-        double bij = 0.0;
-
-        std::vector<double> row(1, 0.0);
-        std::vector<size_t> colIdx(1, cIdx);
-
-        if (i > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(lIdx);
-        }
-        if (i < size.x - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(rIdx);
-        }
-
-        if (j > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(dIdx);
-        } else {
-            bij += 1.0;
-        }
-
-        if (j < size.y - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(uIdx);
-        } else {
-            bij -= 1.0;
-        }
-
-        system.A.addRow(row, colIdx);
-        system.b.append(bij);
-    });
-
-    system.x.resize(system.b.size(), 0.0);
+    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(
+        &system, {128, 128});
 
     auto buffer = system.x;
     FdmCompressedBlas2::residual(system.A, system.x, system.b, &buffer);

--- a/src/tests/unit_tests/fdm_gauss_seidel_solver3_tests.cpp
+++ b/src/tests/unit_tests/fdm_gauss_seidel_solver3_tests.cpp
@@ -83,10 +83,10 @@ TEST(FdmGaussSeidelSolver3, RelaxRedBlack) {
     }
 }
 
-TEST(FdmGaussSeidelSolver3, SolveCompressedRes) {
+TEST(FdmGaussSeidelSolver3, SolveCompressedLowRes) {
     FdmCompressedLinearSystem3 system;
-    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(&system,
-                                                                      {3, 3});
+    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(
+        &system, {3, 3, 3});
 
     FdmGaussSeidelSolver3 solver(100, 10, 1e-9);
     solver.solveCompressed(&system);

--- a/src/tests/unit_tests/fdm_gauss_seidel_solver3_tests.cpp
+++ b/src/tests/unit_tests/fdm_gauss_seidel_solver3_tests.cpp
@@ -111,26 +111,3 @@ TEST(FdmGaussSeidelSolver3, SolveCompressed) {
 
     EXPECT_LT(norm1, norm0);
 }
-
-TEST(FdmGaussSeidelSolver3, RelaxRedBlackCompressed) {
-    FdmCompressedLinearSystem3 system;
-    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(
-        &system, {32, 32, 32});
-
-    auto buffer = system.x;
-    FdmCompressedBlas3::residual(system.A, system.x, system.b, &buffer);
-    double norm0 = FdmCompressedBlas3::l2Norm(buffer);
-
-    for (int i = 0; i < 200; ++i) {
-        FdmGaussSeidelSolver3::relaxRedBlack(
-            system.A, system.b, system.indexToCoord, 1.0, &system.x);
-
-        FdmCompressedBlas3::residual(system.A, system.x, system.b, &buffer);
-        double norm = FdmCompressedBlas3::l2Norm(buffer);
-        if (i > 0) {
-            EXPECT_LT(norm, norm0);
-        }
-
-        norm0 = norm;
-    }
-}

--- a/src/tests/unit_tests/fdm_iccg_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_iccg_solver2_tests.cpp
@@ -4,39 +4,17 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "fdm_linear_system_solver_test_helper2.h"
+
 #include <jet/fdm_iccg_solver2.h>
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 
 TEST(FdmIccgSolver2, SolveLowRes) {
     FdmLinearSystem2 system;
-    system.A.resize(3, 3);
-    system.x.resize(3, 3);
-    system.b.resize(3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system, {3, 3});
 
     FdmIccgSolver2 solver(10, 1e-9);
     solver.solve(&system);
@@ -46,32 +24,16 @@ TEST(FdmIccgSolver2, SolveLowRes) {
 
 TEST(FdmIccgSolver2, Solve) {
     FdmLinearSystem2 system;
-    system.A.resize(128, 128);
-    system.x.resize(128, 128);
-    system.b.resize(128, 128);
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system,
+                                                            {128, 128});
 
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
+    FdmIccgSolver2 solver(200, 1e-4);
+    EXPECT_TRUE(solver.solve(&system));
+}
 
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+TEST(FdmIccgSolver2, SolveCompressed) {
+    FdmLinearSystem2 system;
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system, {3, 3});
 
     FdmIccgSolver2 solver(200, 1e-4);
     EXPECT_TRUE(solver.solve(&system));

--- a/src/tests/unit_tests/fdm_iccg_solver3_tests.cpp
+++ b/src/tests/unit_tests/fdm_iccg_solver3_tests.cpp
@@ -4,47 +4,17 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "fdm_linear_system_solver_test_helper3.h"
+
 #include <jet/fdm_iccg_solver3.h>
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 
 TEST(FdmIccgSolver3, SolveLowRes) {
     FdmLinearSystem3 system;
-    system.A.resize(3, 3, 3);
-    system.x.resize(3, 3, 3);
-    system.b.resize(3, 3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j, size_t k) {
-        if (i > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j, k).center += 1.0;
-        } else {
-            system.b(i, j, k) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).up -= 1.0;
-        } else {
-            system.b(i, j, k) -= 1.0;
-        }
-
-        if (k > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (k < system.A.depth() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).front -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper3::buildTestLinearSystem(&system, {3, 3, 3});
 
     FdmIccgSolver3 solver(100, 1e-9);
     solver.solve(&system);
@@ -54,43 +24,22 @@ TEST(FdmIccgSolver3, SolveLowRes) {
 
 TEST(FdmIccgSolver3, Solve) {
     FdmLinearSystem3 system;
-    system.A.resize(32, 32, 32);
-    system.x.resize(32, 32, 32);
-    system.b.resize(32, 32, 32);
-
-    system.A.forEachIndex([&](size_t i, size_t j, size_t k) {
-        if (i > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j, k).center += 1.0;
-        } else {
-            system.b(i, j, k) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).up -= 1.0;
-        } else {
-            system.b(i, j, k) -= 1.0;
-        }
-
-        if (k > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (k < system.A.depth() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).front -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper3::buildTestLinearSystem(&system,
+                                                            {32, 32, 32});
 
     FdmIccgSolver3 solver(100, 1e-4);
     solver.solve(&system);
 
     EXPECT_TRUE(solver.solve(&system));
+}
+
+TEST(FdmIccgSolver3, SolveCompressed) {
+    FdmCompressedLinearSystem3 system;
+    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(
+        &system, {3, 3, 3});
+
+    FdmIccgSolver3 solver(100, 1e-4);
+    solver.solveCompressed(&system);
+
+    EXPECT_GT(solver.tolerance(), solver.lastResidual());
 }

--- a/src/tests/unit_tests/fdm_jacobi_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_jacobi_solver2_tests.cpp
@@ -5,11 +5,12 @@
 // property of any third parties.
 
 #include <jet/fdm_jacobi_solver2.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
 
-TEST(FdmJacobiSolver2, Constructors) {
+TEST(FdmJacobiSolver2, Solve) {
     FdmLinearSystem2 system;
     system.A.resize(3, 3);
     system.x.resize(3, 3);
@@ -40,6 +41,66 @@ TEST(FdmJacobiSolver2, Constructors) {
 
     FdmJacobiSolver2 solver(100, 10, 1e-9);
     solver.solve(&system);
+
+    EXPECT_GT(solver.tolerance(), solver.lastResidual());
+}
+
+TEST(FdmJacobiSolver2, SolveCompressed) {
+    FdmCompressedLinearSystem2 system;
+    system.coordToIndex.resize(3, 3);
+
+    const auto acc = system.coordToIndex.constAccessor();
+    Size2 size = acc.size();
+
+    system.coordToIndex.forEachIndex([&](size_t i, size_t j) {
+        const size_t cIdx = acc.index(i, j);
+        const size_t lIdx = acc.index(i - 1, j);
+        const size_t rIdx = acc.index(i + 1, j);
+        const size_t dIdx = acc.index(i, j - 1);
+        const size_t uIdx = acc.index(i, j + 1);
+
+        system.coordToIndex[cIdx] = system.b.size();
+        system.indexToCoord.append({i, j});
+        double bij = 0.0;
+
+        std::vector<double> row(1, 0.0);
+        std::vector<size_t> colIdx(1, cIdx);
+
+        if (i > 0) {
+            row[0] += 1.0;
+            row.push_back(-1.0);
+            colIdx.push_back(lIdx);
+        }
+        if (i < size.x - 1) {
+            row[0] += 1.0;
+            row.push_back(-1.0);
+            colIdx.push_back(rIdx);
+        }
+
+        if (j > 0) {
+            row[0] += 1.0;
+            row.push_back(-1.0);
+            colIdx.push_back(dIdx);
+        } else {
+            bij += 1.0;
+        }
+
+        if (j < size.y - 1) {
+            row[0] += 1.0;
+            row.push_back(-1.0);
+            colIdx.push_back(uIdx);
+        } else {
+            bij -= 1.0;
+        }
+
+        system.A.addRow(row, colIdx);
+        system.b.append(bij);
+    });
+
+    system.x.resize(system.b.size(), 0.0);
+
+    FdmJacobiSolver2 solver(100, 10, 1e-9);
+    solver.solveCompressed(&system);
 
     EXPECT_GT(solver.tolerance(), solver.lastResidual());
 }

--- a/src/tests/unit_tests/fdm_jacobi_solver2_tests.cpp
+++ b/src/tests/unit_tests/fdm_jacobi_solver2_tests.cpp
@@ -4,6 +4,8 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "fdm_linear_system_solver_test_helper2.h"
+
 #include <jet/fdm_jacobi_solver2.h>
 
 #include <gtest/gtest.h>
@@ -12,32 +14,7 @@ using namespace jet;
 
 TEST(FdmJacobiSolver2, Solve) {
     FdmLinearSystem2 system;
-    system.A.resize(3, 3);
-    system.x.resize(3, 3);
-    system.b.resize(3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j) {
-        if (i > 0) {
-            system.A(i, j).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j).center += 1.0;
-        } else {
-            system.b(i, j) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j).center += 1.0;
-            system.A(i, j).up -= 1.0;
-        } else {
-            system.b(i, j) -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper2::buildTestLinearSystem(&system, {3, 3});
 
     FdmJacobiSolver2 solver(100, 10, 1e-9);
     solver.solve(&system);
@@ -47,57 +24,8 @@ TEST(FdmJacobiSolver2, Solve) {
 
 TEST(FdmJacobiSolver2, SolveCompressed) {
     FdmCompressedLinearSystem2 system;
-    system.coordToIndex.resize(3, 3);
-
-    const auto acc = system.coordToIndex.constAccessor();
-    Size2 size = acc.size();
-
-    system.coordToIndex.forEachIndex([&](size_t i, size_t j) {
-        const size_t cIdx = acc.index(i, j);
-        const size_t lIdx = acc.index(i - 1, j);
-        const size_t rIdx = acc.index(i + 1, j);
-        const size_t dIdx = acc.index(i, j - 1);
-        const size_t uIdx = acc.index(i, j + 1);
-
-        system.coordToIndex[cIdx] = system.b.size();
-        system.indexToCoord.append({i, j});
-        double bij = 0.0;
-
-        std::vector<double> row(1, 0.0);
-        std::vector<size_t> colIdx(1, cIdx);
-
-        if (i > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(lIdx);
-        }
-        if (i < size.x - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(rIdx);
-        }
-
-        if (j > 0) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(dIdx);
-        } else {
-            bij += 1.0;
-        }
-
-        if (j < size.y - 1) {
-            row[0] += 1.0;
-            row.push_back(-1.0);
-            colIdx.push_back(uIdx);
-        } else {
-            bij -= 1.0;
-        }
-
-        system.A.addRow(row, colIdx);
-        system.b.append(bij);
-    });
-
-    system.x.resize(system.b.size(), 0.0);
+    FdmLinearSystemSolverTestHelper2::buildTestCompressedLinearSystem(&system,
+                                                                      {3, 3});
 
     FdmJacobiSolver2 solver(100, 10, 1e-9);
     solver.solveCompressed(&system);

--- a/src/tests/unit_tests/fdm_jacobi_solver3_tests.cpp
+++ b/src/tests/unit_tests/fdm_jacobi_solver3_tests.cpp
@@ -4,50 +4,31 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "fdm_linear_system_solver_test_helper3.h"
+
 #include <jet/fdm_jacobi_solver3.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
 
-TEST(FdmJacobiSolver3, Constructors) {
+TEST(FdmJacobiSolver3, Solve) {
     FdmLinearSystem3 system;
-    system.A.resize(3, 3, 3);
-    system.x.resize(3, 3, 3);
-    system.b.resize(3, 3, 3);
-
-    system.A.forEachIndex([&](size_t i, size_t j, size_t k) {
-        if (i > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (i < system.A.width() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).right -= 1.0;
-        }
-
-        if (j > 0) {
-            system.A(i, j, k).center += 1.0;
-        } else {
-            system.b(i, j, k) += 1.0;
-        }
-
-        if (j < system.A.height() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).up -= 1.0;
-        } else {
-            system.b(i, j, k) -= 1.0;
-        }
-
-        if (k > 0) {
-            system.A(i, j, k).center += 1.0;
-        }
-        if (k < system.A.depth() - 1) {
-            system.A(i, j, k).center += 1.0;
-            system.A(i, j, k).front -= 1.0;
-        }
-    });
+    FdmLinearSystemSolverTestHelper3::buildTestLinearSystem(&system, {3, 3, 3});
 
     FdmJacobiSolver3 solver(100, 10, 1e-9);
     solver.solve(&system);
+
+    EXPECT_GT(solver.tolerance(), solver.lastResidual());
+}
+
+TEST(FdmJacobiSolver3, SolveCompressed) {
+    FdmCompressedLinearSystem3 system;
+    FdmLinearSystemSolverTestHelper3::buildTestCompressedLinearSystem(
+        &system, {3, 3, 3});
+
+    FdmJacobiSolver3 solver(100, 10, 1e-9);
+    solver.solveCompressed(&system);
 
     EXPECT_GT(solver.tolerance(), solver.lastResidual());
 }

--- a/src/tests/unit_tests/fdm_linear_system_solver_test_helper2.h
+++ b/src/tests/unit_tests/fdm_linear_system_solver_test_helper2.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/fdm_linear_system_solver2.h>
+
+namespace jet {
+
+class FdmLinearSystemSolverTestHelper2 {
+ public:
+    static void buildTestLinearSystem(FdmLinearSystem2* system,
+                                      const Size2& size) {
+        system->A.resize(size);
+        system->x.resize(size);
+        system->b.resize(size);
+
+        system->A.forEachIndex([&](size_t i, size_t j) {
+            if (i > 0) {
+                system->A(i, j).center += 1.0;
+            }
+            if (i < system->A.width() - 1) {
+                system->A(i, j).center += 1.0;
+                system->A(i, j).right -= 1.0;
+            }
+
+            if (j > 0) {
+                system->A(i, j).center += 1.0;
+            } else {
+                system->b(i, j) += 1.0;
+            }
+
+            if (j < system->A.height() - 1) {
+                system->A(i, j).center += 1.0;
+                system->A(i, j).up -= 1.0;
+            } else {
+                system->b(i, j) -= 1.0;
+            }
+        });
+    }
+
+    static void buildTestCompressedLinearSystem(
+        FdmCompressedLinearSystem2* system, const Size2& size) {
+        system->coordToIndex.resize(size);
+
+        const auto acc = system->coordToIndex.constAccessor();
+
+        system->coordToIndex.forEachIndex([&](size_t i, size_t j) {
+            const size_t cIdx = acc.index(i, j);
+            const size_t lIdx = acc.index(i - 1, j);
+            const size_t rIdx = acc.index(i + 1, j);
+            const size_t dIdx = acc.index(i, j - 1);
+            const size_t uIdx = acc.index(i, j + 1);
+
+            system->coordToIndex[cIdx] = system->b.size();
+            system->indexToCoord.append({i, j});
+            double bij = 0.0;
+
+            std::vector<double> row(1, 0.0);
+            std::vector<size_t> colIdx(1, cIdx);
+
+            if (i > 0) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(lIdx);
+            }
+            if (i < size.x - 1) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(rIdx);
+            }
+
+            if (j > 0) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(dIdx);
+            } else {
+                bij += 1.0;
+            }
+
+            if (j < size.y - 1) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(uIdx);
+            } else {
+                bij -= 1.0;
+            }
+
+            system->A.addRow(row, colIdx);
+            system->b.append(bij);
+        });
+
+        system->x.resize(system->b.size(), 0.0);
+    }
+};
+
+}  // namespace jet

--- a/src/tests/unit_tests/fdm_linear_system_solver_test_helper2.h
+++ b/src/tests/unit_tests/fdm_linear_system_solver_test_helper2.h
@@ -42,19 +42,17 @@ class FdmLinearSystemSolverTestHelper2 {
 
     static void buildTestCompressedLinearSystem(
         FdmCompressedLinearSystem2* system, const Size2& size) {
-        system->coordToIndex.resize(size);
+        Array2<size_t> coordToIndex(size);
+        const auto acc = coordToIndex.constAccessor();
 
-        const auto acc = system->coordToIndex.constAccessor();
-
-        system->coordToIndex.forEachIndex([&](size_t i, size_t j) {
+        coordToIndex.forEachIndex([&](size_t i, size_t j) {
             const size_t cIdx = acc.index(i, j);
             const size_t lIdx = acc.index(i - 1, j);
             const size_t rIdx = acc.index(i + 1, j);
             const size_t dIdx = acc.index(i, j - 1);
             const size_t uIdx = acc.index(i, j + 1);
 
-            system->coordToIndex[cIdx] = system->b.size();
-            system->indexToCoord.append({i, j});
+            coordToIndex[cIdx] = system->b.size();
             double bij = 0.0;
 
             std::vector<double> row(1, 0.0);

--- a/src/tests/unit_tests/fdm_linear_system_solver_test_helper3.h
+++ b/src/tests/unit_tests/fdm_linear_system_solver_test_helper3.h
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/fdm_linear_system_solver3.h>
+
+namespace jet {
+
+class FdmLinearSystemSolverTestHelper3 {
+ public:
+    static void buildTestLinearSystem(FdmLinearSystem3* system,
+                                      const Size3& size) {
+        system->A.resize(size);
+        system->x.resize(size);
+        system->b.resize(size);
+
+        system->A.forEachIndex([&](size_t i, size_t j, size_t k) {
+            if (i > 0) {
+                system->A(i, j, k).center += 1.0;
+            }
+            if (i < system->A.width() - 1) {
+                system->A(i, j, k).center += 1.0;
+                system->A(i, j, k).right -= 1.0;
+            }
+
+            if (j > 0) {
+                system->A(i, j, k).center += 1.0;
+            } else {
+                system->b(i, j, k) += 1.0;
+            }
+
+            if (j < system->A.height() - 1) {
+                system->A(i, j, k).center += 1.0;
+                system->A(i, j, k).up -= 1.0;
+            } else {
+                system->b(i, j, k) -= 1.0;
+            }
+
+            if (k > 0) {
+                system->A(i, j, k).center += 1.0;
+            }
+            if (k < system->A.depth() - 1) {
+                system->A(i, j, k).center += 1.0;
+                system->A(i, j, k).front -= 1.0;
+            }
+        });
+    }
+
+    static void buildTestCompressedLinearSystem(
+        FdmCompressedLinearSystem3* system, const Size3& size) {
+        system->coordToIndex.resize(size);
+
+        const auto acc = system->coordToIndex.constAccessor();
+
+        system->coordToIndex.forEachIndex([&](size_t i, size_t j, size_t k) {
+            const size_t cIdx = acc.index(i, j, k);
+            const size_t lIdx = acc.index(i - 1, j, k);
+            const size_t rIdx = acc.index(i + 1, j, k);
+            const size_t dIdx = acc.index(i, j - 1, k);
+            const size_t uIdx = acc.index(i, j + 1, k);
+            const size_t bIdx = acc.index(i, j, k - 1);
+            const size_t fIdx = acc.index(i, j, k + 1);
+
+            system->coordToIndex[cIdx] = system->b.size();
+            system->indexToCoord.append({i, j, k});
+            double bijk = 0.0;
+
+            std::vector<double> row(1, 0.0);
+            std::vector<size_t> colIdx(1, cIdx);
+
+            if (i > 0) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(lIdx);
+            }
+            if (i < size.x - 1) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(rIdx);
+            }
+
+            if (j > 0) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(dIdx);
+            } else {
+                bijk += 1.0;
+            }
+
+            if (j < size.y - 1) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(uIdx);
+            } else {
+                bijk -= 1.0;
+            }
+
+            if (k > 0) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(bIdx);
+            } else {
+                bijk += 1.0;
+            }
+
+            if (k < size.z - 1) {
+                row[0] += 1.0;
+                row.push_back(-1.0);
+                colIdx.push_back(fIdx);
+            } else {
+                bijk -= 1.0;
+            }
+
+            system->A.addRow(row, colIdx);
+            system->b.append(bijk);
+        });
+
+        system->x.resize(system->b.size(), 0.0);
+    }
+};
+
+}  // namespace jet

--- a/src/tests/unit_tests/fdm_linear_system_solver_test_helper3.h
+++ b/src/tests/unit_tests/fdm_linear_system_solver_test_helper3.h
@@ -50,11 +50,10 @@ class FdmLinearSystemSolverTestHelper3 {
 
     static void buildTestCompressedLinearSystem(
         FdmCompressedLinearSystem3* system, const Size3& size) {
-        system->coordToIndex.resize(size);
+        Array3<size_t> coordToIndex(size);
+        const auto acc = coordToIndex.constAccessor();
 
-        const auto acc = system->coordToIndex.constAccessor();
-
-        system->coordToIndex.forEachIndex([&](size_t i, size_t j, size_t k) {
+        coordToIndex.forEachIndex([&](size_t i, size_t j, size_t k) {
             const size_t cIdx = acc.index(i, j, k);
             const size_t lIdx = acc.index(i - 1, j, k);
             const size_t rIdx = acc.index(i + 1, j, k);
@@ -63,8 +62,7 @@ class FdmLinearSystemSolverTestHelper3 {
             const size_t bIdx = acc.index(i, j, k - 1);
             const size_t fIdx = acc.index(i, j, k + 1);
 
-            system->coordToIndex[cIdx] = system->b.size();
-            system->indexToCoord.append({i, j, k});
+            coordToIndex[cIdx] = system->b.size();
             double bijk = 0.0;
 
             std::vector<double> row(1, 0.0);

--- a/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
+++ b/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
@@ -8,6 +8,7 @@
 #include <jet/cell_centered_vector_grid2.h>
 #include <jet/face_centered_grid2.h>
 #include <jet/grid_fractional_single_phase_pressure_solver2.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
@@ -32,18 +33,57 @@ TEST(GridFractionalSinglePhasePressureSolver2, SolveFreeSurface) {
         }
     }
 
-    fluidSdf.fill([&](const Vector2D& x) {
-        return x.y - 2.0;
-    });
+    fluidSdf.fill([&](const Vector2D& x) { return x.y - 2.0; });
 
     GridFractionalSinglePhasePressureSolver2 solver;
-    solver.solve(
-        vel,
-        1.0,
-        &vel,
-        ConstantScalarField2(kMaxD),
-        ConstantVectorField2({0, 0}),
-        fluidSdf);
+    solver.solve(vel, 1.0, &vel, ConstantScalarField2(kMaxD),
+                 ConstantVectorField2({0, 0}), fluidSdf);
+
+    for (size_t j = 0; j < 3; ++j) {
+        for (size_t i = 0; i < 4; ++i) {
+            EXPECT_NEAR(0.0, vel.u(i, j), 1e-6);
+        }
+    }
+
+    for (size_t j = 0; j < 4; ++j) {
+        for (size_t i = 0; i < 3; ++i) {
+            EXPECT_NEAR(0.0, vel.v(i, j), 1e-6);
+        }
+    }
+
+    const auto& pressure = solver.pressure();
+    for (size_t i = 0; i < 3; ++i) {
+        EXPECT_NEAR(1.5, pressure(i, 0), 1e-6);
+        EXPECT_NEAR(0.5, pressure(i, 1), 1e-6);
+        EXPECT_NEAR(0.0, pressure(i, 2), 1e-6);
+    }
+}
+
+TEST(GridFractionalSinglePhasePressureSolver2, SolveFreeSurfaceCompressed) {
+    FaceCenteredGrid2 vel(3, 3);
+    CellCenteredScalarGrid2 fluidSdf(3, 3);
+
+    for (size_t j = 0; j < 3; ++j) {
+        for (size_t i = 0; i < 4; ++i) {
+            vel.u(i, j) = 0.0;
+        }
+    }
+
+    for (size_t j = 0; j < 4; ++j) {
+        for (size_t i = 0; i < 3; ++i) {
+            if (j == 0 || j == 3) {
+                vel.v(i, j) = 0.0;
+            } else {
+                vel.v(i, j) = 1.0;
+            }
+        }
+    }
+
+    fluidSdf.fill([&](const Vector2D& x) { return x.y - 2.0; });
+
+    GridFractionalSinglePhasePressureSolver2 solver;
+    solver.solve(vel, 1.0, &vel, ConstantScalarField2(kMaxD),
+                 ConstantVectorField2({0, 0}), fluidSdf, true);
 
     for (size_t j = 0; j < 3; ++j) {
         for (size_t i = 0; i < 4; ++i) {

--- a/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
+++ b/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
@@ -147,7 +147,7 @@ TEST(GridFractionalSinglePhasePressureSolver2, SolveFreeSurfaceMg) {
     }
 
     const auto& pressure = solver.pressure();
-    for (size_t j = 0; j < 33; ++j) {
+    for (size_t j = 0; j < 32; ++j) {
         for (size_t i = 16; i < 17; ++i) {
             if (j < 16) {
                 EXPECT_NEAR(15.5 - static_cast<double>(j), pressure(i, j), 0.1);

--- a/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
+++ b/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver2_tests.cpp
@@ -7,6 +7,7 @@
 #include <jet/cell_centered_scalar_grid2.h>
 #include <jet/cell_centered_vector_grid2.h>
 #include <jet/face_centered_grid2.h>
+#include <jet/fdm_mg_solver2.h>
 #include <jet/grid_fractional_single_phase_pressure_solver2.h>
 
 #include <gtest/gtest.h>
@@ -102,5 +103,57 @@ TEST(GridFractionalSinglePhasePressureSolver2, SolveFreeSurfaceCompressed) {
         EXPECT_NEAR(1.5, pressure(i, 0), 1e-6);
         EXPECT_NEAR(0.5, pressure(i, 1), 1e-6);
         EXPECT_NEAR(0.0, pressure(i, 2), 1e-6);
+    }
+}
+
+TEST(GridFractionalSinglePhasePressureSolver2, SolveFreeSurfaceMg) {
+    FaceCenteredGrid2 vel(32, 32);
+    CellCenteredScalarGrid2 fluidSdf(32, 32);
+
+    for (size_t j = 0; j < 32; ++j) {
+        for (size_t i = 0; i < 33; ++i) {
+            vel.u(i, j) = 0.0;
+        }
+    }
+
+    for (size_t j = 0; j < 33; ++j) {
+        for (size_t i = 0; i < 32; ++i) {
+            if (j == 0 || j == 32) {
+                vel.v(i, j) = 0.0;
+            } else {
+                vel.v(i, j) = 1.0;
+            }
+        }
+    }
+
+    fluidSdf.fill([&](const Vector2D& x) { return x.y - 16.0; });
+
+    GridFractionalSinglePhasePressureSolver2 solver;
+    solver.setLinearSystemSolver(
+        std::make_shared<FdmMgSolver2>(5, 50, 50, 50, 50));
+    solver.solve(vel, 1.0, &vel, ConstantScalarField2(kMaxD),
+                 ConstantVectorField2({0, 0}), fluidSdf, true);
+
+    for (size_t j = 0; j < 32; ++j) {
+        for (size_t i = 0; i < 33; ++i) {
+            EXPECT_NEAR(0.0, vel.u(i, j), 0.002);
+        }
+    }
+
+    for (size_t j = 0; j < 16; ++j) {
+        for (size_t i = 0; i < 32; ++i) {
+            EXPECT_NEAR(0.0, vel.v(i, j), 0.002);
+        }
+    }
+
+    const auto& pressure = solver.pressure();
+    for (size_t j = 0; j < 33; ++j) {
+        for (size_t i = 16; i < 17; ++i) {
+            if (j < 16) {
+                EXPECT_NEAR(15.5 - static_cast<double>(j), pressure(i, j), 0.1);
+            } else {
+                EXPECT_NEAR(0.0, pressure(i, j), 0.1);
+            }
+        }
     }
 }

--- a/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
+++ b/src/tests/unit_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
@@ -72,3 +72,62 @@ TEST(GridFractionalSinglePhasePressureSolver3, SolveFreeSurface) {
         }
     }
 }
+
+TEST(GridFractionalSinglePhasePressureSolver3, SolveFreeSurfaceCompressed) {
+    FaceCenteredGrid3 vel(3, 3, 3);
+    CellCenteredScalarGrid3 fluidSdf(3, 3, 3);
+
+    vel.fill(Vector3D());
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 4; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                if (j == 0 || j == 3) {
+                    vel.v(i, j, k) = 0.0;
+                } else {
+                    vel.v(i, j, k) = 1.0;
+                }
+            }
+        }
+    }
+
+    fluidSdf.fill([&](const Vector3D& x) { return x.y - 2.0; });
+
+    GridFractionalSinglePhasePressureSolver3 solver;
+    solver.solve(vel, 1.0, &vel, ConstantScalarField3(kMaxD),
+                 ConstantVectorField3({0, 0, 0}), fluidSdf, true);
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 3; ++j) {
+            for (size_t i = 0; i < 4; ++i) {
+                EXPECT_NEAR(0.0, vel.u(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 4; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                EXPECT_NEAR(0.0, vel.v(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    for (size_t k = 0; k < 4; ++k) {
+        for (size_t j = 0; j < 3; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                EXPECT_NEAR(0.0, vel.w(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    const auto& pressure = solver.pressure();
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 2; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                double p = static_cast<double>(1.5 - j);
+                EXPECT_NEAR(p, pressure(i, j, k), 1e-6);
+            }
+        }
+    }
+}

--- a/src/tests/unit_tests/grid_single_phase_pressure_solver3_tests.cpp
+++ b/src/tests/unit_tests/grid_single_phase_pressure_solver3_tests.cpp
@@ -4,10 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include <gtest/gtest.h>
 #include <jet/cell_centered_scalar_grid3.h>
 #include <jet/face_centered_grid3.h>
 #include <jet/grid_single_phase_pressure_solver3.h>
-#include <gtest/gtest.h>
 
 using namespace jet;
 
@@ -59,8 +59,8 @@ TEST(GridSinglePhasePressureSolver3, SolveSinglePhase) {
     for (size_t k = 0; k < 3; ++k) {
         for (size_t j = 0; j < 2; ++j) {
             for (size_t i = 0; i < 3; ++i) {
-                EXPECT_NEAR(
-                    pressure(i, j + 1, k) - pressure(i, j, k), -1.0, 1e-6);
+                EXPECT_NEAR(pressure(i, j + 1, k) - pressure(i, j, k), -1.0,
+                            1e-6);
             }
         }
     }
@@ -85,9 +85,7 @@ TEST(GridSinglePhasePressureSolver3, SolveSinglePhaseWithBoundary) {
     }
 
     // Wall on the right-most column
-    boundarySdf.fill([&](const Vector3D& x) {
-        return -x.x + 2.0;
-    });
+    boundarySdf.fill([&](const Vector3D& x) { return -x.x + 2.0; });
 
     GridSinglePhasePressureSolver3 solver;
     solver.solve(vel, 1.0, &vel, boundarySdf);
@@ -124,8 +122,8 @@ TEST(GridSinglePhasePressureSolver3, SolveSinglePhaseWithBoundary) {
     for (size_t k = 0; k < 3; ++k) {
         for (size_t j = 0; j < 2; ++j) {
             for (size_t i = 0; i < 2; ++i) {
-                EXPECT_NEAR(
-                    pressure(i, j + 1, k) - pressure(i, j, k), -1.0, 1e-6);
+                EXPECT_NEAR(pressure(i, j + 1, k) - pressure(i, j, k), -1.0,
+                            1e-6);
             }
         }
     }
@@ -149,18 +147,70 @@ TEST(GridSinglePhasePressureSolver3, SolveFreeSurface) {
         }
     }
 
-    fluidSdf.fill([&](const Vector3D& x) {
-        return x.y - 2.0;
-    });
+    fluidSdf.fill([&](const Vector3D& x) { return x.y - 2.0; });
 
     GridSinglePhasePressureSolver3 solver;
-    solver.solve(
-        vel,
-        1.0,
-        &vel,
-        ConstantScalarField3(kMaxD),
-        ConstantVectorField3({0, 0, 0}),
-        fluidSdf);
+    solver.solve(vel, 1.0, &vel, ConstantScalarField3(kMaxD),
+                 ConstantVectorField3({0, 0, 0}), fluidSdf);
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 3; ++j) {
+            for (size_t i = 0; i < 4; ++i) {
+                EXPECT_NEAR(0.0, vel.u(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 4; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                EXPECT_NEAR(0.0, vel.v(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    for (size_t k = 0; k < 4; ++k) {
+        for (size_t j = 0; j < 3; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                EXPECT_NEAR(0.0, vel.w(i, j, k), 1e-6);
+            }
+        }
+    }
+
+    const auto& pressure = solver.pressure();
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 2; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                double p = static_cast<double>(2 - j);
+                EXPECT_NEAR(p, pressure(i, j, k), 1e-6);
+            }
+        }
+    }
+}
+
+TEST(GridSinglePhasePressureSolver3, SolveFreeSurfaceCompressed) {
+    FaceCenteredGrid3 vel(3, 3, 3);
+    CellCenteredScalarGrid3 fluidSdf(3, 3, 3);
+
+    vel.fill(Vector3D());
+
+    for (size_t k = 0; k < 3; ++k) {
+        for (size_t j = 0; j < 4; ++j) {
+            for (size_t i = 0; i < 3; ++i) {
+                if (j == 0 || j == 3) {
+                    vel.v(i, j, k) = 0.0;
+                } else {
+                    vel.v(i, j, k) = 1.0;
+                }
+            }
+        }
+    }
+
+    fluidSdf.fill([&](const Vector3D& x) { return x.y - 2.0; });
+
+    GridSinglePhasePressureSolver3 solver;
+    solver.solve(vel, 1.0, &vel, ConstantScalarField3(kMaxD),
+                 ConstantVectorField3({0, 0, 0}), fluidSdf, true);
 
     for (size_t k = 0; k < 3; ++k) {
         for (size_t j = 0; j < 3; ++j) {
@@ -217,21 +267,12 @@ TEST(GridSinglePhasePressureSolver3, SolveFreeSurfaceWithBoundary) {
     }
 
     // Wall on the right-most column
-    boundarySdf.fill([&](const Vector3D& x) {
-        return -x.x + 2.0;
-    });
-    fluidSdf.fill([&](const Vector3D& x) {
-        return x.y - 2.0;
-    });
+    boundarySdf.fill([&](const Vector3D& x) { return -x.x + 2.0; });
+    fluidSdf.fill([&](const Vector3D& x) { return x.y - 2.0; });
 
     GridSinglePhasePressureSolver3 solver;
-    solver.solve(
-        vel,
-        1.0,
-        &vel,
-        boundarySdf,
-        ConstantVectorField3({0, 0, 0}),
-        fluidSdf);
+    solver.solve(vel, 1.0, &vel, boundarySdf, ConstantVectorField3({0, 0, 0}),
+                 fluidSdf);
 
     for (size_t k = 0; k < 3; ++k) {
         for (size_t j = 0; j < 3; ++j) {

--- a/src/tests/unit_tests/matrix_csr_tests.cpp
+++ b/src/tests/unit_tests/matrix_csr_tests.cpp
@@ -216,6 +216,14 @@ TEST(MatrixCsr, BasicSetters) {
     EXPECT_EQ(-4.0, iterAddRow[5]);
     EXPECT_EQ(1.0, iterAddRow[6]);
     EXPECT_EQ(5.0, iterAddRow[7]);
+
+    // Clear
+    matAddRow.clear();
+    EXPECT_EQ(0u, matAddRow.rows());
+    EXPECT_EQ(0u, matAddRow.cols());
+    EXPECT_EQ(0u, matAddRow.numberOfNonZeros());
+    EXPECT_EQ(1u, matAddRow.rowPointersEnd() - matAddRow.rowPointersBegin());
+    EXPECT_EQ(0u, matAddRow.rowPointersBegin()[0]);
 }
 
 TEST(MatrixCsr, BinaryOperatorMethods) {
@@ -425,12 +433,11 @@ TEST(MatrixCsr, SetterOperators) {
     }
     matA2 *= matC2;
 
-    const MatrixCsrD ans2 = {
-            {175.0, 160.0, 145.0, 130.0, 115.0},
-            {550.0, 510.0, 470.0, 430.0, 390.0},
-            {925.0, 860.0, 795.0, 730.0, 665.0},
-            {1300.0, 1210.0, 1120.0, 1030.0, 940.0},
-            {1675.0, 1560.0, 1445.0, 1330.0, 1215.0}};
+    const MatrixCsrD ans2 = {{175.0, 160.0, 145.0, 130.0, 115.0},
+                             {550.0, 510.0, 470.0, 430.0, 390.0},
+                             {925.0, 860.0, 795.0, 730.0, 665.0},
+                             {1300.0, 1210.0, 1120.0, 1030.0, 940.0},
+                             {1675.0, 1560.0, 1445.0, 1330.0, 1215.0}};
     EXPECT_EQ(ans2, matA2);
 
     mat = matA;


### PR DESCRIPTION
This revision lets CSR matrix to be used for FDM solvers. This approach can save computational time when the fluid is occupying computational domain sparsely. Roughly, if the fluid volume is 25% of the entire domain, it can perform 2x faster than the grid-based matrix. Note that the existing FdmLinearSystem2 and 3 are also sparse matrices; The new linear system is a sparse matrix AND compressed by adapting to the fluid volume. We still leave this new linear system to be an option which is not turned on by default since it can consume more memory and time for typical situations and also not suitable for smoke simulations.