### PR TITLE
CMake library exports

### DIFF
--- a/src/jet/CMakeLists.txt
+++ b/src/jet/CMakeLists.txt
@@ -47,9 +47,9 @@ set_target_properties(${target}
 # Compile options
 target_compile_options(${target}
     PRIVATE
+    ${DEFAULT_COMPILE_OPTIONS}
 
     PUBLIC
-    ${DEFAULT_COMPILE_OPTIONS}
 
     INTERFACE
 )

--- a/src/jet/CMakeLists.txt
+++ b/src/jet/CMakeLists.txt
@@ -12,12 +12,6 @@ set(target jet)
 # Define
 set(root_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
-# Includes
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty
-)
-
 # Sources
 file(GLOB header_dir
     ${root_dir}/include/${target})
@@ -70,6 +64,23 @@ target_link_libraries(${target}
     INTERFACE
 )
 
+# Includes
+target_include_directories(${target}
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty
+
+    PUBLIC
+
+    INTERFACE
+    $<BUILD_INTERFACE:${header_dir}>
+    $<INSTALL_INTERFACE:include>
+)
+
 # Install
-install(TARGETS ${target} DESTINATION lib)
+install(TARGETS ${target} DESTINATION lib EXPORT ${target}_Export)
 install(DIRECTORY ${header_dir} DESTINATION include)
+install(EXPORT ${target}_Export
+  DESTINATION lib/cmake/${target}
+  FILE ${target}Config.cmake
+)


### PR DESCRIPTION
Hi,

I recently made a plugin for a vis app our group is making (OSPRay Studio) which uses ```libjet```! I wanted to properly have CMake targets imported from a library install of ```libjet```, so I implemented what I needed to make that work.

However, I'm not sure if this is "complete enough" for my taste, but I'm needing to move on to other things...thus I figured we could at least start a discussion around this to see if it is useful enough to upstream or if it needs some additional changes.