### PR TITLE
Add ImplicitTriangleMesh3 and marchingCubes to Python API

### DIFF
--- a/include/jet/implicit_triangle_mesh3.h
+++ b/include/jet/implicit_triangle_mesh3.h
@@ -27,12 +27,11 @@ class ImplicitTriangleMesh3 final : public ImplicitSurface3 {
  public:
     class Builder;
 
-    ImplicitTriangleMesh3(
-        const TriangleMesh3Ptr& mesh,
-        size_t resolutionX,
-        double margin,
-        const Transform3& transform = Transform3(),
-        bool isNormalFlipped = false);
+    //! Constructs an ImplicitSurface3 with mesh and other grid parameters.
+    ImplicitTriangleMesh3(const TriangleMesh3Ptr& mesh, size_t resolutionX,
+                          double margin,
+                          const Transform3& transform = Transform3(),
+                          bool isNormalFlipped = false);
 
     virtual ~ImplicitTriangleMesh3();
 
@@ -55,8 +54,7 @@ class ImplicitTriangleMesh3 final : public ImplicitSurface3 {
 
     BoundingBox3D boundingBoxLocal() const override;
 
-    Vector3D closestNormalLocal(
-        const Vector3D& otherPoint) const override;
+    Vector3D closestNormalLocal(const Vector3D& otherPoint) const override;
 
     double signedDistanceLocal(const Vector3D& otherPoint) const override;
 

--- a/src/examples/python_examples/apic_example03.py
+++ b/src/examples/python_examples/apic_example03.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2018 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+from pyjet import *
+import numpy as np
+import os
+
+ANIM_NUM_FRAMES = 360
+ANIM_FPS = 60
+
+
+def main():
+    # Create APIC solver
+    resX = 100
+    solver = ApicSolver3(resolution=(resX, resX, resX), domainSizeX=1.0)
+    solver.useCompressedLinearSystem = True
+
+    # Setup emitter
+    bunny_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../resources/bunny.obj')
+    bunny_mesh = TriangleMesh3()
+    bunny_mesh.readObj(bunny_filename)
+    bunny_sdf = ImplicitTriangleMesh3(mesh=bunny_mesh, resolutionX=64, margin=0)
+    emitter = VolumeParticleEmitter3(implicitSurface=bunny_sdf, spacing=1.0 / (2 * resX), isOneShot=False)
+    solver.particleEmitter = emitter
+
+    # Convert to surface
+    grid_size = 1.0 / resX
+    grid = CellCenteredScalarGrid3((resX, resX, resX), (grid_size, grid_size, grid_size))
+
+    def write_surface(frame_cnt, pos):
+        converter = SphPointsToImplicit3(2.0 * grid_size, 0.5)
+        converter.convert(pos.tolist(), grid)
+        surface_mesh = marchingCubes(grid, (grid_size, grid_size, grid_size), (0, 0, 0), 0.0, DIRECTION_ALL)
+        surface_mesh.writeObj('frame_{:06d}.obj'.format(frame_cnt))
+
+    # Make first frame
+    frame = Frame(0, 1.0 / ANIM_FPS)
+
+    for i in range(ANIM_NUM_FRAMES):
+        print('Frame {:d}'.format(i))
+        solver.update(frame)
+        pos = np.array(solver.particleSystemData.positions, copy=False)
+        write_surface(i, pos)
+        frame.advance()
+
+
+if __name__ == '__main__':
+    Logging.mute()
+    main()

--- a/src/python/implicit_triangle_mesh.cpp
+++ b/src/python/implicit_triangle_mesh.cpp
@@ -27,9 +27,9 @@ void addImplicitTriangleMesh3(pybind11::module& m) {
         // CTOR
         .def(py::init<TriangleMesh3Ptr, size_t, double, Transform3, bool>(),
              R"pbdoc(
-             Constructs a triangle with given `points`, `normals`, and `uvs`.
+             Constructs an ImplicitSurface3 with mesh and other grid parameters.
              )pbdoc",
-             py::arg("points"), py::arg("normals"), py::arg("uvs"),
+             py::arg("mesh"), py::arg("resolutionX"), py::arg("margin"),
              py::arg("transform") = Transform3(),
              py::arg("isNormalFlipped") = false)
         .def_property_readonly("grid", &ImplicitTriangleMesh3::grid,

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -54,6 +54,7 @@
 #include "level_set_liquid_solver.h"
 #include "level_set_solver.h"
 #include "logging.h"
+#include "marching_cubes.h"
 #include "particle_emitter.h"
 #include "particle_emitter_set.h"
 #include "particle_system_data.h"
@@ -304,6 +305,9 @@ PYBIND11_MODULE(pyjet, m) {
     addSphSolver3(m);
     addPciSphSolver2(m);
     addPciSphSolver3(m);
+
+    // Global functions
+    addMarchingCubes(m);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = py::str(VERSION_INFO);

--- a/src/python/marching_cubes.cpp
+++ b/src/python/marching_cubes.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "marching_cubes.h"
+#include "pybind11_utils.h"
+
+#include <jet/marching_cubes.h>
+#include <jet/scalar_grid3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addMarchingCubes(pybind11::module& m) {
+    m.def("marchingCubes",
+          [](ScalarGrid3Ptr grid, py::object gridSize, py::object origin,
+             double isoValue, int bndFlag) -> TriangleMesh3Ptr {
+              auto mesh = TriangleMesh3::builder().makeShared();
+              marchingCubes(
+                  grid->constDataAccessor(), objectToVector3D(gridSize),
+                  objectToVector3D(origin), mesh.get(), isoValue, bndFlag);
+              return mesh;
+          },
+          R"pbdoc(
+          Computes marching cubes and extract triangle mesh from grid.
+          )pbdoc");
+}

--- a/src/python/marching_cubes.h
+++ b/src/python/marching_cubes.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2018 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_MARCHING_CUBES_H_
+#define SRC_PYTHON_MARCHING_CUBES_H_
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+void addMarchingCubes(pybind11::module& m);
+
+#endif  // SRC_PYTHON_MARCHING_CUBES_H_


### PR DESCRIPTION
This revision adds/fixes Python API for `ImplicitTriangleMesh3` and `marchingCubes`. It also adds new Python example, `apic_example03.py`, to demonstrate new/fixed features.