### PR TITLE
Enable query engine update from collider

### DIFF
--- a/include/jet/implicit_surface_set2.h
+++ b/include/jet/implicit_surface_set2.h
@@ -41,6 +41,9 @@ class ImplicitSurfaceSet2 final : public ImplicitSurface2 {
     //! Copy constructor.
     ImplicitSurfaceSet2(const ImplicitSurfaceSet2& other);
 
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
+
     //! Returns the number of implicit surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/implicit_surface_set3.h
+++ b/include/jet/implicit_surface_set3.h
@@ -41,6 +41,9 @@ class ImplicitSurfaceSet3 final : public ImplicitSurface3 {
     //! Copy constructor.
     ImplicitSurfaceSet3(const ImplicitSurfaceSet3& other);
 
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
+
     //! Returns the number of implicit surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/surface2.h
+++ b/include/jet/surface2.h
@@ -63,6 +63,9 @@ class Surface2 {
     //! point \p otherPoint.
     Vector2D closestNormal(const Vector2D& otherPoint) const;
 
+    //! Updates internal spatial query engine.
+    virtual void updateQueryEngine();
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.

--- a/include/jet/surface3.h
+++ b/include/jet/surface3.h
@@ -63,6 +63,9 @@ class Surface3 {
     //! point \p otherPoint.
     Vector3D closestNormal(const Vector3D& otherPoint) const;
 
+    //! Updates internal spatial query engine.
+    virtual void updateQueryEngine();
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.

--- a/include/jet/surface_set2.h
+++ b/include/jet/surface_set2.h
@@ -36,6 +36,9 @@ class SurfaceSet2 final : public Surface2 {
     //! Copy constructor.
     SurfaceSet2(const SurfaceSet2& other);
 
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
+
     //! Returns the number of surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/surface_set3.h
+++ b/include/jet/surface_set3.h
@@ -36,6 +36,9 @@ class SurfaceSet3 final : public Surface3 {
     //! Copy constructor.
     SurfaceSet3(const SurfaceSet3& other);
 
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
+
     //! Returns the number of surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/triangle_mesh3.h
+++ b/include/jet/triangle_mesh3.h
@@ -38,23 +38,21 @@ class TriangleMesh3 final : public Surface3 {
     typedef Vector2DArray UvArray;
 
     //! Default constructor.
-    TriangleMesh3(
-        const Transform3& transform = Transform3(),
-        bool isNormalFlipped = false);
+    TriangleMesh3(const Transform3& transform = Transform3(),
+                  bool isNormalFlipped = false);
 
     //! Constructs mesh with points, normals, uvs, and their indices.
-    TriangleMesh3(
-        const PointArray& points,
-        const NormalArray& normals,
-        const UvArray& uvs,
-        const IndexArray& pointIndices,
-        const IndexArray& normalIndices,
-        const IndexArray& uvIndices,
-        const Transform3& transform_ = Transform3(),
-        bool isNormalFlipped = false);
+    TriangleMesh3(const PointArray& points, const NormalArray& normals,
+                  const UvArray& uvs, const IndexArray& pointIndices,
+                  const IndexArray& normalIndices, const IndexArray& uvIndices,
+                  const Transform3& transform_ = Transform3(),
+                  bool isNormalFlipped = false);
 
     //! Copy constructor.
     TriangleMesh3(const TriangleMesh3& other);
+
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
 
     //! Clears all content.
     void clear();
@@ -141,20 +139,17 @@ class TriangleMesh3 final : public Surface3 {
     void addPointTriangle(const Point3UI& newPointIndices);
 
     //! Adds a triangle with point and normal.
-    void addPointNormalTriangle(
-        const Point3UI& newPointIndices,
-        const Point3UI& newNormalIndices);
+    void addPointNormalTriangle(const Point3UI& newPointIndices,
+                                const Point3UI& newNormalIndices);
 
     //! Adds a triangle with point, normal, and UV.
-    void addPointUvNormalTriangle(
-        const Point3UI& newPointIndices,
-        const Point3UI& newUvIndices,
-        const Point3UI& newNormalIndices);
+    void addPointUvNormalTriangle(const Point3UI& newPointIndices,
+                                  const Point3UI& newUvIndices,
+                                  const Point3UI& newNormalIndices);
 
     //! Adds a triangle with point and UV.
-    void addPointUvTriangle(
-        const Point3UI& newPointIndices,
-        const Point3UI& newUvIndices);
+    void addPointUvTriangle(const Point3UI& newPointIndices,
+                            const Point3UI& newUvIndices);
 
     //! Add a triangle.
     void addTriangle(const Triangle3& tri);
@@ -224,7 +219,6 @@ class TriangleMesh3 final : public Surface3 {
 
 //! Shared pointer for the TriangleMesh3 type.
 typedef std::shared_ptr<TriangleMesh3> TriangleMesh3Ptr;
-
 
 //!
 //! \brief Front-end to create TriangleMesh3 objects step by step.

--- a/src/jet/collider2.cpp
+++ b/src/jet/collider2.cpp
@@ -5,22 +5,19 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/collider2.h>
+
 #include <algorithm>
 
 using namespace jet;
 
-Collider2::Collider2() {
-}
+Collider2::Collider2() {}
 
-Collider2::~Collider2() {
-}
+Collider2::~Collider2() {}
 
-void Collider2::resolveCollision(
-    double radius,
-    double restitutionCoefficient,
-    Vector2D* newPosition,
-    Vector2D* newVelocity) {
+void Collider2::resolveCollision(double radius, double restitutionCoefficient,
+                                 Vector2D* newPosition, Vector2D* newVelocity) {
     ColliderQueryResult colliderPoint;
 
     getClosestPoint(_surface, *newPosition, &colliderPoint);
@@ -44,8 +41,8 @@ void Collider2::resolveCollision(
         if (normalDotRelativeVel < 0.0) {
             // Apply restitution coefficient to the surface normal component of
             // the velocity
-            Vector2D deltaRelativeVelN
-                = (-restitutionCoefficient - 1.0) * relativeVelN;
+            Vector2D deltaRelativeVelN =
+                (-restitutionCoefficient - 1.0) * relativeVelN;
             relativeVelN *= -restitutionCoefficient;
 
             // Apply friction to the tangential component of the velocity
@@ -53,18 +50,16 @@ void Collider2::resolveCollision(
             // Friction for Cloth Animation, 2002
             // http://graphics.stanford.edu/papers/cloth-sig02/cloth.pdf
             if (relativeVelT.lengthSquared() > 0.0) {
-                double frictionScale
-                    = std::max(
-                        1.0
-                        - _frictionCoeffient
-                            * deltaRelativeVelN.length()
-                            / relativeVelT.length(), 0.0);
+                double frictionScale = std::max(
+                    1.0 - _frictionCoeffient * deltaRelativeVelN.length() /
+                              relativeVelT.length(),
+                    0.0);
                 relativeVelT *= frictionScale;
             }
 
             // Reassemble the components
-            *newVelocity
-                = relativeVelN + relativeVelT + colliderVelAtTargetPoint;
+            *newVelocity =
+                relativeVelN + relativeVelT + colliderVelAtTargetPoint;
         }
 
         // Geometric fix
@@ -72,46 +67,40 @@ void Collider2::resolveCollision(
     }
 }
 
-double Collider2::frictionCoefficient() const {
-    return _frictionCoeffient;
-}
+double Collider2::frictionCoefficient() const { return _frictionCoeffient; }
 
 void Collider2::setFrictionCoefficient(double newFrictionCoeffient) {
     _frictionCoeffient = std::max(newFrictionCoeffient, 0.0);
 }
 
-const Surface2Ptr& Collider2::surface() const {
-    return _surface;
-}
+const Surface2Ptr& Collider2::surface() const { return _surface; }
 
 void Collider2::setSurface(const Surface2Ptr& newSurface) {
     _surface = newSurface;
 }
 
-void Collider2::getClosestPoint(
-    const Surface2Ptr& surface,
-    const Vector2D& queryPoint,
-    ColliderQueryResult* result) const {
+void Collider2::getClosestPoint(const Surface2Ptr& surface,
+                                const Vector2D& queryPoint,
+                                ColliderQueryResult* result) const {
     result->distance = surface->closestDistance(queryPoint);
     result->point = surface->closestPoint(queryPoint);
     result->normal = surface->closestNormal(queryPoint);
     result->velocity = velocityAt(queryPoint);
 }
 
-bool Collider2::isPenetrating(
-    const ColliderQueryResult& colliderPoint,
-    const Vector2D& position,
-    double radius) {
+bool Collider2::isPenetrating(const ColliderQueryResult& colliderPoint,
+                              const Vector2D& position, double radius) {
     // If the new candidate position of the particle is on the other side of
     // the surface OR the new distance to the surface is less than the
     // particle's radius, this particle is in colliding state.
     return (position - colliderPoint.point).dot(colliderPoint.normal) < 0.0 ||
-        colliderPoint.distance < radius;
+           colliderPoint.distance < radius;
 }
 
-void Collider2::update(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void Collider2::update(double currentTimeInSeconds,
+                       double timeIntervalInSeconds) {
+    _surface->updateQueryEngine();
+
     if (_onUpdateCallback) {
         _onUpdateCallback(this, currentTimeInSeconds, timeIntervalInSeconds);
     }

--- a/src/jet/collider3.cpp
+++ b/src/jet/collider3.cpp
@@ -5,22 +5,19 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/collider3.h>
+
 #include <algorithm>
 
 using namespace jet;
 
-Collider3::Collider3() {
-}
+Collider3::Collider3() {}
 
-Collider3::~Collider3() {
-}
+Collider3::~Collider3() {}
 
-void Collider3::resolveCollision(
-    double radius,
-    double restitutionCoefficient,
-    Vector3D* newPosition,
-    Vector3D* newVelocity) {
+void Collider3::resolveCollision(double radius, double restitutionCoefficient,
+                                 Vector3D* newPosition, Vector3D* newVelocity) {
     ColliderQueryResult colliderPoint;
 
     getClosestPoint(_surface, *newPosition, &colliderPoint);
@@ -44,8 +41,8 @@ void Collider3::resolveCollision(
         if (normalDotRelativeVel < 0.0) {
             // Apply restitution coefficient to the surface normal component of
             // the velocity
-            Vector3D deltaRelativeVelN
-                = (-restitutionCoefficient - 1.0) * relativeVelN;
+            Vector3D deltaRelativeVelN =
+                (-restitutionCoefficient - 1.0) * relativeVelN;
             relativeVelN *= -restitutionCoefficient;
 
             // Apply friction to the tangential component of the velocity
@@ -53,18 +50,16 @@ void Collider3::resolveCollision(
             // Friction for Cloth Animation, 2002
             // http://graphics.stanford.edu/papers/cloth-sig02/cloth.pdf
             if (relativeVelT.lengthSquared() > 0.0) {
-                double frictionScale
-                    = std::max(
-                        1.0
-                        - _frictionCoeffient
-                            * deltaRelativeVelN.length()
-                            / relativeVelT.length(), 0.0);
+                double frictionScale = std::max(
+                    1.0 - _frictionCoeffient * deltaRelativeVelN.length() /
+                              relativeVelT.length(),
+                    0.0);
                 relativeVelT *= frictionScale;
             }
 
             // Reassemble the components
-            *newVelocity
-                = relativeVelN + relativeVelT + colliderVelAtTargetPoint;
+            *newVelocity =
+                relativeVelN + relativeVelT + colliderVelAtTargetPoint;
         }
 
         // Geometric fix
@@ -72,46 +67,40 @@ void Collider3::resolveCollision(
     }
 }
 
-double Collider3::frictionCoefficient() const {
-    return _frictionCoeffient;
-}
+double Collider3::frictionCoefficient() const { return _frictionCoeffient; }
 
 void Collider3::setFrictionCoefficient(double newFrictionCoeffient) {
     _frictionCoeffient = std::max(newFrictionCoeffient, 0.0);
 }
 
-const Surface3Ptr& Collider3::surface() const {
-    return _surface;
-}
+const Surface3Ptr& Collider3::surface() const { return _surface; }
 
 void Collider3::setSurface(const Surface3Ptr& newSurface) {
     _surface = newSurface;
 }
 
-void Collider3::getClosestPoint(
-    const Surface3Ptr& surface,
-    const Vector3D& queryPoint,
-    ColliderQueryResult* result) const {
+void Collider3::getClosestPoint(const Surface3Ptr& surface,
+                                const Vector3D& queryPoint,
+                                ColliderQueryResult* result) const {
     result->distance = surface->closestDistance(queryPoint);
     result->point = surface->closestPoint(queryPoint);
     result->normal = surface->closestNormal(queryPoint);
     result->velocity = velocityAt(queryPoint);
 }
 
-bool Collider3::isPenetrating(
-    const ColliderQueryResult& colliderPoint,
-    const Vector3D& position,
-    double radius) {
+bool Collider3::isPenetrating(const ColliderQueryResult& colliderPoint,
+                              const Vector3D& position, double radius) {
     // If the new candidate position of the particle is on the other side of
     // the surface OR the new distance to the surface is less than the
     // particle's radius, this particle is in colliding state.
     return (position - colliderPoint.point).dot(colliderPoint.normal) < 0.0 ||
-        colliderPoint.distance < radius;
+           colliderPoint.distance < radius;
 }
 
-void Collider3::update(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void Collider3::update(double currentTimeInSeconds,
+                       double timeIntervalInSeconds) {
+    _surface->updateQueryEngine();
+
     if (_onUpdateCallback) {
         _onUpdateCallback(this, currentTimeInSeconds, timeIntervalInSeconds);
     }

--- a/src/jet/implicit_surface_set2.cpp
+++ b/src/jet/implicit_surface_set2.cpp
@@ -30,6 +30,8 @@ ImplicitSurfaceSet2::ImplicitSurfaceSet2(
 ImplicitSurfaceSet2::ImplicitSurfaceSet2(const ImplicitSurfaceSet2& other)
     : ImplicitSurface2(other), _surfaces(other._surfaces) {}
 
+void ImplicitSurfaceSet2::updateQueryEngine() { buildBvh(); }
+
 size_t ImplicitSurfaceSet2::numberOfSurfaces() const {
     return _surfaces.size();
 }

--- a/src/jet/implicit_surface_set3.cpp
+++ b/src/jet/implicit_surface_set3.cpp
@@ -30,6 +30,8 @@ ImplicitSurfaceSet3::ImplicitSurfaceSet3(
 ImplicitSurfaceSet3::ImplicitSurfaceSet3(const ImplicitSurfaceSet3& other)
     : ImplicitSurface3(other), _surfaces(other._surfaces) {}
 
+void ImplicitSurfaceSet3::updateQueryEngine() { buildBvh(); }
+
 size_t ImplicitSurfaceSet3::numberOfSurfaces() const {
     return _surfaces.size();
 }

--- a/src/jet/surface2.cpp
+++ b/src/jet/surface2.cpp
@@ -5,23 +5,20 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/surface2.h>
+
 #include <algorithm>
 
 using namespace jet;
 
 Surface2::Surface2(const Transform2& transform_, bool isNormalFlipped_)
-: transform(transform_)
-, isNormalFlipped(isNormalFlipped_) {
-}
+    : transform(transform_), isNormalFlipped(isNormalFlipped_) {}
 
 Surface2::Surface2(const Surface2& other)
-: transform(other.transform)
-, isNormalFlipped(other.isNormalFlipped) {
-}
+    : transform(other.transform), isNormalFlipped(other.isNormalFlipped) {}
 
-Surface2::~Surface2() {
-}
+Surface2::~Surface2() {}
 
 Vector2D Surface2::closestPoint(const Vector2D& otherPoint) const {
     return transform.toWorld(closestPointLocal(transform.toLocal(otherPoint)));
@@ -52,6 +49,10 @@ Vector2D Surface2::closestNormal(const Vector2D& otherPoint) const {
         closestNormalLocal(transform.toLocal(otherPoint)));
     result *= (isNormalFlipped) ? -1.0 : 1.0;
     return result;
+}
+
+void Surface2::updateQueryEngine() {
+    // Do nothing
 }
 
 bool Surface2::intersectsLocal(const Ray2D& rayLocal) const {

--- a/src/jet/surface3.cpp
+++ b/src/jet/surface3.cpp
@@ -5,23 +5,20 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/surface3.h>
+
 #include <algorithm>
 
 using namespace jet;
 
 Surface3::Surface3(const Transform3& transform_, bool isNormalFlipped_)
-: transform(transform_)
-, isNormalFlipped(isNormalFlipped_) {
-}
+    : transform(transform_), isNormalFlipped(isNormalFlipped_) {}
 
 Surface3::Surface3(const Surface3& other)
-: transform(other.transform)
-, isNormalFlipped(other.isNormalFlipped) {
-}
+    : transform(other.transform), isNormalFlipped(other.isNormalFlipped) {}
 
-Surface3::~Surface3() {
-}
+Surface3::~Surface3() {}
 
 Vector3D Surface3::closestPoint(const Vector3D& otherPoint) const {
     return transform.toWorld(closestPointLocal(transform.toLocal(otherPoint)));
@@ -57,6 +54,10 @@ Vector3D Surface3::closestNormal(const Vector3D& otherPoint) const {
 bool Surface3::intersectsLocal(const Ray3D& rayLocal) const {
     auto result = closestIntersectionLocal(rayLocal);
     return result.isIntersecting;
+}
+
+void Surface3::updateQueryEngine() {
+    // Do nothing
 }
 
 double Surface3::closestDistanceLocal(const Vector3D& otherPointLocal) const {

--- a/src/jet/surface_set2.cpp
+++ b/src/jet/surface_set2.cpp
@@ -14,14 +14,16 @@ SurfaceSet2::SurfaceSet2() {}
 
 SurfaceSet2::SurfaceSet2(const std::vector<Surface2Ptr>& others,
                          const Transform2& transform, bool isNormalFlipped)
-        : Surface2(transform, isNormalFlipped), _surfaces(others) {
+    : Surface2(transform, isNormalFlipped), _surfaces(others) {
     invalidateBvh();
 }
 
 SurfaceSet2::SurfaceSet2(const SurfaceSet2& other)
-        : Surface2(other), _surfaces(other._surfaces) {
+    : Surface2(other), _surfaces(other._surfaces) {
     invalidateBvh();
 }
+
+void SurfaceSet2::updateQueryEngine() { buildBvh(); }
 
 size_t SurfaceSet2::numberOfSurfaces() const { return _surfaces.size(); }
 
@@ -81,7 +83,7 @@ bool SurfaceSet2::intersectsLocal(const Ray2D& ray) const {
 }
 
 SurfaceRayIntersection2 SurfaceSet2::closestIntersectionLocal(
-        const Ray2D& ray) const {
+    const Ray2D& ray) const {
     buildBvh();
 
     const auto testFunc = [](const Surface2Ptr& surface, const Ray2D& ray) {
@@ -124,7 +126,7 @@ void SurfaceSet2::buildBvh() const {
 SurfaceSet2::Builder SurfaceSet2::builder() { return Builder(); }
 
 SurfaceSet2::Builder& SurfaceSet2::Builder::withSurfaces(
-        const std::vector<Surface2Ptr>& others) {
+    const std::vector<Surface2Ptr>& others) {
     _surfaces = others;
     return *this;
 }
@@ -135,6 +137,6 @@ SurfaceSet2 SurfaceSet2::Builder::build() const {
 
 SurfaceSet2Ptr SurfaceSet2::Builder::makeShared() const {
     return std::shared_ptr<SurfaceSet2>(
-            new SurfaceSet2(_surfaces, _transform, _isNormalFlipped),
-            [](SurfaceSet2* obj) { delete obj; });
+        new SurfaceSet2(_surfaces, _transform, _isNormalFlipped),
+        [](SurfaceSet2* obj) { delete obj; });
 }

--- a/src/jet/surface_set3.cpp
+++ b/src/jet/surface_set3.cpp
@@ -23,6 +23,8 @@ SurfaceSet3::SurfaceSet3(const SurfaceSet3& other)
     invalidateBvh();
 }
 
+void SurfaceSet3::updateQueryEngine() { buildBvh(); }
+
 size_t SurfaceSet3::numberOfSurfaces() const { return _surfaces.size(); }
 
 const Surface3Ptr& SurfaceSet3::surfaceAt(size_t i) const {

--- a/src/jet/triangle_mesh3.cpp
+++ b/src/jet/triangle_mesh3.cpp
@@ -48,6 +48,8 @@ TriangleMesh3::TriangleMesh3(const TriangleMesh3& other) : Surface3(other) {
     set(other);
 }
 
+void TriangleMesh3::updateQueryEngine() { buildBvh(); }
+
 Vector3D TriangleMesh3::closestPointLocal(const Vector3D& otherPoint) const {
     buildBvh();
 
@@ -69,7 +71,7 @@ Vector3D TriangleMesh3::closestNormalLocal(const Vector3D& otherPoint) const {
     };
 
     const auto queryResult = _bvh.nearest(otherPoint, distanceFunc);
-//    printf("%zu\n", *queryResult.item);
+    //    printf("%zu\n", *queryResult.item);
     return triangle(*queryResult.item).closestNormal(otherPoint);
 }
 


### PR DESCRIPTION
Without this feature, making any spatial query from "set" type surfaces from parallel execution context will cause race condition. This is originally reported by https://github.com/utilForever/CubbyFlow/issues/217. Introducing mutex could be a natural solution, but that requires heavy assumption on the parallel executer (which is currently std::thread at the moment) which is not ideal -- it can be OpenMP, TBB, PPL, pthread, etc.  In the near future, however, thread-safety-ness should be well documented for the public APIs.