### PR TITLE
Warning fix for latest GCC/Clang compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,20 @@ matrix:
       services: docker
       script:
         - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic bionic
+    # Test Docker based on Ubuntu 18.04 LTS + gcc-latest
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      script:
+        - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic.gcc-latest bionic-gcc-latest
+    # Test Docker based on Ubuntu 18.04 LTS + clang-latest
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      script:
+        - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic.gcc-latest bionic-clang-latest
     # Test OS X 10.11 + Xcode 7.3 + clang
     - os: osx
       osx_image: xcode7.3

--- a/include/jet/detail/serialization-inl.h
+++ b/include/jet/detail/serialization-inl.h
@@ -8,13 +8,15 @@
 #define INCLUDE_JET_DETAIL_SERIALIZATION_INL_H_
 
 #include <jet/serialization.h>
+
 #include <cstring>
 #include <vector>
 
 namespace jet {
 
 template <typename T>
-void serialize(const ConstArrayAccessor1<T>& array, std::vector<uint8_t>* buffer) {
+void serialize(const ConstArrayAccessor1<T>& array,
+               std::vector<uint8_t>* buffer) {
     size_t size = sizeof(T) * array.size();
     serialize(reinterpret_cast<const uint8_t*>(array.data()), size, buffer);
 }
@@ -24,7 +26,7 @@ void deserialize(const std::vector<uint8_t>& buffer, Array1<T>* array) {
     std::vector<uint8_t> data;
     deserialize(buffer, &data);
     array->resize(data.size() / sizeof(T));
-    memcpy(array->data(), data.data(), data.size());
+    memcpy(reinterpret_cast<uint8_t*>(array->data()), data.data(), data.size());
 }
 
 }  // namespace jet

--- a/include/jet/fdm_linear_system_solver2.h
+++ b/include/jet/fdm_linear_system_solver2.h
@@ -8,6 +8,7 @@
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM_SOLVER2_H_
 
 #include <jet/fdm_linear_system2.h>
+
 #include <memory>
 
 namespace jet {
@@ -15,6 +16,10 @@ namespace jet {
 //! Abstract base class for 2-D finite difference-type linear system solver.
 class FdmLinearSystemSolver2 {
  public:
+    FdmLinearSystemSolver2() = default;
+
+    virtual ~FdmLinearSystemSolver2() = default;
+
     //! Solves the given linear system.
     virtual bool solve(FdmLinearSystem2* system) = 0;
 

--- a/include/jet/fdm_linear_system_solver3.h
+++ b/include/jet/fdm_linear_system_solver3.h
@@ -8,6 +8,7 @@
 #define INCLUDE_JET_FDM_LINEAR_SYSTEM_SOLVER3_H_
 
 #include <jet/fdm_linear_system3.h>
+
 #include <memory>
 
 namespace jet {
@@ -15,6 +16,10 @@ namespace jet {
 //! Abstract base class for 3-D finite difference-type linear system solver.
 class FdmLinearSystemSolver3 {
  public:
+    FdmLinearSystemSolver3() = default;
+
+    virtual ~FdmLinearSystemSolver3() = default;
+
     //! Solves the given linear system.
     virtual bool solve(FdmLinearSystem3* system) = 0;
 

--- a/include/jet/fdm_mg_solver2.h
+++ b/include/jet/fdm_mg_solver2.h
@@ -16,6 +16,10 @@ namespace jet {
 //! \brief 2-D finite difference-type linear system solver using Multigrid.
 class FdmMgSolver2 : public FdmLinearSystemSolver2 {
  public:
+    FdmMgSolver2() = default;
+
+    virtual ~FdmMgSolver2() = default;
+
     //! Constructs the solver with given parameters.
     FdmMgSolver2(size_t maxNumberOfLevels,
                  unsigned int numberOfRestrictionIter = 5,

--- a/include/jet/fdm_mg_solver3.h
+++ b/include/jet/fdm_mg_solver3.h
@@ -16,6 +16,10 @@ namespace jet {
 //! \brief 3-D finite difference-type linear system solver using Multigrid.
 class FdmMgSolver3 : public FdmLinearSystemSolver3 {
  public:
+    FdmMgSolver3() = default;
+
+    virtual ~FdmMgSolver3() = default;
+
     //! Constructs the solver with given parameters.
     FdmMgSolver3(size_t maxNumberOfLevels,
                  unsigned int numberOfRestrictionIter = 5,

--- a/include/jet/serialization.h
+++ b/include/jet/serialization.h
@@ -16,6 +16,10 @@ namespace jet {
 //! Abstract base class for any serializable class.
 class Serializable {
  public:
+    Serializable() = default;
+
+    virtual ~Serializable() = default;
+
     //! Serializes this instance into the flat buffer.
     virtual void serialize(std::vector<uint8_t>* buffer) const = 0;
 
@@ -31,7 +35,8 @@ void serialize(const uint8_t* data, size_t size, std::vector<uint8_t>* buffer);
 
 //! Serializes data chunk using common schema.
 template <typename T>
-void serialize(const ConstArrayAccessor1<T>& array, std::vector<uint8_t>* buffer);
+void serialize(const ConstArrayAccessor1<T>& array,
+               std::vector<uint8_t>* buffer);
 
 //! Deserializes buffer to serializable object.
 void deserialize(const std::vector<uint8_t>& buffer,

--- a/scripts/Dockerfile.bionic.clang-latest
+++ b/scripts/Dockerfile.bionic.clang-latest
@@ -2,12 +2,12 @@ FROM ubuntu:18.04
 MAINTAINER Doyub Kim <doyubkim@gmail.com>
 
 RUN apt-get update -yq && \
-    apt-get install -yq build-essential python-dev python-pip python3-dev python3-pip python3-venv cmake
+    apt-get install -yq build-essential python-dev python-pip python3-dev python3-pip python3-venv cmake clang-6.0
 
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. && \
+RUN cmake .. -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests

--- a/scripts/Dockerfile.bionic.gcc-latest
+++ b/scripts/Dockerfile.bionic.gcc-latest
@@ -2,12 +2,12 @@ FROM ubuntu:18.04
 MAINTAINER Doyub Kim <doyubkim@gmail.com>
 
 RUN apt-get update -yq && \
-    apt-get install -yq build-essential python-dev python-pip python3-dev python3-pip python3-venv cmake
+    apt-get install -yq build-essential python-dev python-pip python3-dev python3-pip python3-venv cmake gcc-8 g++-8
 
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. && \
+RUN cmake .. -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests

--- a/scripts/Dockerfile.xenial
+++ b/scripts/Dockerfile.xenial
@@ -9,7 +9,8 @@ ADD . /app
 WORKDIR /app/build
 RUN cmake .. && \
     make -j`nproc` && \
-    make install
+    make install && \
+    bin/unit_tests
 
 RUN apt-get install -yq pkg-config libfreetype6-dev libpng-dev
 RUN pip install -r ../requirements.txt && \

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -13,6 +13,11 @@ set(target pyjet)
 file(GLOB sources
         ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
+# Disable deprecated-register warning for Python2.7 headers
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
+endif ()
+
 # Add Pybind11 module
 pybind11_add_module(${target} ${sources})
 

--- a/src/tests/unit_tests/particle_system_data2_tests.cpp
+++ b/src/tests/unit_tests/particle_system_data2_tests.cpp
@@ -5,7 +5,9 @@
 // property of any third parties.
 
 #include <jet/particle_system_data2.h>
+
 #include <gtest/gtest.h>
+
 #include <vector>
 
 using namespace jet;
@@ -119,16 +121,14 @@ TEST(ParticleSystemData2, AddParticlesException) {
 
     try {
         particleSystem.addParticles(
-            Array1<Vector2D>(
-                {Vector2D(1.0, 2.0), Vector2D(4.0, 5.0)}).accessor(),
-            Array1<Vector2D>(
-                {Vector2D(7.0, 8.0)}).accessor(),
-            Array1<Vector2D>(
-                {Vector2D(5.0, 4.0), Vector2D(2.0, 1.0)}).accessor());
+            Array1<Vector2D>({Vector2D(1.0, 2.0), Vector2D(4.0, 5.0)})
+                .accessor(),
+            Array1<Vector2D>({Vector2D(7.0, 8.0)}).accessor(),
+            Array1<Vector2D>({Vector2D(5.0, 4.0), Vector2D(2.0, 1.0)})
+                .accessor());
 
         EXPECT_FALSE(true) << "Invalid argument shoudl throw exception.";
-    }
-    catch (std::invalid_argument) {
+    } catch (std::invalid_argument&) {
         // Do nothing -- expected exception
     }
 
@@ -136,16 +136,14 @@ TEST(ParticleSystemData2, AddParticlesException) {
 
     try {
         particleSystem.addParticles(
-            Array1<Vector2D>(
-                {Vector2D(1.0, 2.0), Vector2D(4.0, 5.0)}).accessor(),
-            Array1<Vector2D>(
-                {Vector2D(7.0, 8.0), Vector2D(2.0, 1.0)}).accessor(),
-            Array1<Vector2D>(
-                {Vector2D(5.0, 4.0)}).accessor());
+            Array1<Vector2D>({Vector2D(1.0, 2.0), Vector2D(4.0, 5.0)})
+                .accessor(),
+            Array1<Vector2D>({Vector2D(7.0, 8.0), Vector2D(2.0, 1.0)})
+                .accessor(),
+            Array1<Vector2D>({Vector2D(5.0, 4.0)}).accessor());
 
         EXPECT_FALSE(true) << "Invalid argument shoudl throw exception.";
-    }
-    catch (std::invalid_argument) {
+    } catch (std::invalid_argument&) {
         // Do nothing -- expected exception
     }
 
@@ -155,27 +153,10 @@ TEST(ParticleSystemData2, AddParticlesException) {
 TEST(ParticleSystemData2, BuildNeighborSearcher) {
     ParticleSystemData2 particleSystem;
     ParticleSystemData2::VectorData positions = {
-        {0.5, 0.7},
-        {0.1, 0.5},
-        {0.3, 0.1},
-        {0.2, 0.6},
-        {0.9, 0.7},
-        {0.2, 0.5},
-        {0.5, 0.8},
-        {0.2, 0.3},
-        {0.9, 0.1},
-        {0.6, 0.8},
-        {0.1, 0.7},
-        {0.4, 0.5},
-        {0.5, 0.9},
-        {0.7, 0.9},
-        {0.2, 0.8},
-        {0.5, 0.5},
-        {0.4, 0.1},
-        {0.2, 0.4},
-        {0.1, 0.6},
-        {0.9, 0.8}
-    };
+        {0.5, 0.7}, {0.1, 0.5}, {0.3, 0.1}, {0.2, 0.6}, {0.9, 0.7},
+        {0.2, 0.5}, {0.5, 0.8}, {0.2, 0.3}, {0.9, 0.1}, {0.6, 0.8},
+        {0.1, 0.7}, {0.4, 0.5}, {0.5, 0.9}, {0.7, 0.9}, {0.2, 0.8},
+        {0.5, 0.5}, {0.4, 0.1}, {0.2, 0.4}, {0.1, 0.6}, {0.9, 0.8}};
     particleSystem.addParticles(positions);
 
     const double radius = 0.4;
@@ -185,16 +166,13 @@ TEST(ParticleSystemData2, BuildNeighborSearcher) {
     const Vector2D searchOrigin = {0.1, 0.2};
     std::vector<size_t> found;
     neighborSearcher->forEachNearbyPoint(
-        searchOrigin,
-        radius,
-        [&](size_t i, const Vector2D&) {
-            found.push_back(i);
-        });
+        searchOrigin, radius,
+        [&](size_t i, const Vector2D&) { found.push_back(i); });
 
     for (size_t ii = 0; ii < positions.size(); ++ii) {
         if (searchOrigin.distanceTo(positions[ii]) <= radius) {
-            EXPECT_TRUE(
-                found.end() != std::find(found.begin(), found.end(), ii));
+            EXPECT_TRUE(found.end() !=
+                        std::find(found.begin(), found.end(), ii));
         }
     }
 }
@@ -202,27 +180,10 @@ TEST(ParticleSystemData2, BuildNeighborSearcher) {
 TEST(ParticleSystemData2, BuildNeighborLists) {
     ParticleSystemData2 particleSystem;
     ParticleSystemData2::VectorData positions = {
-        {0.3, 0.5},
-        {0.6, 0.8},
-        {0.1, 0.8},
-        {0.7, 0.9},
-        {0.3, 0.2},
-        {0.8, 0.3},
-        {0.8, 0.5},
-        {0.4, 0.9},
-        {0.8, 0.6},
-        {0.2, 0.9},
-        {0.1, 0.2},
-        {0.6, 0.9},
-        {0.2, 0.2},
-        {0.5, 0.6},
-        {0.8, 0.4},
-        {0.4, 0.2},
-        {0.2, 0.3},
-        {0.8, 0.6},
-        {0.2, 0.8},
-        {1.0, 0.5}
-    };
+        {0.3, 0.5}, {0.6, 0.8}, {0.1, 0.8}, {0.7, 0.9}, {0.3, 0.2},
+        {0.8, 0.3}, {0.8, 0.5}, {0.4, 0.9}, {0.8, 0.6}, {0.2, 0.9},
+        {0.1, 0.2}, {0.6, 0.9}, {0.2, 0.2}, {0.5, 0.6}, {0.8, 0.4},
+        {0.4, 0.2}, {0.2, 0.3}, {0.8, 0.6}, {0.2, 0.8}, {1.0, 0.5}};
     particleSystem.addParticles(positions);
 
     const double radius = 0.4;
@@ -236,9 +197,8 @@ TEST(ParticleSystemData2, BuildNeighborLists) {
         const auto& neighbors = neighborLists[i];
         for (size_t ii = 0; ii < positions.size(); ++ii) {
             if (ii != i && positions[ii].distanceTo(positions[i]) <= radius) {
-                EXPECT_TRUE(
-                    neighbors.end()
-                    != std::find(neighbors.begin(), neighbors.end(), ii));
+                EXPECT_TRUE(neighbors.end() !=
+                            std::find(neighbors.begin(), neighbors.end(), ii));
             }
         }
     }
@@ -248,27 +208,10 @@ TEST(ParticleSystemData2, Serialization) {
     ParticleSystemData2 particleSystem;
 
     ParticleSystemData2::VectorData positions = {
-        {0.3, 0.5},
-        {0.6, 0.8},
-        {0.1, 0.8},
-        {0.7, 0.9},
-        {0.3, 0.2},
-        {0.8, 0.3},
-        {0.8, 0.5},
-        {0.4, 0.9},
-        {0.8, 0.6},
-        {0.2, 0.9},
-        {0.1, 0.2},
-        {0.6, 0.9},
-        {0.2, 0.2},
-        {0.5, 0.6},
-        {0.8, 0.4},
-        {0.4, 0.2},
-        {0.2, 0.3},
-        {0.8, 0.6},
-        {0.2, 0.8},
-        {1.0, 0.5}
-    };
+        {0.3, 0.5}, {0.6, 0.8}, {0.1, 0.8}, {0.7, 0.9}, {0.3, 0.2},
+        {0.8, 0.3}, {0.8, 0.5}, {0.4, 0.9}, {0.8, 0.6}, {0.2, 0.9},
+        {0.1, 0.2}, {0.6, 0.9}, {0.2, 0.2}, {0.5, 0.6}, {0.8, 0.4},
+        {0.4, 0.2}, {0.2, 0.3}, {0.8, 0.6}, {0.2, 0.8}, {1.0, 0.5}};
     particleSystem.addParticles(positions);
 
     size_t a0 = particleSystem.addScalarData(2.0);

--- a/src/tests/unit_tests/particle_system_data3_tests.cpp
+++ b/src/tests/unit_tests/particle_system_data3_tests.cpp
@@ -5,7 +5,9 @@
 // property of any third parties.
 
 #include <jet/particle_system_data3.h>
+
 #include <gtest/gtest.h>
+
 #include <vector>
 
 using namespace jet;
@@ -97,12 +99,12 @@ TEST(ParticleSystemData3, AddParticles) {
     particleSystem.resize(12);
 
     particleSystem.addParticles(
-        Array1<Vector3D>(
-            {Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)}).accessor(),
-        Array1<Vector3D>(
-            {Vector3D(7.0, 8.0, 9.0), Vector3D(8.0, 7.0, 6.0)}).accessor(),
-        Array1<Vector3D>(
-            {Vector3D(5.0, 4.0, 3.0), Vector3D(2.0, 1.0, 3.0)}).accessor());
+        Array1<Vector3D>({Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)})
+            .accessor(),
+        Array1<Vector3D>({Vector3D(7.0, 8.0, 9.0), Vector3D(8.0, 7.0, 6.0)})
+            .accessor(),
+        Array1<Vector3D>({Vector3D(5.0, 4.0, 3.0), Vector3D(2.0, 1.0, 3.0)})
+            .accessor());
 
     EXPECT_EQ(14u, particleSystem.numberOfParticles());
     auto p = particleSystem.positions();
@@ -123,16 +125,14 @@ TEST(ParticleSystemData3, AddParticlesException) {
 
     try {
         particleSystem.addParticles(
-            Array1<Vector3D>(
-                {Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)}).accessor(),
-            Array1<Vector3D>(
-                {Vector3D(7.0, 8.0, 9.0)}).accessor(),
-            Array1<Vector3D>(
-                {Vector3D(5.0, 4.0, 3.0), Vector3D(2.0, 1.0, 3.0)}).accessor());
+            Array1<Vector3D>({Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)})
+                .accessor(),
+            Array1<Vector3D>({Vector3D(7.0, 8.0, 9.0)}).accessor(),
+            Array1<Vector3D>({Vector3D(5.0, 4.0, 3.0), Vector3D(2.0, 1.0, 3.0)})
+                .accessor());
 
         EXPECT_FALSE(true) << "Invalid argument shoudl throw exception.";
-    }
-    catch (std::invalid_argument) {
+    } catch (std::invalid_argument&) {
         // Do nothing -- expected exception
     }
 
@@ -140,16 +140,14 @@ TEST(ParticleSystemData3, AddParticlesException) {
 
     try {
         particleSystem.addParticles(
-            Array1<Vector3D>(
-                {Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)}).accessor(),
-            Array1<Vector3D>(
-                {Vector3D(7.0, 8.0, 9.0), Vector3D(2.0, 1.0, 3.0)}).accessor(),
-            Array1<Vector3D>(
-                {Vector3D(5.0, 4.0, 3.0)}).accessor());
+            Array1<Vector3D>({Vector3D(1.0, 2.0, 3.0), Vector3D(4.0, 5.0, 6.0)})
+                .accessor(),
+            Array1<Vector3D>({Vector3D(7.0, 8.0, 9.0), Vector3D(2.0, 1.0, 3.0)})
+                .accessor(),
+            Array1<Vector3D>({Vector3D(5.0, 4.0, 3.0)}).accessor());
 
         EXPECT_FALSE(true) << "Invalid argument shoudl throw exception.";
-    }
-    catch (std::invalid_argument) {
+    } catch (std::invalid_argument&) {
         // Do nothing -- expected exception
     }
 
@@ -159,27 +157,11 @@ TEST(ParticleSystemData3, AddParticlesException) {
 TEST(ParticleSystemData3, BuildNeighborSearcher) {
     ParticleSystemData3 particleSystem;
     ParticleSystemData3::VectorData positions = {
-        {0.1, 0.0, 0.4},
-        {0.6, 0.2, 0.6},
-        {1.0, 0.3, 0.4},
-        {0.9, 0.2, 0.2},
-        {0.8, 0.4, 0.9},
-        {0.1, 0.6, 0.2},
-        {0.8, 0.0, 0.5},
-        {0.9, 0.8, 0.2},
-        {0.3, 0.5, 0.2},
-        {0.1, 0.6, 0.6},
-        {0.1, 0.2, 0.1},
-        {0.2, 0.0, 0.0},
-        {0.2, 0.6, 0.1},
-        {0.1, 0.3, 0.7},
-        {0.9, 0.7, 0.6},
-        {0.4, 0.5, 0.1},
-        {0.1, 0.1, 0.6},
-        {0.7, 0.8, 1.0},
-        {0.6, 0.9, 0.4},
-        {0.7, 0.7, 0.0}
-    };
+        {0.1, 0.0, 0.4}, {0.6, 0.2, 0.6}, {1.0, 0.3, 0.4}, {0.9, 0.2, 0.2},
+        {0.8, 0.4, 0.9}, {0.1, 0.6, 0.2}, {0.8, 0.0, 0.5}, {0.9, 0.8, 0.2},
+        {0.3, 0.5, 0.2}, {0.1, 0.6, 0.6}, {0.1, 0.2, 0.1}, {0.2, 0.0, 0.0},
+        {0.2, 0.6, 0.1}, {0.1, 0.3, 0.7}, {0.9, 0.7, 0.6}, {0.4, 0.5, 0.1},
+        {0.1, 0.1, 0.6}, {0.7, 0.8, 1.0}, {0.6, 0.9, 0.4}, {0.7, 0.7, 0.0}};
     particleSystem.addParticles(positions);
 
     const double radius = 0.4;
@@ -189,16 +171,13 @@ TEST(ParticleSystemData3, BuildNeighborSearcher) {
     const Vector3D searchOrigin = {0.1, 0.2, 0.3};
     std::vector<size_t> found;
     neighborSearcher->forEachNearbyPoint(
-        searchOrigin,
-        radius,
-        [&](size_t i, const Vector3D&) {
-            found.push_back(i);
-        });
+        searchOrigin, radius,
+        [&](size_t i, const Vector3D&) { found.push_back(i); });
 
     for (size_t ii = 0; ii < positions.size(); ++ii) {
         if (searchOrigin.distanceTo(positions[ii]) <= radius) {
-            EXPECT_TRUE(
-                found.end() != std::find(found.begin(), found.end(), ii));
+            EXPECT_TRUE(found.end() !=
+                        std::find(found.begin(), found.end(), ii));
         }
     }
 }
@@ -206,27 +185,11 @@ TEST(ParticleSystemData3, BuildNeighborSearcher) {
 TEST(ParticleSystemData3, BuildNeighborLists) {
     ParticleSystemData3 particleSystem;
     ParticleSystemData3::VectorData positions = {
-        {0.7, 0.2, 0.2},
-        {0.7, 0.8, 1.0},
-        {0.9, 0.4, 0.0},
-        {0.5, 0.1, 0.6},
-        {0.6, 0.3, 0.8},
-        {0.1, 0.6, 0.0},
-        {0.5, 1.0, 0.2},
-        {0.6, 0.7, 0.8},
-        {0.2, 0.4, 0.7},
-        {0.8, 0.5, 0.8},
-        {0.0, 0.8, 0.4},
-        {0.3, 0.0, 0.6},
-        {0.7, 0.8, 0.3},
-        {0.0, 0.7, 0.1},
-        {0.6, 0.3, 0.8},
-        {0.3, 0.2, 1.0},
-        {0.3, 0.5, 0.6},
-        {0.3, 0.9, 0.6},
-        {0.9, 1.0, 1.0},
-        {0.0, 0.1, 0.6}
-    };
+        {0.7, 0.2, 0.2}, {0.7, 0.8, 1.0}, {0.9, 0.4, 0.0}, {0.5, 0.1, 0.6},
+        {0.6, 0.3, 0.8}, {0.1, 0.6, 0.0}, {0.5, 1.0, 0.2}, {0.6, 0.7, 0.8},
+        {0.2, 0.4, 0.7}, {0.8, 0.5, 0.8}, {0.0, 0.8, 0.4}, {0.3, 0.0, 0.6},
+        {0.7, 0.8, 0.3}, {0.0, 0.7, 0.1}, {0.6, 0.3, 0.8}, {0.3, 0.2, 1.0},
+        {0.3, 0.5, 0.6}, {0.3, 0.9, 0.6}, {0.9, 1.0, 1.0}, {0.0, 0.1, 0.6}};
     particleSystem.addParticles(positions);
 
     const double radius = 0.4;
@@ -240,9 +203,8 @@ TEST(ParticleSystemData3, BuildNeighborLists) {
         const auto& neighbors = neighborLists[i];
         for (size_t ii = 0; ii < positions.size(); ++ii) {
             if (ii != i && positions[ii].distanceTo(positions[i]) <= radius) {
-                EXPECT_TRUE(
-                    neighbors.end()
-                    != std::find(neighbors.begin(), neighbors.end(), ii));
+                EXPECT_TRUE(neighbors.end() !=
+                            std::find(neighbors.begin(), neighbors.end(), ii));
             }
         }
     }
@@ -252,27 +214,11 @@ TEST(ParticleSystemData3, Serialization) {
     ParticleSystemData3 particleSystem;
 
     ParticleSystemData3::VectorData positions = {
-        {0.7, 0.2, 0.2},
-        {0.7, 0.8, 1.0},
-        {0.9, 0.4, 0.0},
-        {0.5, 0.1, 0.6},
-        {0.6, 0.3, 0.8},
-        {0.1, 0.6, 0.0},
-        {0.5, 1.0, 0.2},
-        {0.6, 0.7, 0.8},
-        {0.2, 0.4, 0.7},
-        {0.8, 0.5, 0.8},
-        {0.0, 0.8, 0.4},
-        {0.3, 0.0, 0.6},
-        {0.7, 0.8, 0.3},
-        {0.0, 0.7, 0.1},
-        {0.6, 0.3, 0.8},
-        {0.3, 0.2, 1.0},
-        {0.3, 0.5, 0.6},
-        {0.3, 0.9, 0.6},
-        {0.9, 1.0, 1.0},
-        {0.0, 0.1, 0.6}
-    };
+        {0.7, 0.2, 0.2}, {0.7, 0.8, 1.0}, {0.9, 0.4, 0.0}, {0.5, 0.1, 0.6},
+        {0.6, 0.3, 0.8}, {0.1, 0.6, 0.0}, {0.5, 1.0, 0.2}, {0.6, 0.7, 0.8},
+        {0.2, 0.4, 0.7}, {0.8, 0.5, 0.8}, {0.0, 0.8, 0.4}, {0.3, 0.0, 0.6},
+        {0.7, 0.8, 0.3}, {0.0, 0.7, 0.1}, {0.6, 0.3, 0.8}, {0.3, 0.2, 1.0},
+        {0.3, 0.5, 0.6}, {0.3, 0.9, 0.6}, {0.9, 1.0, 1.0}, {0.0, 0.1, 0.6}};
     particleSystem.addParticles(positions);
 
     size_t a0 = particleSystem.addScalarData(2.0);


### PR DESCRIPTION
This revision includes:
- Fix for warnings generated by latest compilers such as gcc-8 and clang-6.0
- CI scripts that will monitor builds for those compilers on the latest Ubuntu LTS
- Minor clang-formatting

This revision should resolve #170 and #171 
