### PR TITLE
Fix debug macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,11 @@ include_directories(external/tinyobj)
 include_directories(src/examples)
 
 # Build type - Release by default
+message("CMake build type: " ${CMAKE_BUILD_TYPE})
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
+elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
+    add_definitions(-DDEBUG)
 endif()
 
 # Configure tasking system backend

--- a/src/jet/triangle_mesh3.cpp
+++ b/src/jet/triangle_mesh3.cpp
@@ -253,20 +253,12 @@ void TriangleMesh3::addPointTriangle(const Point3UI& newPointIndices) {
 }
 
 void TriangleMesh3::addNormalTriangle(const Point3UI& newNormalIndices) {
-    // Number of normal indices must match with number of point indices once
-    // you decided to add normal indices. Same for the uvs as well.
-    JET_ASSERT(_pointIndices.size() == _normalIndices.size());
-
     _normalIndices.append(newNormalIndices);
 
     invalidateBvh();
 }
 
 void TriangleMesh3::addUvTriangle(const Point3UI& newUvIndices) {
-    // Number of normal indices must match with number of point indices once
-    // you decided to add normal indices. Same for the uvs as well.
-    JET_ASSERT(_pointIndices.size() == _uvIndices.size());
-
     _uvIndices.append(newUvIndices);
 
     invalidateBvh();
@@ -274,10 +266,6 @@ void TriangleMesh3::addUvTriangle(const Point3UI& newUvIndices) {
 
 void TriangleMesh3::addPointNormalTriangle(const Point3UI& newPointIndices,
                                            const Point3UI& newNormalIndices) {
-    // Number of normal indices must match with number of point indices once
-    // you decided to add normal indices. Same for the uvs as well.
-    JET_ASSERT(_pointIndices.size() == _normalIndices.size());
-
     _pointIndices.append(newPointIndices);
     _normalIndices.append(newNormalIndices);
 
@@ -287,10 +275,6 @@ void TriangleMesh3::addPointNormalTriangle(const Point3UI& newPointIndices,
 void TriangleMesh3::addPointUvNormalTriangle(const Point3UI& newPointIndices,
                                              const Point3UI& newUvIndices,
                                              const Point3UI& newNormalIndices) {
-    // Number of normal indices must match with number of point indices once
-    // you decided to add normal indices. Same for the uvs as well.
-    JET_ASSERT(_pointIndices.size() == _normalIndices.size());
-    JET_ASSERT(_pointIndices.size() == _uvIndices.size());
     _pointIndices.append(newPointIndices);
     _normalIndices.append(newNormalIndices);
     _uvIndices.append(newUvIndices);
@@ -300,9 +284,6 @@ void TriangleMesh3::addPointUvNormalTriangle(const Point3UI& newPointIndices,
 
 void TriangleMesh3::addPointUvTriangle(const Point3UI& newPointIndices,
                                        const Point3UI& newUvIndices) {
-    // Number of normal indices must match with number of point indices once
-    // you decided to add normal indices. Same for the uvs as well.
-    JET_ASSERT(_pointIndices.size() == _uvs.size());
     _pointIndices.append(newPointIndices);
     _uvIndices.append(newUvIndices);
 


### PR DESCRIPTION
This revision fixes `DEBUG` macro not being enabled under `CMAKE_BUILD_TYPE=Debug`. This also removes wrong assert statements from `TriangleMesh3` code.