### PR TITLE
Make code coverage build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ include(cmake/CompileOptions.cmake)
 
 # Code coverage - Debug only
 # NOTE: Code coverage results with an optimized (non-Debug) build may be misleading
-if (CMAKE_BUILD_TYPE MATCHES Debug AND CMAKE_COMPILER_IS_GNUCXX)
+option(BUILD_COVERAGE "Build code coverage" OFF)
+if (CMAKE_BUILD_TYPE MATCHES Debug AND CMAKE_COMPILER_IS_GNUCXX AND BUILD_COVERAGE)
     include(CodeCoverage)
     setup_target_for_coverage(${PROJECT_NAME}_coverage unit_tests coverage)
 endif()

--- a/scripts/travis_build_codecov.sh
+++ b/scripts/travis_build_codecov.sh
@@ -8,7 +8,7 @@ sudo apt-get install -yq lcov curl
 
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_COVERAGE=ON
 make unit_tests
 lcov -c -i -d src/tests/unit_tests -o base.info
 bin/unit_tests


### PR DESCRIPTION
Code coverage build is now optional and turned off by default. This removes dependency to `lcov` when simply building Jet under debug mode.