### PR TITLE
Fix link error problem in mem_perf_tests

### DIFF
--- a/src/tests/mem_perf_tests/fdm_iccg_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/fdm_iccg_solver3_tests.cpp
@@ -4,10 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include "mem_perf_tests.h"
+#include <gtest/gtest.h>
 #include <jet/fdm_iccg_solver3.h>
 #include <jet/timer.h>
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
 
 using namespace jet;
 
@@ -28,5 +28,5 @@ TEST(FdmIccgSolver3, Memory) {
 
     const auto msg = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO("Mem usage: %f %s.\n", msg.first, msg.second.c_str());
+    printMemReport(msg.first, msg.second);
 }

--- a/src/tests/mem_perf_tests/fdm_iccg_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/fdm_iccg_solver3_tests.cpp
@@ -4,10 +4,12 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
+
 #include <jet/fdm_iccg_solver3.h>
 #include <jet/timer.h>
-#include "mem_perf_tests.h"
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 

--- a/src/tests/mem_perf_tests/flip_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/flip_solver3_tests.cpp
@@ -4,10 +4,12 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
+
 #include <jet/flip_solver3.h>
 #include <jet/timer.h>
-#include "mem_perf_tests.h"
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 

--- a/src/tests/mem_perf_tests/flip_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/flip_solver3_tests.cpp
@@ -4,10 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include "mem_perf_tests.h"
+#include <gtest/gtest.h>
 #include <jet/flip_solver3.h>
 #include <jet/timer.h>
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
 
 using namespace jet;
 
@@ -16,18 +16,13 @@ TEST(FlipSolver3, Memory) {
 
     const size_t mem0 = getCurrentRSS();
 
-    auto solver = FlipSolver3::builder()
-        .withResolution({n, n, n})
-        .makeShared();
+    auto solver = FlipSolver3::builder().withResolution({n, n, n}).makeShared();
 
     const size_t mem1 = getCurrentRSS();
 
     const auto msg1 = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO(
-        "Start mem. usage: %f %s.\n",
-        msg1.first,
-        msg1.second.c_str());
+    printMemReport(msg1.first, msg1.second);
 
     solver->update(Frame(1, 0.01));
 
@@ -35,8 +30,5 @@ TEST(FlipSolver3, Memory) {
 
     const auto msg2 = makeReadableByteSize(mem2 - mem0);
 
-    JET_PRINT_INFO(
-        "Single update mem. usage: %f %s.\n",
-        msg2.first,
-        msg2.second.c_str());
+    printMemReport(msg2.first, msg2.second);
 }

--- a/src/tests/mem_perf_tests/grid_fluid_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/grid_fluid_solver3_tests.cpp
@@ -4,10 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include "mem_perf_tests.h"
+#include <gtest/gtest.h>
 #include <jet/grid_fluid_solver3.h>
 #include <jet/timer.h>
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
 
 using namespace jet;
 
@@ -16,18 +16,14 @@ TEST(GridFluidSolver3, Memory) {
 
     const size_t mem0 = getCurrentRSS();
 
-    auto solver = GridFluidSolver3::builder()
-        .withResolution({n, n, n})
-        .makeShared();
+    auto solver =
+        GridFluidSolver3::builder().withResolution({n, n, n}).makeShared();
 
     const size_t mem1 = getCurrentRSS();
 
     const auto msg1 = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO(
-        "Start mem. usage: %f %s.\n",
-        msg1.first,
-        msg1.second.c_str());
+    printMemReport(msg1.first, msg1.second);
 
     solver->update(Frame(1, 0.01));
 
@@ -35,8 +31,5 @@ TEST(GridFluidSolver3, Memory) {
 
     const auto msg2 = makeReadableByteSize(mem2 - mem0);
 
-    JET_PRINT_INFO(
-        "Single update mem. usage: %f %s.\n",
-        msg2.first,
-        msg2.second.c_str());
+    printMemReport(msg2.first, msg2.second);
 }

--- a/src/tests/mem_perf_tests/grid_fluid_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/grid_fluid_solver3_tests.cpp
@@ -4,10 +4,12 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <gtest/gtest.h>
+#include "mem_perf_tests.h"
+
 #include <jet/grid_fluid_solver3.h>
 #include <jet/timer.h>
-#include "mem_perf_tests.h"
+
+#include <gtest/gtest.h>
 
 using namespace jet;
 

--- a/src/tests/mem_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
+++ b/src/tests/mem_perf_tests/grid_fractional_single_phase_pressure_solver3_tests.cpp
@@ -52,8 +52,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullUncompressed) {
 
     const auto msg = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
-                   msg.second.c_str());
+    printMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed) {
@@ -65,8 +64,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FullCompressed) {
 
     const auto msg = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
-                   msg.second.c_str());
+    printMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed) {
@@ -78,8 +76,7 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceUncompressed) {
 
     const auto msg = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
-                   msg.second.c_str());
+    printMemReport(msg.first, msg.second);
 }
 
 TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed) {
@@ -91,6 +88,5 @@ TEST(GridFractionalSinglePhasePressureSolver3, FreeSurfaceCompressed) {
 
     const auto msg = makeReadableByteSize(mem1 - mem0);
 
-    JET_PRINT_INFO("Single solve mem. usage: %f %s.\n", msg.first,
-                   msg.second.c_str());
+    printMemReport(msg.first, msg.second);
 }

--- a/src/tests/mem_perf_tests/mem_perf_tests.cpp
+++ b/src/tests/mem_perf_tests/mem_perf_tests.cpp
@@ -4,9 +4,14 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include "mem_perf_tests.h"
+#include <iostream>
 #include <string>
 #include <utility>
+#include "mem_perf_tests.h"
+
+void printMemReport(double memUsage, const std::string& memMessage) {
+    std::cout << "Mem usage: " << memUsage << ' ' << memMessage << '\n';
+}
 
 std::pair<double, std::string> makeReadableByteSize(size_t bytes) {
     double s = static_cast<double>(bytes);

--- a/src/tests/mem_perf_tests/mem_perf_tests.cpp
+++ b/src/tests/mem_perf_tests/mem_perf_tests.cpp
@@ -4,10 +4,11 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "mem_perf_tests.h"
+
 #include <iostream>
 #include <string>
 #include <utility>
-#include "mem_perf_tests.h"
 
 void printMemReport(double memUsage, const std::string& memMessage) {
     std::cout << "Mem usage: " << memUsage << ' ' << memMessage << '\n';

--- a/src/tests/mem_perf_tests/mem_perf_tests.h
+++ b/src/tests/mem_perf_tests/mem_perf_tests.h
@@ -11,33 +11,10 @@
 #include <utility>
 #include <vector>
 
-// gtest hack
-namespace testing {
-
-namespace internal {
-
-enum GTestColor {
-    COLOR_DEFAULT,
-    COLOR_RED,
-    COLOR_GREEN,
-    COLOR_YELLOW
-};
-
-extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
-
-}  // namespace internal
-
-}  // namespace testing
+void printMemReport(double memUsage, const std::string& memMessage);
 
 size_t getCurrentRSS();
 
 std::pair<double, std::string> makeReadableByteSize(size_t bytes);
-
-#define JET_PRINT_INFO(fmt, ...) \
-    testing::internal::ColoredPrintf( \
-        testing::internal::COLOR_YELLOW,  "[   STAT   ] "); \
-    testing::internal::ColoredPrintf( \
-        testing::internal::COLOR_YELLOW, fmt, __VA_ARGS__); \
-
 
 #endif  // SRC_TESTS_PERF_TESTS_PERF_TESTS_H_


### PR DESCRIPTION
This revision fixes link errors when building the ```mem_perf_tests``` project (#167). I replaced gtest hack code with ```printMemReport``` function.