### PR TITLE
Add support for frame rate specification at render time.

### DIFF
--- a/scripts/render.py
+++ b/scripts/render.py
@@ -96,7 +96,7 @@ def render_still_points2(filename_x, filename_y, output_filename, **kwargs):
     plt.close(fig)
     print ('Rendered <%s>' % output_filename)
 
-def render_point2(filename):
+def render_point2(filename, frame_rate=60):
     if is_animation(parse_tags(filename)):
         data = []
         def get_pt_data(filename, frame):
@@ -149,7 +149,7 @@ def render_point2(filename):
         pt, = ax.plot(x, y, 'bo', markersize=3)
         anim = animation.FuncAnimation(fig, update_pts, len(seq), fargs=(pt,), interval=60, blit=False)
         output_filename = get_output_movie_filename(filename.replace(',' + X_TAG, ''))
-        anim.save(output_filename, fps=60, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
+        anim.save(output_filename, fps=frame_rate, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
         plt.close(fig)
         print ('Rendered <%s>' % output_filename)
     else:
@@ -204,7 +204,7 @@ def render_still_line2(filename_x, filename_y, output_filename, **kwargs):
     plt.close(fig)
     print ('Rendered <%s>' % output_filename)
 
-def render_line2(filename):
+def render_line2(filename, frame_rate=60):
     if is_animation(parse_tags(filename)):
         data = []
         def get_line_data(filename, frame):
@@ -257,7 +257,7 @@ def render_line2(filename):
         line, = ax.plot(x, y, lw=2, marker='o', markersize=3)
         anim = animation.FuncAnimation(fig, update_lines, len(seq), fargs=(line,), interval=60, blit=False)
         output_filename = get_output_movie_filename(filename.replace(',' + X_TAG, ''))
-        anim.save(output_filename, fps=60, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
+        anim.save(output_filename, fps=frame_rate, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
         plt.close(fig)
         print ('Rendered <%s>' % output_filename)
     else:
@@ -337,7 +337,7 @@ def render_still_vector_grid2(filename_x, filename_y, output_filename, **kwargs)
     plt.close(fig)
     print ('Rendered <%s>' % output_filename)
 
-def render_grid2(filename):
+def render_grid2(filename, frame_rate=60):
     if is_animation(parse_tags(filename)):
         dirname = os.path.dirname(filename)
         basename = os.path.basename(filename).replace('0000', '[0-9][0-9][0-9][0-9]')
@@ -362,7 +362,7 @@ def render_grid2(filename):
 
         output_filename = get_output_movie_filename(filename.replace(',' + X_TAG, ''))
         anim = animation.FuncAnimation(fig, update_image, frames=len(seq), interval=60, blit=False)
-        anim.save(output_filename, fps=60, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
+        anim.save(output_filename, fps=frame_rate, bitrate=5000, writer=video_writer, extra_args=video_extra_args)
         plt.close(fig)
         print ('Rendered <%s>' % output_filename)
     else:

--- a/scripts/render_manual_tests_output.py
+++ b/scripts/render_manual_tests_output.py
@@ -6,8 +6,27 @@ Renders manual_tests output files
 
 import render
 import utils
+import argparse
+
+def processArguments():
+    parser = argparse.ArgumentParser(
+        description='Renders matplotlib files generated with jet.\n'
+                    'Run this utility from the same level as the manual_tests_output directory.')
+
+    parser.add_argument('-f', '--fps', type=int, help='override animation frame rate (default is 60fps)')
+    return parser.parse_args()
+
+def getFrameRate(arguments):
+    if arguments.fps:
+        fps = arguments.fps
+    else:
+        fps = 60
+    return fps
 
 if __name__ == '__main__':
+
+    fps = getFrameRate(processArguments())
+
     filenames = utils.get_all_files('manual_tests_output', ['*' + render.INPUT_ARRAY_FORMAT])
     filenames.sort()
 
@@ -21,19 +40,20 @@ if __name__ == '__main__':
             if render.is_animation(tags) and '0000' not in tags:
                 continue
             if render.POINT2_TAG in tags:
-                render.render_point2(filename)
+                render.render_point2(filename, fps)
             elif render.POINT3_TAG in tags:
                 render.render_point3(filename)
             elif render.LINE2_TAG in tags:
-                render.render_line2(filename)
+                render.render_line2(filename, fps)
             elif render.LINE3_TAG in tags:
                 render.render_line3(filename)
             elif render.GRID2_TAG in tags:
-                render.render_grid2(filename)
+                render.render_grid2(filename, fps)
             elif render.GRID3_TAG in tags:
                 render.render_grid3(filename)
         except Exception as e:
             print ('Failed to render', filename)
             print ('Why?')
             print (e)
+
 


### PR DESCRIPTION
It is easy to change the frame rate in jet/animation.h, but after having done so, generating the movie file using the included script requires changing calls in render.py, so this is a suggestion to expose the frame rate.

Calling the script without specifying the frame rate continues to default to 60fps, and a little help nugget is added too.