### PR TITLE
Fix missing logic in FDM gauss-seidel solver

### DIFF
--- a/src/jet/fdm_gauss_seidel_solver3.cpp
+++ b/src/jet/fdm_gauss_seidel_solver3.cpp
@@ -31,7 +31,11 @@ bool FdmGaussSeidelSolver3::solve(FdmLinearSystem3* system) {
     _lastNumberOfIterations = _maxNumberOfIterations;
 
     for (unsigned int iter = 0; iter < _maxNumberOfIterations; ++iter) {
-        relax(system->A, system->b, _sorFactor, &system->x);
+        if (_useRedBlackOrdering) {
+            relaxRedBlack(system->A, system->b, _sorFactor, &system->x);
+        } else {
+            relax(system->A, system->b, _sorFactor, &system->x);
+        }
 
         if (iter != 0 && iter % _residualCheckInterval == 0) {
             FdmBlas3::residual(system->A, system->x, system->b, &_residual);


### PR DESCRIPTION
Hello,

In FdmGaussSeidelSolver3::solve method, call relax function.
However, I think that the logic should be separated according to the variables that store whether or not to use red-black ordering like FdmGaussSeidelSolver2.