### PR TITLE
Fix default params for ImplicitTriangleMesh3

### DIFF
--- a/include/jet/implicit_triangle_mesh3.h
+++ b/include/jet/implicit_triangle_mesh3.h
@@ -28,8 +28,8 @@ class ImplicitTriangleMesh3 final : public ImplicitSurface3 {
     class Builder;
 
     //! Constructs an ImplicitSurface3 with mesh and other grid parameters.
-    ImplicitTriangleMesh3(const TriangleMesh3Ptr& mesh, size_t resolutionX,
-                          double margin,
+    ImplicitTriangleMesh3(const TriangleMesh3Ptr& mesh, size_t resolutionX = 32,
+                          double margin = 0.2,
                           const Transform3& transform = Transform3(),
                           bool isNormalFlipped = false);
 

--- a/src/examples/python_examples/apic_example03.py
+++ b/src/examples/python_examples/apic_example03.py
@@ -26,16 +26,16 @@ def main():
     bunny_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../resources/bunny.obj')
     bunny_mesh = TriangleMesh3()
     bunny_mesh.readObj(bunny_filename)
-    bunny_sdf = ImplicitTriangleMesh3(mesh=bunny_mesh, resolutionX=64, margin=0)
+    bunny_sdf = ImplicitTriangleMesh3(mesh=bunny_mesh, resolutionX=64, margin=0.2)
     emitter = VolumeParticleEmitter3(implicitSurface=bunny_sdf, spacing=1.0 / (2 * resX), isOneShot=False)
     solver.particleEmitter = emitter
 
     # Convert to surface
     grid_size = 1.0 / resX
-    grid = CellCenteredScalarGrid3((resX, resX, resX), (grid_size, grid_size, grid_size))
+    grid = VertexCenteredScalarGrid3((resX, resX, resX), (grid_size, grid_size, grid_size))
 
     def write_surface(frame_cnt, pos):
-        converter = SphPointsToImplicit3(2.0 * grid_size, 0.5)
+        converter = SphPointsToImplicit3(1.5 * grid_size, 0.5)
         converter.convert(pos.tolist(), grid)
         surface_mesh = marchingCubes(grid, (grid_size, grid_size, grid_size), (0, 0, 0), 0.0, DIRECTION_ALL)
         surface_mesh.writeObj('frame_{:06d}.obj'.format(frame_cnt))

--- a/src/python/implicit_triangle_mesh.cpp
+++ b/src/python/implicit_triangle_mesh.cpp
@@ -29,8 +29,8 @@ void addImplicitTriangleMesh3(pybind11::module& m) {
              R"pbdoc(
              Constructs an ImplicitSurface3 with mesh and other grid parameters.
              )pbdoc",
-             py::arg("mesh"), py::arg("resolutionX"), py::arg("margin"),
-             py::arg("transform") = Transform3(),
+             py::arg("mesh"), py::arg("resolutionX") = 32,
+             py::arg("margin") = 0.2, py::arg("transform") = Transform3(),
              py::arg("isNormalFlipped") = false)
         .def_property_readonly("grid", &ImplicitTriangleMesh3::grid,
                                R"pbdoc(The grid data.)pbdoc");


### PR DESCRIPTION
This revision includes:
* Consistent default parameters for ImplicitTriangleMesh3 between C++ and Python APIs
* Python APIC example fix (`margin=0` should not be used). This issue was reported in issue #191