### PR TITLE
work around bug for sph examples

### DIFF
--- a/src/examples/sph_sim/main.cpp
+++ b/src/examples/sph_sim/main.cpp
@@ -113,7 +113,7 @@ void runExample1(const std::string& rootDir, double targetSpacing,
                           .makeShared();
 
     auto emitter = VolumeParticleEmitter3::builder()
-                       .withSurface(surfaceSet)
+                       .withImplicitSurface(surfaceSet)
                        .withSpacing(targetSpacing)
                        .withMaxRegion(sourceBound)
                        .withIsOneShot(true)
@@ -170,7 +170,7 @@ void runExample2(const std::string& rootDir, double targetSpacing,
                           .makeShared();
 
     auto emitter = VolumeParticleEmitter3::builder()
-                       .withSurface(surfaceSet)
+                       .withImplicitSurface(surfaceSet)
                        .withSpacing(targetSpacing)
                        .withMaxRegion(sourceBound)
                        .withIsOneShot(true)


### PR DESCRIPTION
Examples 1 and 2 should be of spheres of water dropping into a pool of water.

However, when I ran both of them, I only saw a sphere of water dropping into
an empty box.

The emitter is constructed from a two surfaces: a sphere at (.5, 1.0, .5) with
radius .15 and a plane with normal (0, 1, 0) and point (0, .5, 0).

But when I called surfaceSet->closestPoint(Vector3D{.5, .4,.5}); and printed
the returned Vector3D, I got 0.5, 0.85, 0.5 which is point on the sphere
despite the point (.5, .5, .5) being on the plane and closer to my queried
point.

I didn't track down the problem with the implementation closestPoint()
but I think it is inside Vector3D ImplicitSurfaceSet3::closestPointLocal,
possibly in the bounding volume hierarchy.

In any case, changing the lines here in the example main functions does
fix the problem in the particular cases of the examples and makes the example
have a sphere of water dropping into a pool of water.