### PR TITLE
Expose more properties for VolumeParticleEmitter in Python API

### DIFF
--- a/include/jet/volume_particle_emitter3.h
+++ b/include/jet/volume_particle_emitter3.h
@@ -84,7 +84,7 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //!
     void setIsOneShot(bool newValue);
 
-    //! Returns trhe if particles can be overlapped.
+    //! Returns true if particles can be overlapped.
     bool allowOverlapping() const;
 
     //!

--- a/src/examples/python_examples/apic_example02.py
+++ b/src/examples/python_examples/apic_example02.py
@@ -38,8 +38,8 @@ def main():
     solver.collider = collider
 
     # Visualization
-    fig, ax = plt.subplots()
-    ax.set_aspect('equal')
+    fig = plt.figure(figsize=(3, 6))
+    ax = fig.add_axes([0, 0, 1, 1], frameon=False)
     ax.set_xlim(0, 1), ax.set_xticks([])
     ax.set_ylim(0, 2), ax.set_yticks([])
 

--- a/src/examples/python_examples/collider_emitter_anim_example.py
+++ b/src/examples/python_examples/collider_emitter_anim_example.py
@@ -9,6 +9,7 @@ third parties.
 """
 
 from pyjet import *
+import math
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
@@ -18,14 +19,19 @@ ANIM_FPS = 60
 
 
 def main():
+    """
+    This example demonstrates how to animate emitter as well as collider properties.
+    """
+
     # Create APIC solver
-    resX = 32
+    resX = 24
     solver = ApicSolver3(resolution=(resX, 2 * resX, resX), domainSizeX=1.0)
+    solver.useCompressedLinearSystem = True
 
     # Setup emitter
     sphere = Sphere3(center=(0.5, 1.0, 0.5), radius=0.15)
     emitter = VolumeParticleEmitter3(
-        implicitSurface=sphere, spacing=1.0 / (2 * resX))
+        implicitSurface=sphere, spacing=1.0 / (2 * resX), isOneShot=False, initialVelocity=(0, 0, 0))
     solver.particleEmitter = emitter
 
     # Setup collider
@@ -50,6 +56,16 @@ def main():
 
     # Animation
     def updatefig(*args):
+        # Change emitter velocity after frame 50
+        if frame.index == 50:
+            emitter.initialVelocity = (0, 3, 0)
+        # Stop emitter after frame 100
+        if frame.index == 100:
+            emitter.isOneShot = True
+        # Animate collider's position (and thus the velocity which is its derivative)
+        collider.surface.transform = Transform3(translation=(0.2 * math.sin(10 * frame.timeInSeconds()), 0, 0))
+        collider.linearVelocity = (2.0 * math.cos(10 * frame.timeInSeconds()), 0, 0)
+
         solver.update(frame)
         frame.advance()
         pos = np.array(solver.particleSystemData.positions, copy=False)

--- a/src/python/volume_particle_emitter.cpp
+++ b/src/python/volume_particle_emitter.cpp
@@ -85,8 +85,8 @@ void addVolumeParticleEmitter2(py::module& m) {
                  if (kwargs.contains("spacing")) {
                      spacing = kwargs["spacing"].cast<double>();
                  }
-                 if (kwargs.contains("initialVel")) {
-                     initialVel = objectToVector2D(kwargs["initialVel"]);
+                 if (kwargs.contains("initialVelocity")) {
+                     initialVel = objectToVector2D(kwargs["initialVelocity"]);
                  }
                  if (kwargs.contains("maxNumberOfParticles")) {
                      maxNumberOfParticles =
@@ -119,6 +119,36 @@ void addVolumeParticleEmitter2(py::module& m) {
              (optional), whether it's one shot or not (optional), whether it
              should allow overlapping or not (optional), and random seed
              (optional).
+             )pbdoc")
+        .def_property("jitter", &VolumeParticleEmitter2::jitter,
+                      &VolumeParticleEmitter2::setJitter, R"pbdoc(
+             Jitter amount between 0 and 1.
+             )pbdoc")
+        .def_property("isOneShot", &VolumeParticleEmitter2::isOneShot,
+                      &VolumeParticleEmitter2::setIsOneShot, R"pbdoc(
+             True if particles should be emitted just once.
+             )pbdoc")
+        .def_property("allowOverlapping",
+                      &VolumeParticleEmitter2::allowOverlapping,
+                      &VolumeParticleEmitter2::setAllowOverlapping, R"pbdoc(
+             True if particles can be overlapped.
+             )pbdoc")
+        .def_property(
+            "allowOverlapping", &VolumeParticleEmitter2::maxNumberOfParticles,
+            &VolumeParticleEmitter2::setMaxNumberOfParticles, R"pbdoc(
+             Max number of particles to be emitted.
+             )pbdoc")
+        .def_property("spacing", &VolumeParticleEmitter2::spacing,
+                      &VolumeParticleEmitter2::setSpacing, R"pbdoc(
+             The spacing between particles.
+             )pbdoc")
+        .def_property(
+            "initialVelocity", &VolumeParticleEmitter2::initialVelocity,
+            [](VolumeParticleEmitter2& instance, py::object newInitialVel) {
+                instance.setInitialVelocity(objectToVector2D(newInitialVel));
+            },
+            R"pbdoc(
+             The initial velocity of the particles.
              )pbdoc");
 }
 
@@ -192,8 +222,8 @@ void addVolumeParticleEmitter3(py::module& m) {
                  if (kwargs.contains("spacing")) {
                      spacing = kwargs["spacing"].cast<double>();
                  }
-                 if (kwargs.contains("initialVel")) {
-                     initialVel = objectToVector3D(kwargs["initialVel"]);
+                 if (kwargs.contains("initialVelocity")) {
+                     initialVel = objectToVector3D(kwargs["initialVelocity"]);
                  }
                  if (kwargs.contains("maxNumberOfParticles")) {
                      maxNumberOfParticles =
@@ -226,5 +256,35 @@ void addVolumeParticleEmitter3(py::module& m) {
              (optional), whether it's one shot or not (optional), whether it
              should allow overlapping or not (optional), and random seed
              (optional).
+             )pbdoc")
+        .def_property("jitter", &VolumeParticleEmitter3::jitter,
+                      &VolumeParticleEmitter3::setJitter, R"pbdoc(
+             Jitter amount between 0 and 1.
+             )pbdoc")
+        .def_property("isOneShot", &VolumeParticleEmitter3::isOneShot,
+                      &VolumeParticleEmitter3::setIsOneShot, R"pbdoc(
+             True if particles should be emitted just once.
+             )pbdoc")
+        .def_property("allowOverlapping",
+                      &VolumeParticleEmitter3::allowOverlapping,
+                      &VolumeParticleEmitter3::setAllowOverlapping, R"pbdoc(
+             True if particles can be overlapped.
+             )pbdoc")
+        .def_property(
+            "allowOverlapping", &VolumeParticleEmitter3::maxNumberOfParticles,
+            &VolumeParticleEmitter3::setMaxNumberOfParticles, R"pbdoc(
+             Max number of particles to be emitted.
+             )pbdoc")
+        .def_property("spacing", &VolumeParticleEmitter3::spacing,
+                      &VolumeParticleEmitter3::setSpacing, R"pbdoc(
+             The spacing between particles.
+             )pbdoc")
+        .def_property(
+            "initialVelocity", &VolumeParticleEmitter3::initialVelocity,
+            [](VolumeParticleEmitter3& instance, py::object newInitialVel) {
+                instance.setInitialVelocity(objectToVector3D(newInitialVel));
+            },
+            R"pbdoc(
+             The initial velocity of the particles.
              )pbdoc");
 }


### PR DESCRIPTION
This revision includes:
* Expose more properties for VolumeParticleEmitter in Python API
* Add a Python example to demonstrate the new APIs.
* Rendering issue workaround for Matplotlib (3.0.2).

This PR is related to Issue #220.