### PR TITLE
 Fix issue with anisotropic surface reconstruction 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,8 @@
 // Place your settings in this file to overwrite the default settings
 {
 	"editor.tabSize": 4,
-
 	"editor.insertSpaces": true,
-
 	"files.trimTrailingWhitespace": true,
-
-	"files.insertFinalNewline": false,
-
-    "C_Cpp.clang_format_style": "file",
-
-    "C_Cpp.clang_format_formatOnSave": true
+	"files.insertFinalNewline": true,
+	"C_Cpp.clang_format_style": "file"
 }

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -7,7 +7,11 @@ cd build
 cmake ..
 make
 bin/unit_tests
+if [[ "$unamestr" == 'Darwin' ]]; then
+    echo "Disabling pip test for macOS"
+else
 cd ..
-pip install --user -r requirements.txt
-pip install --user .
-python src/tests/python_tests/main.py
+    pip install --user -r requirements.txt
+    pip install --user .
+    python src/tests/python_tests/main.py
+fi

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -7,10 +7,12 @@ cd build
 cmake ..
 make
 bin/unit_tests
+
+unamestr=`uname`
 if [[ "$unamestr" == 'Darwin' ]]; then
     echo "Disabling pip test for macOS"
 else
-cd ..
+    cd ..
     pip install --user -r requirements.txt
     pip install --user .
     python src/tests/python_tests/main.py

--- a/src/jet/anisotropic_points_to_implicit2.cpp
+++ b/src/jet/anisotropic_points_to_implicit2.cpp
@@ -82,6 +82,8 @@ void AnisotropicPointsToImplicit2::convert(
         PointKdTreeSearcher2::builder().makeShared();
     meanNeighborSearcher->build(points);
 
+    JET_INFO << "Built neighbor searcher.";
+
     SphSystemData2 meanParticles;
     meanParticles.addParticles(points);
     meanParticles.setNeighborSearcher(meanNeighborSearcher);
@@ -150,6 +152,8 @@ void AnisotropicPointsToImplicit2::convert(
         }
     });
 
+    JET_INFO << "Computed G and means.";
+
     // SPH estimator
     meanParticles.setKernelRadius(h);
     meanParticles.updateDensities();
@@ -172,10 +176,16 @@ void AnisotropicPointsToImplicit2::convert(
         return _cutOffDensity - sum;
     });
 
+    JET_INFO << "Computed SDF.";
+
     if (_isOutputSdf) {
         FmmLevelSetSolver2 solver;
         solver.reinitialize(*temp, kMaxD, output);
+
+        JET_INFO << "Completed einitialization.";
     } else {
         temp->swap(output);
     }
+
+    JET_INFO << "Done converting points to implicit surface.";
 }

--- a/src/jet/anisotropic_points_to_implicit2.cpp
+++ b/src/jet/anisotropic_points_to_implicit2.cpp
@@ -138,11 +138,15 @@ void AnisotropicPointsToImplicit2::convert(
             Matrix2x2D w;
             svd(cov, u, v, w);
 
+            // Take off the sign
+            v.x = std::fabs(v.x);
+            v.y = std::fabs(v.y);
+
             // Constrain Sigma
-            const double maxSingularVal = v.absmax();
+            const double maxSingularVal = v.max();
             const double kr = 4.0;
-            v.x = sign(v.x) * absmax(v.x, maxSingularVal / kr);
-            v.y = sign(v.y) * absmax(v.y, maxSingularVal / kr);
+            v.x = std::max(v.x, maxSingularVal / kr);
+            v.y = std::max(v.y, maxSingularVal / kr);
             const auto invSigma = Matrix2x2D::makeScaleMatrix(1.0 / v);
 
             // Compute G

--- a/src/jet/anisotropic_points_to_implicit2.cpp
+++ b/src/jet/anisotropic_points_to_implicit2.cpp
@@ -139,14 +139,13 @@ void AnisotropicPointsToImplicit2::convert(
             // Constrain Sigma
             const double maxSingularVal = v.absmax();
             const double kr = 4.0;
-            v[0] = std::max(v[0], maxSingularVal / kr);
-            v[1] = std::max(v[1], maxSingularVal / kr);
+            v.x = sign(v.x) * absmax(v.x, maxSingularVal / kr);
+            v.y = sign(v.y) * absmax(v.y, maxSingularVal / kr);
             const auto invSigma = Matrix2x2D::makeScaleMatrix(1.0 / v);
 
             // Compute G
-            const double relA = v[0] * v[1];  // area preservation
-            const Matrix2x2D g =
-                invH * std::sqrt(relA) * (w * invSigma * u.transposed());
+            const double scale = std::sqrt(v.x * v.y);  // area preservation
+            const Matrix2x2D g = invH * scale * (w * invSigma * u.transposed());
             gs[i] = g;
         }
     });

--- a/src/jet/anisotropic_points_to_implicit3.cpp
+++ b/src/jet/anisotropic_points_to_implicit3.cpp
@@ -141,12 +141,17 @@ void AnisotropicPointsToImplicit3::convert(
             Matrix3x3D w;
             svd(cov, u, v, w);
 
+            // Take off the sign
+            v.x = std::fabs(v.x);
+            v.y = std::fabs(v.y);
+            v.z = std::fabs(v.z);
+
             // Constrain Sigma
-            const double maxSingularVal = v.absmax();
+            const double maxSingularVal = v.max();
             const double kr = 4.0;
-            v.x = sign(v.x) * absmax(v.x, maxSingularVal / kr);
-            v.y = sign(v.y) * absmax(v.y, maxSingularVal / kr);
-            v.z = sign(v.z) * absmax(v.z, maxSingularVal / kr);
+            v.x = std::max(v.x, maxSingularVal / kr);
+            v.y = std::max(v.y, maxSingularVal / kr);
+            v.z = std::max(v.z, maxSingularVal / kr);
 
             const auto invSigma = Matrix3x3D::makeScaleMatrix(1.0 / v);
 


### PR DESCRIPTION
This revision fixes Issue #130 which was caused by the singular value clamping (taking max instead of absmax). It also includes VSCode setting fix which was outdated.