### PR TITLE
Empty (implicit) surface set handling from colliders

### DIFF
--- a/include/jet/implicit_surface_set2.h
+++ b/include/jet/implicit_surface_set2.h
@@ -44,6 +44,9 @@ class ImplicitSurfaceSet2 final : public ImplicitSurface2 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
+
     //! Returns the number of implicit surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/implicit_surface_set3.h
+++ b/include/jet/implicit_surface_set3.h
@@ -44,6 +44,9 @@ class ImplicitSurfaceSet3 final : public ImplicitSurface3 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
+
     //! Returns the number of implicit surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/surface2.h
+++ b/include/jet/surface2.h
@@ -69,6 +69,9 @@ class Surface2 {
     //! Returns true if bounding box can be defined.
     virtual bool isBounded() const;
 
+    //! Returns true if the surface is a valid geometry.
+    virtual bool isValidGeometry() const;
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.

--- a/include/jet/surface3.h
+++ b/include/jet/surface3.h
@@ -69,6 +69,9 @@ class Surface3 {
     //! Returns true if bounding box can be defined.
     virtual bool isBounded() const;
 
+    //! Returns true if the surface is a valid geometry.
+    virtual bool isValidGeometry() const;
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.

--- a/include/jet/surface_set2.h
+++ b/include/jet/surface_set2.h
@@ -39,6 +39,9 @@ class SurfaceSet2 final : public Surface2 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
+
     //! Returns the number of surfaces.
     size_t numberOfSurfaces() const;
 

--- a/include/jet/surface_set3.h
+++ b/include/jet/surface_set3.h
@@ -39,6 +39,9 @@ class SurfaceSet3 final : public Surface3 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
+
     //! Returns the number of surfaces.
     size_t numberOfSurfaces() const;
 

--- a/src/jet/collider2.cpp
+++ b/src/jet/collider2.cpp
@@ -18,6 +18,12 @@ Collider2::~Collider2() {}
 
 void Collider2::resolveCollision(double radius, double restitutionCoefficient,
                                  Vector2D* newPosition, Vector2D* newVelocity) {
+    JET_ASSERT(_surface);
+
+    if (!_surface->isValidGeometry()) {
+        return;
+    }
+
     ColliderQueryResult colliderPoint;
 
     getClosestPoint(_surface, *newPosition, &colliderPoint);
@@ -99,6 +105,12 @@ bool Collider2::isPenetrating(const ColliderQueryResult& colliderPoint,
 
 void Collider2::update(double currentTimeInSeconds,
                        double timeIntervalInSeconds) {
+    JET_ASSERT(_surface);
+
+    if (!_surface->isValidGeometry()) {
+        return;
+    }
+
     _surface->updateQueryEngine();
 
     if (_onUpdateCallback) {

--- a/src/jet/collider3.cpp
+++ b/src/jet/collider3.cpp
@@ -18,6 +18,12 @@ Collider3::~Collider3() {}
 
 void Collider3::resolveCollision(double radius, double restitutionCoefficient,
                                  Vector3D* newPosition, Vector3D* newVelocity) {
+    JET_ASSERT(_surface);
+
+    if (!_surface->isValidGeometry()) {
+        return;
+    }
+
     ColliderQueryResult colliderPoint;
 
     getClosestPoint(_surface, *newPosition, &colliderPoint);
@@ -99,6 +105,12 @@ bool Collider3::isPenetrating(const ColliderQueryResult& colliderPoint,
 
 void Collider3::update(double currentTimeInSeconds,
                        double timeIntervalInSeconds) {
+    JET_ASSERT(_surface);
+
+    if (!_surface->isValidGeometry()) {
+        return;
+    }
+
     _surface->updateQueryEngine();
 
     if (_onUpdateCallback) {

--- a/src/jet/implicit_surface_set2.cpp
+++ b/src/jet/implicit_surface_set2.cpp
@@ -41,6 +41,8 @@ ImplicitSurfaceSet2::ImplicitSurfaceSet2(const ImplicitSurfaceSet2& other)
 
 void ImplicitSurfaceSet2::updateQueryEngine() { buildBvh(); }
 
+bool ImplicitSurfaceSet2::isValidGeometry() const { return !_surfaces.empty(); }
+
 size_t ImplicitSurfaceSet2::numberOfSurfaces() const {
     return _surfaces.size();
 }

--- a/src/jet/implicit_surface_set2.cpp
+++ b/src/jet/implicit_surface_set2.cpp
@@ -41,7 +41,17 @@ ImplicitSurfaceSet2::ImplicitSurfaceSet2(const ImplicitSurfaceSet2& other)
 
 void ImplicitSurfaceSet2::updateQueryEngine() { buildBvh(); }
 
-bool ImplicitSurfaceSet2::isValidGeometry() const { return !_surfaces.empty(); }
+bool ImplicitSurfaceSet2::isValidGeometry() const {
+    // All surfaces should be valid.
+    for (auto surface : _surfaces) {
+        if (!surface->isValidGeometry()) {
+            return false;
+        }
+    }
+
+    // Empty set is not valid.
+    return !_surfaces.empty();
+}
 
 size_t ImplicitSurfaceSet2::numberOfSurfaces() const {
     return _surfaces.size();

--- a/src/jet/implicit_surface_set3.cpp
+++ b/src/jet/implicit_surface_set3.cpp
@@ -41,6 +41,8 @@ ImplicitSurfaceSet3::ImplicitSurfaceSet3(const ImplicitSurfaceSet3& other)
 
 void ImplicitSurfaceSet3::updateQueryEngine() { buildBvh(); }
 
+bool ImplicitSurfaceSet3::isValidGeometry() const { return !_surfaces.empty(); }
+
 size_t ImplicitSurfaceSet3::numberOfSurfaces() const {
     return _surfaces.size();
 }

--- a/src/jet/implicit_surface_set3.cpp
+++ b/src/jet/implicit_surface_set3.cpp
@@ -41,7 +41,17 @@ ImplicitSurfaceSet3::ImplicitSurfaceSet3(const ImplicitSurfaceSet3& other)
 
 void ImplicitSurfaceSet3::updateQueryEngine() { buildBvh(); }
 
-bool ImplicitSurfaceSet3::isValidGeometry() const { return !_surfaces.empty(); }
+bool ImplicitSurfaceSet3::isValidGeometry() const {
+    // All surfaces should be valid.
+    for (auto surface : _surfaces) {
+        if (!surface->isValidGeometry()) {
+            return false;
+        }
+    }
+
+    // Empty set is not valid.
+    return !_surfaces.empty();
+}
 
 size_t ImplicitSurfaceSet3::numberOfSurfaces() const {
     return _surfaces.size();

--- a/src/jet/surface2.cpp
+++ b/src/jet/surface2.cpp
@@ -59,6 +59,10 @@ bool Surface2::isBounded() const {
     return true;
 }
 
+bool Surface2::isValidGeometry() const {
+    return true;
+}
+
 bool Surface2::intersectsLocal(const Ray2D& rayLocal) const {
     auto result = closestIntersectionLocal(rayLocal);
     return result.isIntersecting;

--- a/src/jet/surface3.cpp
+++ b/src/jet/surface3.cpp
@@ -64,6 +64,10 @@ bool Surface3::isBounded() const {
     return true;
 }
 
+bool Surface3::isValidGeometry() const {
+    return true;
+}
+
 double Surface3::closestDistanceLocal(const Vector3D& otherPointLocal) const {
     return otherPointLocal.distanceTo(closestPointLocal(otherPointLocal));
 }

--- a/src/jet/surface_set2.cpp
+++ b/src/jet/surface_set2.cpp
@@ -32,6 +32,8 @@ SurfaceSet2::SurfaceSet2(const SurfaceSet2& other)
 
 void SurfaceSet2::updateQueryEngine() { buildBvh(); }
 
+bool SurfaceSet2::isValidGeometry() const { return !_surfaces.empty(); }
+
 size_t SurfaceSet2::numberOfSurfaces() const { return _surfaces.size(); }
 
 const Surface2Ptr& SurfaceSet2::surfaceAt(size_t i) const {

--- a/src/jet/surface_set2.cpp
+++ b/src/jet/surface_set2.cpp
@@ -32,7 +32,17 @@ SurfaceSet2::SurfaceSet2(const SurfaceSet2& other)
 
 void SurfaceSet2::updateQueryEngine() { buildBvh(); }
 
-bool SurfaceSet2::isValidGeometry() const { return !_surfaces.empty(); }
+bool SurfaceSet2::isValidGeometry() const {
+    // All surfaces should be valid.
+    for (auto surface : _surfaces) {
+        if (!surface->isValidGeometry()) {
+            return false;
+        }
+    }
+
+    // Empty set is not valid.
+    return !_surfaces.empty();
+}
 
 size_t SurfaceSet2::numberOfSurfaces() const { return _surfaces.size(); }
 

--- a/src/jet/surface_set3.cpp
+++ b/src/jet/surface_set3.cpp
@@ -32,7 +32,17 @@ SurfaceSet3::SurfaceSet3(const SurfaceSet3& other)
 
 void SurfaceSet3::updateQueryEngine() { buildBvh(); }
 
-bool SurfaceSet3::isValidGeometry() const { return !_surfaces.empty(); }
+bool SurfaceSet3::isValidGeometry() const {
+    // All surfaces should be valid.
+    for (auto surface : _surfaces) {
+        if (!surface->isValidGeometry()) {
+            return false;
+        }
+    }
+
+    // Empty set is not valid.
+    return !_surfaces.empty();
+}
 
 size_t SurfaceSet3::numberOfSurfaces() const { return _surfaces.size(); }
 

--- a/src/jet/surface_set3.cpp
+++ b/src/jet/surface_set3.cpp
@@ -32,6 +32,8 @@ SurfaceSet3::SurfaceSet3(const SurfaceSet3& other)
 
 void SurfaceSet3::updateQueryEngine() { buildBvh(); }
 
+bool SurfaceSet3::isValidGeometry() const { return !_surfaces.empty(); }
+
 size_t SurfaceSet3::numberOfSurfaces() const { return _surfaces.size(); }
 
 const Surface3Ptr& SurfaceSet3::surfaceAt(size_t i) const {

--- a/src/tests/unit_tests/implicit_surface_set2_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set2_tests.cpp
@@ -199,3 +199,15 @@ TEST(ImplicitSurfaceSet2, ClosestNormal) {
     EXPECT_DOUBLE_EQ(boxNormal.x, setNormal.x);
     EXPECT_DOUBLE_EQ(boxNormal.y, setNormal.y);
 }
+
+TEST(ImplicitSurfaceSet2, IsValidGeometry) {
+    auto surfaceSet = ImplicitSurfaceSet2::builder()
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isValidGeometry());
+
+    auto box = std::make_shared<Box2>(BoundingBox2D({0, 0}, {1, 2}));
+    surfaceSet->addExplicitSurface(box);
+
+    EXPECT_TRUE(surfaceSet->isValidGeometry());
+}

--- a/src/tests/unit_tests/implicit_surface_set2_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set2_tests.cpp
@@ -201,13 +201,17 @@ TEST(ImplicitSurfaceSet2, ClosestNormal) {
 }
 
 TEST(ImplicitSurfaceSet2, IsValidGeometry) {
-    auto surfaceSet = ImplicitSurfaceSet2::builder()
-            .makeShared();
+    auto surfaceSet = ImplicitSurfaceSet2::builder().makeShared();
 
     EXPECT_FALSE(surfaceSet->isValidGeometry());
 
     auto box = std::make_shared<Box2>(BoundingBox2D({0, 0}, {1, 2}));
-    surfaceSet->addExplicitSurface(box);
+    auto surfaceSet2 = ImplicitSurfaceSet2::builder().makeShared();
+    surfaceSet2->addExplicitSurface(box);
 
-    EXPECT_TRUE(surfaceSet->isValidGeometry());
+    EXPECT_TRUE(surfaceSet2->isValidGeometry());
+
+    surfaceSet2->addSurface(surfaceSet);
+
+    EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }

--- a/src/tests/unit_tests/implicit_surface_set3_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set3_tests.cpp
@@ -203,3 +203,15 @@ TEST(ImplicitSurfaceSet3, ClosestNormal) {
     EXPECT_DOUBLE_EQ(boxNormal.y, setNormal.y);
     EXPECT_DOUBLE_EQ(boxNormal.z, setNormal.z);
 }
+
+TEST(ImplicitSurfaceSet3, IsValidGeometry) {
+    auto surfaceSet = ImplicitSurfaceSet3::builder()
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isValidGeometry());
+
+    auto box = std::make_shared<Box3>(BoundingBox3D({0, 0, 0}, {1, 2, 3}));
+    surfaceSet->addExplicitSurface(box);
+
+    EXPECT_TRUE(surfaceSet->isValidGeometry());
+}

--- a/src/tests/unit_tests/implicit_surface_set3_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set3_tests.cpp
@@ -205,13 +205,17 @@ TEST(ImplicitSurfaceSet3, ClosestNormal) {
 }
 
 TEST(ImplicitSurfaceSet3, IsValidGeometry) {
-    auto surfaceSet = ImplicitSurfaceSet3::builder()
-            .makeShared();
+    auto surfaceSet = ImplicitSurfaceSet3::builder().makeShared();
 
     EXPECT_FALSE(surfaceSet->isValidGeometry());
 
     auto box = std::make_shared<Box3>(BoundingBox3D({0, 0, 0}, {1, 2, 3}));
-    surfaceSet->addExplicitSurface(box);
+    auto surfaceSet2 = ImplicitSurfaceSet3::builder().makeShared();
+    surfaceSet2->addExplicitSurface(box);
 
-    EXPECT_TRUE(surfaceSet->isValidGeometry());
+    EXPECT_TRUE(surfaceSet2->isValidGeometry());
+
+    surfaceSet2->addSurface(surfaceSet);
+
+    EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }

--- a/src/tests/unit_tests/rigid_body_collider2_tests.cpp
+++ b/src/tests/unit_tests/rigid_body_collider2_tests.cpp
@@ -4,8 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <jet/rigid_body_collider2.h>
+#include <jet/implicit_surface_set2.h>
 #include <jet/plane2.h>
+#include <jet/rigid_body_collider2.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
@@ -21,11 +23,8 @@ TEST(RigidBodyCollider2, ResolveCollision) {
         double radius = 0.05;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -43,11 +42,8 @@ TEST(RigidBodyCollider2, ResolveCollision) {
         double radius = 0.2;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.2, newPosition.y);
@@ -63,11 +59,8 @@ TEST(RigidBodyCollider2, ResolveCollision) {
         double radius = 0.1;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -85,11 +78,8 @@ TEST(RigidBodyCollider2, ResolveCollision) {
         double radius = 0.1;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -109,11 +99,8 @@ TEST(RigidBodyCollider2, ResolveCollision) {
 
         collider.setFrictionCoefficient(0.1);
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -134,4 +121,21 @@ TEST(RigidBodyCollider2, VelocityAt) {
     Vector2D result = collider.velocityAt({5, 7});
     EXPECT_DOUBLE_EQ(-35.0, result.x);
     EXPECT_DOUBLE_EQ(27.0, result.y);
+}
+
+TEST(RigidBodyCollider2, Empty) {
+    RigidBodyCollider2 collider(ImplicitSurfaceSet2::builder().makeShared());
+
+    Vector2D newPosition(1, 0.1);
+    Vector2D newVelocity(1, 0);
+    double radius = 0.05;
+    double restitutionCoefficient = 0.5;
+
+    collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                              &newVelocity);
+
+    EXPECT_DOUBLE_EQ(1.0, newPosition.x);
+    EXPECT_DOUBLE_EQ(0.1, newPosition.y);
+    EXPECT_DOUBLE_EQ(1.0, newVelocity.x);
+    EXPECT_DOUBLE_EQ(0.0, newVelocity.y);
 }

--- a/src/tests/unit_tests/rigid_body_collider3_tests.cpp
+++ b/src/tests/unit_tests/rigid_body_collider3_tests.cpp
@@ -4,8 +4,10 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <jet/rigid_body_collider3.h>
+#include <jet/implicit_surface_set3.h>
 #include <jet/plane3.h>
+#include <jet/rigid_body_collider3.h>
+
 #include <gtest/gtest.h>
 
 using namespace jet;
@@ -21,11 +23,8 @@ TEST(RigidBodyCollider3, ResolveCollision) {
         double radius = 0.05;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -45,11 +44,8 @@ TEST(RigidBodyCollider3, ResolveCollision) {
         double radius = 0.2;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.2, newPosition.y);
@@ -66,11 +62,8 @@ TEST(RigidBodyCollider3, ResolveCollision) {
         double radius = 0.1;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -90,11 +83,8 @@ TEST(RigidBodyCollider3, ResolveCollision) {
         double radius = 0.1;
         double restitutionCoefficient = 0.5;
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -116,11 +106,8 @@ TEST(RigidBodyCollider3, ResolveCollision) {
 
         collider.setFrictionCoefficient(0.1);
 
-        collider.resolveCollision(
-            radius,
-            restitutionCoefficient,
-            &newPosition,
-            &newVelocity);
+        collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                                  &newVelocity);
 
         EXPECT_DOUBLE_EQ(1.0, newPosition.x);
         EXPECT_DOUBLE_EQ(0.1, newPosition.y);
@@ -144,4 +131,23 @@ TEST(RigidBodyCollider3, VelocityAt) {
     EXPECT_DOUBLE_EQ(-35.0, result.x);
     EXPECT_DOUBLE_EQ(27.0, result.y);
     EXPECT_DOUBLE_EQ(-2.0, result.z);
+}
+
+TEST(RigidBodyCollider3, Empty) {
+    RigidBodyCollider3 collider(ImplicitSurfaceSet3::builder().makeShared());
+
+    Vector3D newPosition(1, 0.1, 0);
+    Vector3D newVelocity(1, 0, 0);
+    double radius = 0.05;
+    double restitutionCoefficient = 0.5;
+
+    collider.resolveCollision(radius, restitutionCoefficient, &newPosition,
+                              &newVelocity);
+
+    EXPECT_DOUBLE_EQ(1.0, newPosition.x);
+    EXPECT_DOUBLE_EQ(0.1, newPosition.y);
+    EXPECT_DOUBLE_EQ(0.0, newPosition.z);
+    EXPECT_DOUBLE_EQ(1.0, newVelocity.x);
+    EXPECT_DOUBLE_EQ(0.0, newVelocity.y);
+    EXPECT_DOUBLE_EQ(0.0, newVelocity.z);
 }

--- a/src/tests/unit_tests/surface_set2_tests.cpp
+++ b/src/tests/unit_tests/surface_set2_tests.cpp
@@ -394,3 +394,28 @@ TEST(SurfaceSet2, MixedBoundTypes) {
 
     EXPECT_VECTOR2_NEAR(answer, cp, 1e-9);
 }
+
+TEST(SurfaceSet2, IsValidGeometry) {
+    auto surfaceSet = SurfaceSet2::builder()
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isValidGeometry());
+
+    BoundingBox2D domain(Vector2D(), Vector2D(1, 2));
+
+    auto plane = Plane2::builder()
+            .withNormal({0, 1})
+            .withPoint({0, 0.25 * domain.height()})
+            .makeShared();
+
+    auto sphere = Sphere2::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet2 = SurfaceSet2::builder()
+            .withSurfaces({plane, sphere})
+            .makeShared();
+
+    EXPECT_TRUE(surfaceSet2->isValidGeometry());
+}

--- a/src/tests/unit_tests/surface_set2_tests.cpp
+++ b/src/tests/unit_tests/surface_set2_tests.cpp
@@ -418,4 +418,8 @@ TEST(SurfaceSet2, IsValidGeometry) {
             .makeShared();
 
     EXPECT_TRUE(surfaceSet2->isValidGeometry());
+
+    surfaceSet2->addSurface(surfaceSet);
+
+    EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }

--- a/src/tests/unit_tests/surface_set3_tests.cpp
+++ b/src/tests/unit_tests/surface_set3_tests.cpp
@@ -420,4 +420,8 @@ TEST(SurfaceSet3, IsValidGeometry) {
             .makeShared();
 
     EXPECT_TRUE(surfaceSet2->isValidGeometry());
+
+    surfaceSet2->addSurface(surfaceSet);
+
+    EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }

--- a/src/tests/unit_tests/surface_set3_tests.cpp
+++ b/src/tests/unit_tests/surface_set3_tests.cpp
@@ -396,3 +396,28 @@ TEST(SurfaceSet3, MixedBoundTypes) {
 
     EXPECT_VECTOR3_NEAR(answer, cp, 1e-9);
 }
+
+TEST(SurfaceSet3, IsValidGeometry) {
+    auto surfaceSet = SurfaceSet3::builder()
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isValidGeometry());
+
+    BoundingBox3D domain(Vector3D(), Vector3D(1, 2, 1));
+
+    auto plane = Plane3::builder()
+            .withNormal({0, 1, 0})
+            .withPoint({0, 0.25 * domain.height(), 0})
+            .makeShared();
+
+    auto sphere = Sphere3::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet2 = SurfaceSet3::builder()
+            .withSurfaces({plane, sphere})
+            .makeShared();
+
+    EXPECT_TRUE(surfaceSet2->isValidGeometry());
+}


### PR DESCRIPTION
This revision adds "isInvalidGeometry" to check if a surface is/has a valid geometry. Surface set types of classes override this method and return false if they do not contain any geometries.

This PR fixes Issue #200 