### PR TITLE
Fix deprecated API from Python 3.7

### DIFF
--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -100,10 +100,8 @@
 
 namespace py = pybind11;
 
-PYBIND11_PLUGIN(pyjet) {
-    py::module m("pyjet", R"pbdoc(
-        Fluid simulation engine for computer graphics applications
-    )pbdoc");
+PYBIND11_MODULE(pyjet, m) {
+    m.doc() = "Fluid simulation engine for computer graphics applications";
 
     // Constants
     addConstants(m);
@@ -312,6 +310,4 @@ PYBIND11_PLUGIN(pyjet) {
 #else
     m.attr("__version__") = py::str("dev");
 #endif
-
-    return m.ptr();
 }


### PR DESCRIPTION
This revision updates pybind11 commit to the recent one which fixes Python 3.7 API break due to deprecation. Since this has been warned at least since 3.6, even targeting 3.6 will prevent building Jet Framework (due to `-Werror`). This has been found by building Jet from the latest Miniconda environment.

In addition to the commit ID bump, latest pybind11 also deprecates the use of PYBIND11_PLUGIN. Thus, this diff also fixes that issue as well.