### PR TITLE
Support for multiple tasking systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     include_directories(src/winix)
 endif()
 
+# Configure tasking system backend
+include(cmake/TaskingSystemOptions.cmake)
+
 # Compile options
 include(cmake/CompileOptions.cmake)
 

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -35,7 +35,11 @@ set(DEFAULT_INCLUDE_DIRECTORIES)
 # Libraries
 #
 
-set(DEFAULT_LIBRARIES)
+set(DEFAULT_LIBRARIES
+  PUBLIC
+  ${TASKING_SYSTEM_LIBS}
+  PRIVATE
+)
 
 
 #
@@ -93,7 +97,7 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
         -Wall
-        -Werror
+        #-Werror
 
         # Required for CMake < 3.1; should be removed if minimum required CMake version is raised.
         $<$<VERSION_LESS:${CMAKE_VERSION},3.1>:

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -3,7 +3,7 @@
 # Platform and architecture setup
 #
 
-option(JET_WARNINGS_AS_ERRORS OFF)
+option(JET_WARNINGS_AS_ERRORS ON)
 if(JET_WARNINGS_AS_ERRORS)
     if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         set(WARN_AS_ERROR_FLAGS "/WX")

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -3,6 +3,15 @@
 # Platform and architecture setup
 #
 
+option(JET_WARNINGS_AS_ERRORS OFF)
+if(JET_WARNINGS_AS_ERRORS)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set(WARN_AS_ERROR_FLAGS "/WX")
+    else()
+        set(WARN_AS_ERROR_FLAGS "-Werror")
+    endif()
+endif()
+
 # Get upper case system name
 string(TOUPPER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME_UPPER)
 
@@ -70,7 +79,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
         /MP           # -> build with multiple processes
         /W4           # -> warning level 4
-        /WX           # -> treat warnings as errors
+        ${WARN_AS_ERROR_FLAGS}
 
         # /wd4251       # -> disable warning: 'identifier': class 'type' needs to have dll-interface to be used by clients of class 'type2'
         # /wd4592       # -> disable warning: 'identifier': symbol will be dynamically initialized (implementation limitation)
@@ -97,7 +106,7 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
         -Wall
-        #-Werror
+        ${WARN_AS_ERROR_FLAGS}
 
         # Required for CMake < 3.1; should be removed if minimum required CMake version is raised.
         $<$<VERSION_LESS:${CMAKE_VERSION},3.1>:

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -108,8 +108,7 @@ set(TBB_ROOT_LAST ${TBB_ROOT} CACHE INTERNAL "Last value of TBB_ROOT to detect c
 
 set(TBB_ERROR_MESSAGE
   "Threading Building Blocks (TBB) with minimum version ${TBB_VERSION_REQUIRED} not found.
-Jet uses TBB as default tasking system. Please make sure you have the TBB headers installed as well (the package is typically named 'libtbb-dev' or 'tbb-devel') and/or hint the location of TBB in TBB_ROOT.
-Alternatively, you can try to use OpenMP as tasking system by setting JET_TASKING_SYSTEM=OpenMP")
+Please make sure you have the TBB headers installed as well (the package is typically named 'libtbb-dev' or 'tbb-devel') and/or hint the location of TBB in TBB_ROOT. Alternatively, you can try to use OpenMP as tasking system by setting JET_TASKING_SYSTEM=OpenMP or C++11 threads using JET_TASKING_SYSTEM=CPP11Threads")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(TBB

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -1,0 +1,163 @@
+
+#
+# Find TBB
+#
+
+set(TBB_VERSION_REQUIRED "2.0")
+
+if (NOT TBB_ROOT)
+  set(TBB_ROOT $ENV{TBB_ROOT})
+endif()
+if (NOT TBB_ROOT)
+  set(TBB_ROOT $ENV{TBBROOT})
+endif()
+
+# detect changed TBB_ROOT
+if (NOT TBB_ROOT STREQUAL TBB_ROOT_LAST)
+  unset(TBB_INCLUDE_DIR CACHE)
+  unset(TBB_LIBRARY CACHE)
+  unset(TBB_LIBRARY_DEBUG CACHE)
+  unset(TBB_LIBRARY_MALLOC CACHE)
+  unset(TBB_LIBRARY_MALLOC_DEBUG CACHE)
+  unset(TBB_INCLUDE_DIR_MIC CACHE)
+  unset(TBB_LIBRARY_MIC CACHE)
+  unset(TBB_LIBRARY_MALLOC_MIC CACHE)
+endif()
+
+if (WIN32)
+  # workaround for parentheses in variable name / CMP0053
+  set(PROGRAMFILESx86 "PROGRAMFILES(x86)")
+  set(PROGRAMFILES32 "$ENV{${PROGRAMFILESx86}}")
+  if (NOT PROGRAMFILES32)
+    set(PROGRAMFILES32 "$ENV{PROGRAMFILES}")
+  endif()
+  if (NOT PROGRAMFILES32)
+    set(PROGRAMFILES32 "C:/Program Files (x86)")
+  endif()
+  find_path(TBB_ROOT include/tbb/task_scheduler_init.h
+    DOC "Root of TBB installation"
+    HINTS ${TBB_ROOT}
+    PATHS
+      ${PROJECT_SOURCE_DIR}/tbb
+      ${PROJECT_SOURCE_DIR}/../tbb
+      "${PROGRAMFILES32}/IntelSWTools/compilers_and_libraries/windows/tbb"
+      "${PROGRAMFILES32}/Intel/Composer XE/tbb"
+      "${PROGRAMFILES32}/Intel/compilers_and_libraries/windows/tbb"
+  )
+
+  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(TBB_ARCH intel64)
+  else()
+    set(TBB_ARCH ia32)
+  endif()
+
+  if (MSVC10)
+    set(TBB_VCVER vc10)
+  elseif (MSVC11)
+    set(TBB_VCVER vc11)
+  elseif (MSVC12)
+    set(TBB_VCVER vc12)
+  else()
+    set(TBB_VCVER vc14)
+  endif()
+
+  set(TBB_LIBDIR ${TBB_ROOT}/lib/${TBB_ARCH}/${TBB_VCVER})
+  set(TBB_BINDIR ${TBB_ROOT}/bin/${TBB_ARCH}/${TBB_VCVER})
+
+  find_path(TBB_INCLUDE_DIR tbb/task_scheduler_init.h PATHS ${TBB_ROOT}/include NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY tbb PATHS ${TBB_LIBDIR} NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY_DEBUG tbb_debug PATHS ${TBB_LIBDIR} NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY_MALLOC tbbmalloc PATHS ${TBB_LIBDIR} NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY_MALLOC_DEBUG tbbmalloc_debug PATHS ${TBB_LIBDIR} NO_DEFAULT_PATH)
+
+else ()
+
+  find_path(TBB_ROOT include/tbb/task_scheduler_init.h
+    DOC "Root of TBB installation"
+    HINTS ${TBB_ROOT}
+    PATHS
+      ${PROJECT_SOURCE_DIR}/tbb
+      /opt/intel/composerxe/tbb
+      /opt/intel/compilers_and_libraries/tbb
+  )
+
+  if (APPLE)
+    find_path(TBB_INCLUDE_DIR tbb/task_scheduler_init.h PATHS ${TBB_ROOT}/include NO_DEFAULT_PATH)
+    find_library(TBB_LIBRARY tbb PATHS ${TBB_ROOT}/lib NO_DEFAULT_PATH)
+    find_library(TBB_LIBRARY_DEBUG tbb_debug PATHS ${TBB_ROOT}/lib NO_DEFAULT_PATH)
+    find_library(TBB_LIBRARY_MALLOC tbbmalloc PATHS ${TBB_ROOT}/lib NO_DEFAULT_PATH)
+    find_library(TBB_LIBRARY_MALLOC_DEBUG tbbmalloc_debug PATHS ${TBB_ROOT}/lib NO_DEFAULT_PATH)
+  else()
+    find_path(TBB_INCLUDE_DIR tbb/task_scheduler_init.h PATHS ${TBB_ROOT}/include NO_DEFAULT_PATH)
+    find_library(TBB_LIBRARY libtbb.so.2 HINTS ${TBB_ROOT}/lib/intel64/gcc4.4)
+    find_library(TBB_LIBRARY_DEBUG libtbb_debug.so.2 HINTS ${TBB_ROOT}/lib/intel64/gcc4.4)
+    find_library(TBB_LIBRARY_MALLOC libtbbmalloc.so.2 HINTS ${TBB_ROOT}/lib/intel64/gcc4.4)
+    find_library(TBB_LIBRARY_MALLOC_DEBUG libtbbmalloc_debug.so.2 HINTS ${TBB_ROOT}/lib/intel64/gcc4.4)
+  endif()
+
+  find_path(TBB_INCLUDE_DIR_MIC tbb/task_scheduler_init.h PATHS ${TBB_ROOT}/include NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY_MIC libtbb.so.2 PATHS ${TBB_ROOT}/lib/mic NO_DEFAULT_PATH)
+  find_library(TBB_LIBRARY_MALLOC_MIC libtbbmalloc.so.2 PATHS ${TBB_ROOT}/lib/mic NO_DEFAULT_PATH)
+
+  mark_as_advanced(TBB_INCLUDE_DIR_MIC)
+  mark_as_advanced(TBB_LIBRARY_MIC)
+  mark_as_advanced(TBB_LIBRARY_MALLOC_MIC)
+endif()
+
+set(TBB_ROOT_LAST ${TBB_ROOT} CACHE INTERNAL "Last value of TBB_ROOT to detect changes")
+
+set(TBB_ERROR_MESSAGE
+  "Threading Building Blocks (TBB) with minimum version ${TBB_VERSION_REQUIRED} not found.
+Jet uses TBB as default tasking system. Please make sure you have the TBB headers installed as well (the package is typically named 'libtbb-dev' or 'tbb-devel') and/or hint the location of TBB in TBB_ROOT.
+Alternatively, you can try to use OpenMP as tasking system by setting JET_TASKING_SYSTEM=OpenMP")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+  ${TBB_ERROR_MESSAGE}
+  TBB_INCLUDE_DIR TBB_LIBRARY TBB_LIBRARY_MALLOC
+)
+
+# check version
+if (TBB_INCLUDE_DIR)
+  file(READ ${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h TBB_STDDEF_H)
+
+  string(REGEX MATCH "#define TBB_VERSION_MAJOR ([0-9])" DUMMY "${TBB_STDDEF_H}")
+  set(TBB_VERSION_MAJOR ${CMAKE_MATCH_1})
+
+  string(REGEX MATCH "#define TBB_VERSION_MINOR ([0-9])" DUMMY "${TBB_STDDEF_H}")
+  set(TBB_VERSION "${TBB_VERSION_MAJOR}.${CMAKE_MATCH_1}")
+
+  if (TBB_VERSION VERSION_LESS TBB_VERSION_REQUIRED)
+    message(FATAL_ERROR ${TBB_ERROR_MESSAGE})
+  endif()
+
+  set(TBB_VERSION ${TBB_VERSION} CACHE STRING "TBB Version")
+  mark_as_advanced(TBB_VERSION)
+endif()
+
+if (TBB_FOUND)
+  set(TBB_INCLUDE_DIRS ${TBB_INCLUDE_DIR})
+  # NOTE(jda) - TBB found in CentOS 6/7 package manager does not have debug
+  #             versions of the library...silently fall-back to using only the
+  #             libraries which we actually found.
+  if (NOT TBB_LIBRARY_DEBUG)
+    set(TBB_LIBRARIES ${TBB_LIBRARY} ${TBB_LIBRARY_MALLOC})
+  else ()
+    set(TBB_LIBRARIES
+        optimized ${TBB_LIBRARY} optimized ${TBB_LIBRARY_MALLOC}
+        debug ${TBB_LIBRARY_DEBUG} debug ${TBB_LIBRARY_MALLOC_DEBUG}
+    )
+  endif()
+endif()
+
+if (TBB_INCLUDE_DIR AND TBB_LIBRARY_MIC AND TBB_LIBRARY_MALLOC_MIC)
+  set(TBB_FOUND_MIC TRUE)
+  set(TBB_INCLUDE_DIRS_MIC ${TBB_INCLUDE_DIR_MIC})
+  set(TBB_LIBRARIES_MIC ${TBB_LIBRARY_MIC} ${TBB_LIBRARY_MALLOC_MIC})
+endif()
+
+mark_as_advanced(TBB_INCLUDE_DIR)
+mark_as_advanced(TBB_LIBRARY)
+mark_as_advanced(TBB_LIBRARY_DEBUG)
+mark_as_advanced(TBB_LIBRARY_MALLOC)
+mark_as_advanced(TBB_LIBRARY_MALLOC_DEBUG)

--- a/cmake/TaskingSystemOptions.cmake
+++ b/cmake/TaskingSystemOptions.cmake
@@ -3,7 +3,24 @@
 # Setup tasking system build configuration
 #
 
-set(JET_TASKING_SYSTEM CPP11Threads CACHE STRING
+# Determine the best default option for tasking system backend
+if(NOT DEFINED JET_TASKING_SYSTEM)
+  find_package(TBB QUIET)
+  if(TBB_FOUND)
+    set(TASKING_DEFAULT TBB)
+  else()
+    find_package(OpenMP QUIET)
+    if(OpenMP_FOUND)
+      set(TASKING_DEFAULT OpenMP)
+    else()
+      set(TASKING_DEFAULT CPP11Threads)
+    endif()
+  endif()
+else()
+  set(TASKING_DEFAULT ${JET_TASKING_SYSTEM})
+endif()
+
+set(JET_TASKING_SYSTEM ${TASKING_DEFAULT} CACHE STRING
     "Per-node thread tasking system [CPP11Threads,TBB,OpenMP,Serial]")
 
 set_property(CACHE JET_TASKING_SYSTEM PROPERTY

--- a/cmake/TaskingSystemOptions.cmake
+++ b/cmake/TaskingSystemOptions.cmake
@@ -1,0 +1,62 @@
+
+#
+# Setup tasking system build configuration
+#
+
+set(JET_TASKING_SYSTEM CPP11Threads CACHE STRING
+    "Per-node thread tasking system [CPP11Threads,TBB,OpenMP,Serial]")
+
+set_property(CACHE JET_TASKING_SYSTEM PROPERTY
+             STRINGS CPP11Threads TBB OpenMP Serial)
+
+# NOTE(jda) - Make the JET_TASKING_SYSTEM build option case-insensitive
+string(TOUPPER ${JET_TASKING_SYSTEM} JET_TASKING_SYSTEM_ID)
+
+set(JET_TASKING_TBB          FALSE)
+set(JET_TASKING_OPENMP       FALSE)
+set(JET_TASKING_CPP11THREADS FALSE)
+set(JET_TASKING_SERIAL       FALSE)
+
+if(${JET_TASKING_SYSTEM_ID} STREQUAL "TBB")
+  set(JET_TASKING_TBB TRUE)
+elseif(${JET_TASKING_SYSTEM_ID} STREQUAL "OPENMP")
+  set(JET_TASKING_OPENMP TRUE)
+elseif(${JET_TASKING_SYSTEM_ID} STREQUAL "CPP11THREADS")
+  set(JET_TASKING_CPP11THREADS TRUE)
+else()
+  set(JET_TASKING_SERIAL TRUE)
+endif()
+
+unset(TASKING_SYSTEM_LIBS)
+unset(TASKING_SYSTEM_LIBS_MIC)
+
+if(JET_TASKING_TBB)
+  find_package(TBB REQUIRED)
+  add_definitions(-DJET_TASKING_TBB)
+  include_directories(${TBB_INCLUDE_DIRS})
+  set(TASKING_SYSTEM_LIBS ${TBB_LIBRARIES})
+  set(TASKING_SYSTEM_LIBS_MIC ${TBB_LIBRARIES_MIC})
+else()
+  unset(TBB_INCLUDE_DIR          CACHE)
+  unset(TBB_LIBRARY              CACHE)
+  unset(TBB_LIBRARY_DEBUG        CACHE)
+  unset(TBB_LIBRARY_MALLOC       CACHE)
+  unset(TBB_LIBRARY_MALLOC_DEBUG CACHE)
+  unset(TBB_INCLUDE_DIR_MIC      CACHE)
+  unset(TBB_LIBRARY_MIC          CACHE)
+  unset(TBB_LIBRARY_MALLOC_MIC   CACHE)
+  if(JET_TASKING_OPENMP)
+    find_package(OpenMP)
+    if(OPENMP_FOUND)
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+      set(CMAKE_EXE_LINKER_FLAGS
+          "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+      add_definitions(-DJET_TASKING_OPENMP)
+    endif()
+  elseif(JET_TASKING_CPP11THREADS)
+      add_definitions(-DJET_TASKING_CPP11THREADS)
+  else()#Serial
+    # Do nothing, will fall back to scalar code (useful for debugging)
+  endif()
+endif()

--- a/include/jet/detail/parallel-inl.h
+++ b/include/jet/detail/parallel-inl.h
@@ -171,6 +171,8 @@ void parallelFor(IndexType start, IndexType end, const Function& func,
     }
 
 #ifdef JET_TASKING_TBB
+    (void)policy;
+
     tbb::parallel_for(start, end, func);
 #elif JET_TASKING_CPP11THREADS
     // Estimate number of threads in the pool
@@ -214,6 +216,9 @@ void parallelFor(IndexType start, IndexType end, const Function& func,
         }
     }
 #else
+
+    (void)policy;
+
 #  ifdef JET_TASKING_OPENMP
 #    pragma omp parallel for
 #    if defined(_MSC_VER) && !defined(__INTEL_COMPILER)

--- a/include/jet/detail/parallel-inl.h
+++ b/include/jet/detail/parallel-inl.h
@@ -32,8 +32,7 @@ namespace internal {
 template<typename TASK_T>
 inline void schedule(TASK_T&& fcn) {
 #ifdef JET_TASKING_TBB
-    struct LocalTBBTask : public tbb::task
-    {
+    struct LocalTBBTask : public tbb::task {
         TASK_T func;
         tbb::task* execute() override { func(); return nullptr; }
         LocalTBBTask(TASK_T&& f) : func(std::forward<TASK_T>(f)) {}

--- a/include/jet/detail/parallel-inl.h
+++ b/include/jet/detail/parallel-inl.h
@@ -216,10 +216,18 @@ void parallelFor(IndexType start, IndexType end, const Function& func,
 #else
 #  ifdef JET_TASKING_OPENMP
 #    pragma omp parallel for
-#  endif
+#    if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+    for (ssize_t i = start; i < ssize_t(end); ++i) {
+#    else // !MSVC || Intel
+    for (auto i = start; i < end; ++i) {
+#    endif // MSVC && !Intel
+      func(i);
+    }
+#  else // JET_TASKING_OPENMP
     for (auto i = start; i < end; ++i) {
       func(i);
     }
+#  endif // JET_TASKING_OPENMP
 #endif
 }
 

--- a/include/jet/detail/parallel-inl.h
+++ b/include/jet/detail/parallel-inl.h
@@ -12,12 +12,59 @@
 
 #include <algorithm>
 #include <functional>
-#include <thread>
+#include <future>
 #include <vector>
+
+#ifdef JET_TASKING_TBB
+#  include <tbb/parallel_for.h>
+#  include <tbb/task.h>
+#elif defined(JET_TASKING_CPP11THREADS)
+#  include <thread>
+#endif
 
 namespace jet {
 
 namespace internal {
+
+// NOTE - This abstraction takes a lambda which should take captured
+//        variables by *value* to ensure no captured references race
+//        with the task itself.
+template<typename TASK_T>
+inline void schedule(TASK_T&& fcn) {
+#ifdef JET_TASKING_TBB
+    struct LocalTBBTask : public tbb::task
+    {
+        TASK_T func;
+        tbb::task* execute() override { func(); return nullptr; }
+        LocalTBBTask(TASK_T&& f) : func(std::forward<TASK_T>(f)) {}
+    };
+
+    auto *tbb_node =
+      new(tbb::task::allocate_root())LocalTBBTask(std::forward<TASK_T>(fcn));
+    tbb::task::enqueue(*tbb_node);
+#elif defined(JET_TASKING_CPP11THREADS)
+    std::thread thread(fcn);
+    thread.detach();
+#else// OpenMP or Serial --> synchronous!
+    fcn();
+#endif
+}
+
+template<typename TASK_T>
+using operator_return_t = typename std::result_of<TASK_T()>::type;
+
+// NOTE - see above, same issues associated with schedule()
+template<typename TASK_T>
+inline auto async(TASK_T&& fcn) -> std::future<operator_return_t<TASK_T>> {
+    using package_t = std::packaged_task<operator_return_t<TASK_T>()>;
+
+    auto task   = new package_t(std::forward<TASK_T>(fcn));
+    auto future = task->get_future();
+
+    schedule([=](){ (*task)(); delete task; });
+
+    return future;
+}
 
 // Adopted from:
 // Radenski, A.
@@ -68,7 +115,7 @@ void parallelMergeSort(RandomIterator a, size_t size, RandomIterator2 temp,
     if (numThreads == 1) {
         std::sort(a, a + size, compareFunction);
     } else if (numThreads > 1) {
-        std::vector<std::thread> pool;
+        std::vector<std::future<void>> pool;
         pool.reserve(2);
 
         auto launchRange = [compareFunction](RandomIterator begin, size_t k2,
@@ -77,14 +124,23 @@ void parallelMergeSort(RandomIterator a, size_t size, RandomIterator2 temp,
             parallelMergeSort(begin, k2, temp, numThreads, compareFunction);
         };
 
-        pool.emplace_back(launchRange, a, size / 2, temp, numThreads / 2);
-        pool.emplace_back(launchRange, a + size / 2, size - size / 2,
-                          temp + size / 2, numThreads - numThreads / 2);
+        pool.emplace_back(
+            internal::async([=]() {
+                launchRange(a, size / 2, temp, numThreads / 2);
+            })
+        );
+
+        pool.emplace_back(
+            internal::async([=]() {
+                launchRange(a + size / 2, size - size / 2,
+                            temp + size / 2, numThreads - numThreads / 2);
+            })
+        );
 
         // Wait for jobs to finish
-        for (std::thread& t : pool) {
-            if (t.joinable()) {
-                t.join();
+        for (auto& f : pool) {
+            if (f.valid()) {
+                f.wait();
             }
         }
 
@@ -115,6 +171,9 @@ void parallelFor(IndexType start, IndexType end, const Function& func,
         return;
     }
 
+#ifdef JET_TASKING_TBB
+    tbb::parallel_for(start, end, func);
+#elif JET_TASKING_CPP11THREADS
     // Estimate number of threads in the pool
     unsigned int numThreadsHint = maxNumberOfThreads();
     const unsigned int numThreads =
@@ -155,6 +214,14 @@ void parallelFor(IndexType start, IndexType end, const Function& func,
             t.join();
         }
     }
+#else
+#  ifdef JET_TASKING_OPENMP
+#    pragma omp parallel for
+#  endif
+    for (auto i = start; i < end; ++i) {
+      func(i);
+    }
+#endif
 }
 
 template <typename IndexType, typename Function>
@@ -178,23 +245,23 @@ void parallelRangeFor(IndexType start, IndexType end, const Function& func,
     slice = std::max(slice, IndexType(1));
 
     // Create pool and launch jobs
-    std::vector<std::thread> pool;
+    std::vector<std::future<void>> pool;
     pool.reserve(numThreads);
     IndexType i1 = start;
     IndexType i2 = std::min(start + slice, end);
     for (unsigned int i = 0; i + 1 < numThreads && i1 < end; ++i) {
-        pool.emplace_back(func, i1, i2);
+        pool.emplace_back(internal::async([=](){ func(i1, i2); }));
         i1 = i2;
         i2 = std::min(i2 + slice, end);
     }
     if (i1 < end) {
-        pool.emplace_back(func, i1, end);
+        pool.emplace_back(internal::async([=](){ func(i1, end); }));
     }
 
     // Wait for jobs to finish
-    for (std::thread& t : pool) {
-        if (t.joinable()) {
-            t.join();
+    for (auto& f : pool) {
+        if (f.valid()) {
+            f.wait();
         }
     }
 }
@@ -283,24 +350,24 @@ Value parallelReduce(IndexType start, IndexType end, const Value& identity,
     };
 
     // Create pool and launch jobs
-    std::vector<std::thread> pool;
+    std::vector<std::future<void>> pool;
     pool.reserve(numThreads);
     IndexType i1 = start;
     IndexType i2 = std::min(start + slice, end);
     unsigned int tid = 0;
     for (; tid + 1 < numThreads && i1 < end; ++tid) {
-        pool.emplace_back(launchRange, i1, i2, tid);
+        pool.emplace_back(internal::async([=](){ launchRange(i1, i2, tid); }));
         i1 = i2;
         i2 = std::min(i2 + slice, end);
     }
     if (i1 < end) {
-        pool.emplace_back(launchRange, i1, end, tid);
+        pool.emplace_back(internal::async([=]() {launchRange(i1, end, tid); }));
     }
 
     // Wait for jobs to finish
-    for (std::thread& t : pool) {
-        if (t.joinable()) {
-            t.join();
+    for (auto& f : pool) {
+        if (f.valid()) {
+            f.wait();
         }
     }
 

--- a/src/jet/CMakeLists.txt
+++ b/src/jet/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(${target}
 
     PUBLIC
     ${DEFAULT_LINKER_OPTIONS}
+    ${DEFAULT_LIBRARIES}
 
     INTERFACE
 )

--- a/src/jet/parallel.cpp
+++ b/src/jet/parallel.cpp
@@ -6,13 +6,32 @@
 
 #include <jet/parallel.h>
 
+#include <memory>
 #include <thread>
+
+#if defined(JET_TASKING_TBB)
+# include <tbb/task_arena.h>
+# include <tbb/task_scheduler_init.h>
+#elif defined(JET_TASKING_OPENMP)
+# include <omp.h>
+#endif
 
 static unsigned int sMaxNumberOfThreads = std::thread::hardware_concurrency();
 
 namespace jet {
 
 void setMaxNumberOfThreads(unsigned int numThreads) {
+#if defined(JET_TASKING_TBB)
+    static std::unique_ptr<tbb::task_scheduler_init> tbbInit;
+    if (!tbbInit.get())
+      tbbInit.reset(new tbb::task_scheduler_init(numThreads));
+    else {
+      tbbInit->terminate();
+      tbbInit->initialize(numThreads);
+    }
+#elif defined(JET_TASKING_OPENMP)
+    omp_set_num_threads(numThreads);
+#endif
     sMaxNumberOfThreads = std::max(numThreads, 1u);
 }
 


### PR DESCRIPTION
I've done some work on ```libjet``` targeting different CPU threading backends. I think this mostly captures the "low hanging fruit", as I didn't do anything fancy in terms of profiling. However, I believe these changes will allow it to be a bit easier to play with different options wrt CPU threading for future optimization work.

Some notes about the changes:

- There's a new CMake option (```JET_TASKING_SYSTEM```) which can be toggled between ```CPP11Threads```, ```TBB```, ```OpenMP```, and ```Serial```
    - ```CPP11Threads``` uses the original implementation which schedules tasks on a ```std::thread```
    - ```TBB``` has ```jet::parallelFor()``` forward to ```tbb::parallel_for()```
    - ```OpenMP``` does the same as the TBB option, but instead uses OpenMP
    - ```Serial``` turns all ```jet::parallelFor()``` calls into a simple for-loop
- There are two new functions in ```parallel-inl.h```:
    - ```jet::internal::schedule()``` either throws the given task on the thread pool or spawns a ```std::thread```, depending on the value of ```JET_TASKING_SYSTEM```
    - ```jet::internal::async()``` wraps the task in a ```std::packaged_task``` to get a future to the given task's return value, then launches the given task with ```jet::internal::schedule()```.
- The ```CPP11Threads``` implementations have been modified to use the new ```jet::internal::async()``` function (functionally the same as before, just trying to reuse code...code looks practically identical to the old version)
- ```jet::parallelRangeFor()``` has not been modified (yet)...I'm not sure you really need a range-for() if you have TBB, but that can be punted to be a future implementation decision (or outright reject)
- With gcc-7.2.1 (I run Arch Linux) I ran into warnings which got turned into errors. I decided to make warnings as errors optional via the ```JET_WARNINGS_AS_ERRORS``` CMake option, which defaults to being off. I'm not too picky about what the default value is, but having a way to turn off a non-critical build error without modifying CMake I think is important.
- I have only tested this on Linux, but because I used techniques we use in OSPRay I have confidence it should be fully cross-platform.

I did my best to keep as close to the native coding style in the project, but of course I probably made mistakes. :)

Here are some performance timings on my 2x10 core (40 total hw threads) Ivy Bridge workstation:

command --> ```bin/smoke_sim -e 1 -f 250```
- CPP11Threads: 10m14s
- TBB: 3m58s
- OpenMP: (default, static scheduling) 4m09s, (OMP_SCHEDULE=dynamic) 3m54s
- Serial: 10m07s
- ```master``` branch: 10m08s

So it looks like both TBB and OpenMP provide nice speedups, though scaling isn't exactly perfect. I left the OpenMP parallel_for without any clauses, so you can play with as much as you want using environment variables without needing to recompile. It looks like the 'dynamic' schedule for OpenMP helps a little bit. It's at least a start!

If you do any nesting of ```jet::parallelFor()``` calls, TBB will outpace OpenMP because (as it is currently implemented), nested OpenMP parallel regions will just be ignored and treated as serial. TBB will create more tasks at nested levels, which _can_ be helpful depending on your problem. (nesting is useful for OSPRay --> unbalanced workloads)

Finally, all the unit tests pass with every tasking system backend (and the first example works), so I assume correctness has been maintained...though I'm certainly not an expert in the code base, nor am I an expert in CFD to know where further improvements could be made. I guess I should get the book! :)
