### PR TITLE
Animation support for emitters and collider sets in Python

### DIFF
--- a/include/jet/volume_particle_emitter2.h
+++ b/include/jet/volume_particle_emitter2.h
@@ -12,6 +12,7 @@
 #include <jet/implicit_surface2.h>
 #include <jet/particle_emitter2.h>
 #include <jet/point_generator2.h>
+
 #include <limits>
 #include <memory>
 #include <random>
@@ -35,7 +36,9 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //! \param[in]  implicitSurface         The implicit surface.
     //! \param[in]  maxRegion               The max region.
     //! \param[in]  spacing                 The spacing between particles.
-    //! \param[in]  initialVel              The initial velocity.
+    //! \param[in]  initialVel              The initial velocity of new particles.
+    //! \param[in]  linearVel               The linear velocity of the emitter.
+    //! \param[in]  angularVel              The angular velocity of the emitter.
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
     //!                                     emitted.
     //! \param[in]  jitter                  The jitter amount between 0 and 1.
@@ -49,6 +52,8 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
         const BoundingBox2D& maxRegion,
         double spacing,
         const Vector2D& initialVel = Vector2D(),
+        const Vector2D& linearVel = Vector2D(),
+        double angularVel = 0.0,
         size_t maxNumberOfParticles = kMaxSize,
         double jitter = 0.0,
         bool isOneShot = true,
@@ -152,7 +157,7 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     double _spacing;
     Vector2D _initialVel;
     Vector2D _linearVel;
-    double _angularVel;
+    double _angularVel = 0.0;
     PointGenerator2Ptr _pointsGen;
 
     size_t _maxNumberOfParticles = kMaxSize;
@@ -206,6 +211,12 @@ class VolumeParticleEmitter2::Builder final {
     //! Returns builder with initial velocity.
     Builder& withInitialVelocity(const Vector2D& initialVel);
 
+    //! Returns builder with linear velocity.
+    Builder& withLinearVelocity(const Vector2D& linearVel);
+
+    //! Returns builder with angular velocity.
+    Builder& withAngularVelocity(double angularVel);
+
     //! Returns builder with max number of particles.
     Builder& withMaxNumberOfParticles(size_t maxNumberOfParticles);
 
@@ -232,7 +243,9 @@ class VolumeParticleEmitter2::Builder final {
     bool _isBoundSet = false;
     BoundingBox2D _bounds;
     double _spacing = 0.1;
-    Vector2D _initialVel{0, 0};
+    Vector2D _initialVel;
+    Vector2D _linearVel;
+    double _angularVel = 0.0;
     size_t _maxNumberOfParticles = kMaxSize;
     double _jitter = 0.0;
     bool _isOneShot = true;

--- a/include/jet/volume_particle_emitter2.h
+++ b/include/jet/volume_particle_emitter2.h
@@ -33,7 +33,7 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //! the particle generation region.
     //!
     //! \param[in]  implicitSurface         The implicit surface.
-    //! \param[in]  bounds                  The max region.
+    //! \param[in]  maxRegion               The max region.
     //! \param[in]  spacing                 The spacing between particles.
     //! \param[in]  initialVel              The initial velocity.
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
@@ -46,7 +46,7 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //!
     VolumeParticleEmitter2(
         const ImplicitSurface2Ptr& implicitSurface,
-        const BoundingBox2D& bounds,
+        const BoundingBox2D& maxRegion,
         double spacing,
         const Vector2D& initialVel = Vector2D(),
         size_t maxNumberOfParticles = kMaxSize,
@@ -64,6 +64,18 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //! \param[in]  newPointsGen The new points generator.
     //!
     void setPointGenerator(const PointGenerator2Ptr& newPointsGen);
+
+    //! Returns source surface.
+    const ImplicitSurface2Ptr& surface() const;
+
+    //! Sets the source surface.
+    void setSurface(const ImplicitSurface2Ptr& newSurface);
+
+    //! Returns max particle gen region.
+    const BoundingBox2D& maxRegion() const;
+
+    //! Sets the max particle gen region.
+    void setMaxRegion(const BoundingBox2D& newBox);
 
     //! Returns jitter amount.
     double jitter() const;
@@ -117,6 +129,18 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //! Returns the initial velocity of the particles.
     void setInitialVelocity(const Vector2D& newInitialVel);
 
+    //! Returns the linear velocity of the emitter.
+    Vector2D linearVelocity() const;
+
+    //! Sets the linear velocity of the emitter.
+    void setLinearVelocity(const Vector2D& newLinearVel);
+
+    //! Returns the angular velocity of the emitter.
+    double angularVelocity() const;
+
+    //! Sets the linear velocity of the emitter.
+    void setAngularVelocity(double newAngularVel);
+
     //! Returns builder fox VolumeParticleEmitter2.
     static Builder builder();
 
@@ -127,6 +151,8 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     BoundingBox2D _bounds;
     double _spacing;
     Vector2D _initialVel;
+    Vector2D _linearVel;
+    double _angularVel;
     PointGenerator2Ptr _pointsGen;
 
     size_t _maxNumberOfParticles = kMaxSize;
@@ -152,6 +178,8 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
         Array1<Vector2D>* newVelocities);
 
     double random();
+
+    Vector2D velocityAt(const Vector2D& point) const;
 };
 
 //! Shared pointer for the VolumeParticleEmitter2 type.

--- a/include/jet/volume_particle_emitter3.h
+++ b/include/jet/volume_particle_emitter3.h
@@ -32,7 +32,7 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //! the particle generation region.
     //!
     //! \param[in]  implicitSurface         The implicit surface.
-    //! \param[in]  bounds                  The max region.
+    //! \param[in]  maxRegion               The max region.
     //! \param[in]  spacing                 The spacing between particles.
     //! \param[in]  initialVel              The initial velocity.
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
@@ -45,7 +45,7 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //!
     VolumeParticleEmitter3(
         const ImplicitSurface3Ptr& implicitSurface,
-        const BoundingBox3D& bounds,
+        const BoundingBox3D& maxRegion,
         double spacing,
         const Vector3D& initialVel = Vector3D(),
         size_t maxNumberOfParticles = kMaxSize,
@@ -63,6 +63,18 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //! \param[in]  newPointsGen The new points generator.
     //!
     void setPointGenerator(const PointGenerator3Ptr& newPointsGen);
+
+    //! Returns source surface.
+    const ImplicitSurface3Ptr& surface() const;
+
+    //! Sets the source surface.
+    void setSurface(const ImplicitSurface3Ptr& newSurface);
+
+    //! Returns max particle gen region.
+    const BoundingBox3D& maxRegion() const;
+
+    //! Sets the max particle gen region.
+    void setMaxRegion(const BoundingBox3D& newBox);
 
     //! Returns jitter amount.
     double jitter() const;
@@ -116,6 +128,18 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //! Returns the initial velocity of the particles.
     void setInitialVelocity(const Vector3D& newInitialVel);
 
+    //! Returns the linear velocity of the emitter.
+    Vector3D linearVelocity() const;
+
+    //! Sets the linear velocity of the emitter.
+    void setLinearVelocity(const Vector3D& newLinearVel);
+
+    //! Returns the angular velocity of the emitter.
+    Vector3D angularVelocity() const;
+
+    //! Sets the linear velocity of the emitter.
+    void setAngularVelocity(const Vector3D& newAngularVel);
+
     //! Returns builder fox VolumeParticleEmitter3.
     static Builder builder();
 
@@ -126,6 +150,8 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     BoundingBox3D _bounds;
     double _spacing;
     Vector3D _initialVel;
+    Vector3D _linearVel;
+    Vector3D _angularVel;
     PointGenerator3Ptr _pointsGen;
 
     size_t _maxNumberOfParticles = kMaxSize;
@@ -151,6 +177,8 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
         Array1<Vector3D>* newVelocities);
 
     double random();
+
+    Vector3D velocityAt(const Vector3D& point) const;
 };
 
 //! Shared pointer for the VolumeParticleEmitter3 type.

--- a/include/jet/volume_particle_emitter3.h
+++ b/include/jet/volume_particle_emitter3.h
@@ -11,6 +11,7 @@
 #include <jet/implicit_surface3.h>
 #include <jet/particle_emitter3.h>
 #include <jet/point_generator3.h>
+
 #include <limits>
 #include <memory>
 #include <random>
@@ -35,6 +36,8 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //! \param[in]  maxRegion               The max region.
     //! \param[in]  spacing                 The spacing between particles.
     //! \param[in]  initialVel              The initial velocity.
+    //! \param[in]  linearVel               The linear velocity of the emitter.
+    //! \param[in]  angularVel              The angular velocity of the emitter.
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
     //!                                     emitted.
     //! \param[in]  jitter                  The jitter amount between 0 and 1.
@@ -48,6 +51,8 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
         const BoundingBox3D& maxRegion,
         double spacing,
         const Vector3D& initialVel = Vector3D(),
+        const Vector3D& linearVel = Vector3D(),
+        const Vector3D& angularVel = Vector3D(),
         size_t maxNumberOfParticles = kMaxSize,
         double jitter = 0.0,
         bool isOneShot = true,
@@ -205,6 +210,12 @@ class VolumeParticleEmitter3::Builder final {
     //! Returns builder with initial velocity.
     Builder& withInitialVelocity(const Vector3D& initialVel);
 
+    //! Returns builder with linear velocity.
+    Builder& withLinearVelocity(const Vector3D& linearVel);
+
+    //! Returns builder with angular velocity.
+    Builder& withAngularVelocity(const Vector3D& angularVel);
+
     //! Returns builder with max number of particles.
     Builder& withMaxNumberOfParticles(size_t maxNumberOfParticles);
 
@@ -231,7 +242,9 @@ class VolumeParticleEmitter3::Builder final {
     bool _isBoundSet = false;
     BoundingBox3D _bounds;
     double _spacing = 0.1;
-    Vector3D _initialVel{0, 0, 0};
+    Vector3D _initialVel;
+    Vector3D _linearVel;
+    Vector3D _angularVel;
     size_t _maxNumberOfParticles = kMaxSize;
     double _jitter = 0.0;
     bool _isOneShot = true;

--- a/src/examples/python_examples/collider_emitter_anim_example.py
+++ b/src/examples/python_examples/collider_emitter_anim_example.py
@@ -31,7 +31,11 @@ def main():
     # Setup emitter
     sphere = Sphere3(center=(0.5, 1.0, 0.5), radius=0.15)
     emitter = VolumeParticleEmitter3(
-        implicitSurface=sphere, spacing=1.0 / (2 * resX), isOneShot=False, initialVelocity=(0, 0, 0))
+        implicitSurface=sphere,
+        maxRegion=solver.gridSystemData.boundingBox,
+        spacing=1.0 / (2 * resX),
+        isOneShot=False,
+        initialVelocity=(0, 0, 0))
     solver.particleEmitter = emitter
 
     # Setup collider
@@ -62,6 +66,10 @@ def main():
         # Stop emitter after frame 100
         if frame.index == 100:
             emitter.isOneShot = True
+        # Animate emitter's position (and thus the velocity which is its derivative)
+        emitter.surface.transform = Transform3(translation=(0.1 * math.sin(5 * frame.timeInSeconds()), 0, 0))
+        emitter.linearVelocity = (0.5 * math.cos(5 * frame.timeInSeconds()), 0, 0)
+
         # Animate collider's position (and thus the velocity which is its derivative)
         collider.surface.transform = Transform3(translation=(0.2 * math.sin(10 * frame.timeInSeconds()), 0, 0))
         collider.linearVelocity = (2.0 * math.cos(10 * frame.timeInSeconds()), 0, 0)

--- a/src/jet/volume_particle_emitter2.cpp
+++ b/src/jet/volume_particle_emitter2.cpp
@@ -18,12 +18,12 @@ using namespace jet;
 static const size_t kDefaultHashGridResolution = 64;
 
 VolumeParticleEmitter2::VolumeParticleEmitter2(
-    const ImplicitSurface2Ptr& implicitSurface, const BoundingBox2D& bounds,
+    const ImplicitSurface2Ptr& implicitSurface, const BoundingBox2D& maxRegion,
     double spacing, const Vector2D& initialVel, size_t maxNumberOfParticles,
     double jitter, bool isOneShot, bool allowOverlapping, uint32_t seed)
     : _rng(seed),
       _implicitSurface(implicitSurface),
-      _bounds(bounds),
+      _bounds(maxRegion),
       _spacing(spacing),
       _initialVel(initialVel),
       _maxNumberOfParticles(maxNumberOfParticles),
@@ -65,12 +65,19 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
 
     _implicitSurface->updateQueryEngine();
 
+    BoundingBox2D region = _bounds;
+    if (_implicitSurface->isBounded()) {
+        BoundingBox2D surfaceBBox = _implicitSurface->boundingBox();
+        region.lowerCorner = max(region.lowerCorner, surfaceBBox.lowerCorner);
+        region.upperCorner = min(region.upperCorner, surfaceBBox.upperCorner);
+    }
+
     // Reserving more space for jittering
     const double j = jitter();
     const double maxJitterDist = 0.5 * j * _spacing;
 
     if (_allowOverlapping || _isOneShot) {
-        _pointsGen->forEachPoint(_bounds, _spacing, [&](const Vector2D& point) {
+        _pointsGen->forEachPoint(region, _spacing, [&](const Vector2D& point) {
             double newAngleInRadian = (random() - 0.5) * kTwoPiD;
             Matrix2x2D rotationMatrix =
                 Matrix2x2D::makeRotationMatrix(newAngleInRadian);
@@ -97,7 +104,7 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
-        _pointsGen->forEachPoint(_bounds, _spacing, [&](const Vector2D& point) {
+        _pointsGen->forEachPoint(region, _spacing, [&](const Vector2D& point) {
             double newAngleInRadian = (random() - 0.5) * kTwoPiD;
             Matrix2x2D rotationMatrix =
                 Matrix2x2D::makeRotationMatrix(newAngleInRadian);
@@ -121,12 +128,30 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
     }
 
     newVelocities->resize(newPositions->size());
-    newVelocities->set(_initialVel);
+    newVelocities->parallelForEachIndex([&](size_t i) {
+        (*newVelocities)[i] = velocityAt((*newPositions)[i]);
+    });
 }
 
 void VolumeParticleEmitter2::setPointGenerator(
     const PointGenerator2Ptr& newPointsGen) {
     _pointsGen = newPointsGen;
+}
+
+const ImplicitSurface2Ptr& VolumeParticleEmitter2::surface() const {
+    return _implicitSurface;
+}
+
+void VolumeParticleEmitter2::setSurface(const ImplicitSurface2Ptr& newSurface) {
+    _implicitSurface = newSurface;
+}
+
+const BoundingBox2D& VolumeParticleEmitter2::maxRegion() const {
+    return _bounds;
+}
+
+void VolumeParticleEmitter2::setMaxRegion(const BoundingBox2D& newMaxRegion) {
+    _bounds = newMaxRegion;
 }
 
 double VolumeParticleEmitter2::jitter() const { return _jitter; }
@@ -170,9 +195,26 @@ void VolumeParticleEmitter2::setInitialVelocity(const Vector2D& newInitialVel) {
     _initialVel = newInitialVel;
 }
 
+Vector2D VolumeParticleEmitter2::linearVelocity() const { return _linearVel; }
+
+void VolumeParticleEmitter2::setLinearVelocity(const Vector2D& newLinearVel) {
+    _linearVel = newLinearVel;
+}
+
+double VolumeParticleEmitter2::angularVelocity() const { return _angularVel; }
+
+void VolumeParticleEmitter2::setAngularVelocity(double newAngularVel) {
+    _angularVel = newAngularVel;
+}
+
 double VolumeParticleEmitter2::random() {
     std::uniform_real_distribution<> d(0.0, 1.0);
     return d(_rng);
+}
+
+Vector2D VolumeParticleEmitter2::velocityAt(const Vector2D& point) const {
+    Vector2D r = point - _implicitSurface->transform.translation();
+    return _linearVel + _angularVel * Vector2D(-r.y, r.x) + _initialVel;
 }
 
 VolumeParticleEmitter2::Builder VolumeParticleEmitter2::builder() {

--- a/src/jet/volume_particle_emitter2.cpp
+++ b/src/jet/volume_particle_emitter2.cpp
@@ -19,13 +19,16 @@ static const size_t kDefaultHashGridResolution = 64;
 
 VolumeParticleEmitter2::VolumeParticleEmitter2(
     const ImplicitSurface2Ptr& implicitSurface, const BoundingBox2D& maxRegion,
-    double spacing, const Vector2D& initialVel, size_t maxNumberOfParticles,
-    double jitter, bool isOneShot, bool allowOverlapping, uint32_t seed)
+    double spacing, const Vector2D& initialVel, const Vector2D& linearVel,
+    double angularVel, size_t maxNumberOfParticles, double jitter,
+    bool isOneShot, bool allowOverlapping, uint32_t seed)
     : _rng(seed),
       _implicitSurface(implicitSurface),
       _bounds(maxRegion),
       _spacing(spacing),
       _initialVel(initialVel),
+      _linearVel(linearVel),
+      _angularVel(angularVel),
       _maxNumberOfParticles(maxNumberOfParticles),
       _jitter(jitter),
       _isOneShot(isOneShot),
@@ -261,6 +264,18 @@ VolumeParticleEmitter2::Builder::withInitialVelocity(
 }
 
 VolumeParticleEmitter2::Builder&
+VolumeParticleEmitter2::Builder::withLinearVelocity(const Vector2D& linearVel) {
+    _linearVel = linearVel;
+    return *this;
+}
+
+VolumeParticleEmitter2::Builder&
+VolumeParticleEmitter2::Builder::withAngularVelocity(double angularVel) {
+    _angularVel = angularVel;
+    return *this;
+}
+
+VolumeParticleEmitter2::Builder&
 VolumeParticleEmitter2::Builder::withMaxNumberOfParticles(
     size_t maxNumberOfParticles) {
     _maxNumberOfParticles = maxNumberOfParticles;
@@ -293,14 +308,16 @@ VolumeParticleEmitter2::Builder::withRandomSeed(uint32_t seed) {
 
 VolumeParticleEmitter2 VolumeParticleEmitter2::Builder::build() const {
     return VolumeParticleEmitter2(_implicitSurface, _bounds, _spacing,
-                                  _initialVel, _maxNumberOfParticles, _jitter,
-                                  _isOneShot, _allowOverlapping, _seed);
+                                  _initialVel, _linearVel, _angularVel,
+                                  _maxNumberOfParticles, _jitter, _isOneShot,
+                                  _allowOverlapping, _seed);
 }
 
 VolumeParticleEmitter2Ptr VolumeParticleEmitter2::Builder::makeShared() const {
     return std::shared_ptr<VolumeParticleEmitter2>(
         new VolumeParticleEmitter2(_implicitSurface, _bounds, _spacing,
-                                   _initialVel, _maxNumberOfParticles, _jitter,
-                                   _isOneShot, _allowOverlapping),
+                                   _initialVel, _linearVel, _angularVel,
+                                   _maxNumberOfParticles, _jitter, _isOneShot,
+                                   _allowOverlapping),
         [](VolumeParticleEmitter2* obj) { delete obj; });
 }

--- a/src/jet/volume_particle_emitter3.cpp
+++ b/src/jet/volume_particle_emitter3.cpp
@@ -18,13 +18,16 @@ static const size_t kDefaultHashGridResolution = 64;
 
 VolumeParticleEmitter3::VolumeParticleEmitter3(
     const ImplicitSurface3Ptr& implicitSurface, const BoundingBox3D& maxRegion,
-    double spacing, const Vector3D& initialVel, size_t maxNumberOfParticles,
-    double jitter, bool isOneShot, bool allowOverlapping, uint32_t seed)
+    double spacing, const Vector3D& initialVel, const Vector3D& linearVel,
+    const Vector3D& angularVel, size_t maxNumberOfParticles, double jitter,
+    bool isOneShot, bool allowOverlapping, uint32_t seed)
     : _rng(seed),
       _implicitSurface(implicitSurface),
       _bounds(maxRegion),
       _spacing(spacing),
       _initialVel(initialVel),
+      _linearVel(linearVel),
+      _angularVel(angularVel),
       _maxNumberOfParticles(maxNumberOfParticles),
       _jitter(jitter),
       _isOneShot(isOneShot),
@@ -254,6 +257,19 @@ VolumeParticleEmitter3::Builder::withInitialVelocity(
 }
 
 VolumeParticleEmitter3::Builder&
+VolumeParticleEmitter3::Builder::withLinearVelocity(const Vector3D& linearVel) {
+    _linearVel = linearVel;
+    return *this;
+}
+
+VolumeParticleEmitter3::Builder&
+VolumeParticleEmitter3::Builder::withAngularVelocity(
+    const Vector3D& angularVel) {
+    _angularVel = angularVel;
+    return *this;
+}
+
+VolumeParticleEmitter3::Builder&
 VolumeParticleEmitter3::Builder::withMaxNumberOfParticles(
     size_t maxNumberOfParticles) {
     _maxNumberOfParticles = maxNumberOfParticles;
@@ -286,14 +302,16 @@ VolumeParticleEmitter3::Builder::withRandomSeed(uint32_t seed) {
 
 VolumeParticleEmitter3 VolumeParticleEmitter3::Builder::build() const {
     return VolumeParticleEmitter3(_implicitSurface, _bounds, _spacing,
-                                  _initialVel, _maxNumberOfParticles, _jitter,
-                                  _isOneShot, _allowOverlapping, _seed);
+                                  _initialVel, _linearVel, _angularVel,
+                                  _maxNumberOfParticles, _jitter, _isOneShot,
+                                  _allowOverlapping, _seed);
 }
 
 VolumeParticleEmitter3Ptr VolumeParticleEmitter3::Builder::makeShared() const {
     return std::shared_ptr<VolumeParticleEmitter3>(
         new VolumeParticleEmitter3(_implicitSurface, _bounds, _spacing,
-                                   _initialVel, _maxNumberOfParticles, _jitter,
-                                   _isOneShot, _allowOverlapping),
+                                   _initialVel, _linearVel, _angularVel,
+                                   _maxNumberOfParticles, _jitter, _isOneShot,
+                                   _allowOverlapping),
         [](VolumeParticleEmitter3* obj) { delete obj; });
 }

--- a/src/jet/volume_particle_emitter3.cpp
+++ b/src/jet/volume_particle_emitter3.cpp
@@ -17,12 +17,12 @@ using namespace jet;
 static const size_t kDefaultHashGridResolution = 64;
 
 VolumeParticleEmitter3::VolumeParticleEmitter3(
-    const ImplicitSurface3Ptr& implicitSurface, const BoundingBox3D& bounds,
+    const ImplicitSurface3Ptr& implicitSurface, const BoundingBox3D& maxRegion,
     double spacing, const Vector3D& initialVel, size_t maxNumberOfParticles,
     double jitter, bool isOneShot, bool allowOverlapping, uint32_t seed)
     : _rng(seed),
       _implicitSurface(implicitSurface),
-      _bounds(bounds),
+      _bounds(maxRegion),
       _spacing(spacing),
       _initialVel(initialVel),
       _maxNumberOfParticles(maxNumberOfParticles),
@@ -63,11 +63,19 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
     }
 
     _implicitSurface->updateQueryEngine();
+
+    BoundingBox3D region = _bounds;
+    if (_implicitSurface->isBounded()) {
+        BoundingBox3D surfaceBBox = _implicitSurface->boundingBox();
+        region.lowerCorner = max(region.lowerCorner, surfaceBBox.lowerCorner);
+        region.upperCorner = min(region.upperCorner, surfaceBBox.upperCorner);
+    }
+
     // Reserving more space for jittering
     const double j = jitter();
     const double maxJitterDist = 0.5 * j * _spacing;
     if (_allowOverlapping || _isOneShot) {
-        _pointsGen->forEachPoint(_bounds, _spacing, [&](const Vector3D& point) {
+        _pointsGen->forEachPoint(region, _spacing, [&](const Vector3D& point) {
             Vector3D randomDir = uniformSampleSphere(random(), random());
             Vector3D offset = maxJitterDist * randomDir;
             Vector3D candidate = point + offset;
@@ -92,7 +100,7 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
-        _pointsGen->forEachPoint(_bounds, _spacing, [&](const Vector3D& point) {
+        _pointsGen->forEachPoint(region, _spacing, [&](const Vector3D& point) {
             Vector3D randomDir = uniformSampleSphere(random(), random());
             Vector3D offset = maxJitterDist * randomDir;
             Vector3D candidate = point + offset;
@@ -113,12 +121,30 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
     }
 
     newVelocities->resize(newPositions->size());
-    newVelocities->set(_initialVel);
+    newVelocities->parallelForEachIndex([&](size_t i) {
+        (*newVelocities)[i] = velocityAt((*newPositions)[i]);
+    });
 }
 
 void VolumeParticleEmitter3::setPointGenerator(
     const PointGenerator3Ptr& newPointsGen) {
     _pointsGen = newPointsGen;
+}
+
+const ImplicitSurface3Ptr& VolumeParticleEmitter3::surface() const {
+    return _implicitSurface;
+}
+
+void VolumeParticleEmitter3::setSurface(const ImplicitSurface3Ptr& newSurface) {
+    _implicitSurface = newSurface;
+}
+
+const BoundingBox3D& VolumeParticleEmitter3::maxRegion() const {
+    return _bounds;
+}
+
+void VolumeParticleEmitter3::setMaxRegion(const BoundingBox3D& newMaxRegion) {
+    _bounds = newMaxRegion;
 }
 
 double VolumeParticleEmitter3::jitter() const { return _jitter; }
@@ -162,9 +188,26 @@ void VolumeParticleEmitter3::setInitialVelocity(const Vector3D& newInitialVel) {
     _initialVel = newInitialVel;
 }
 
+Vector3D VolumeParticleEmitter3::linearVelocity() const { return _linearVel; }
+
+void VolumeParticleEmitter3::setLinearVelocity(const Vector3D& newLinearVel) {
+    _linearVel = newLinearVel;
+}
+
+Vector3D VolumeParticleEmitter3::angularVelocity() const { return _angularVel; }
+
+void VolumeParticleEmitter3::setAngularVelocity(const Vector3D& newAngularVel) {
+    _angularVel = newAngularVel;
+}
+
 double VolumeParticleEmitter3::random() {
     std::uniform_real_distribution<> d(0.0, 1.0);
     return d(_rng);
+}
+
+Vector3D VolumeParticleEmitter3::velocityAt(const Vector3D& point) const {
+    Vector3D r = point - _implicitSurface->transform.translation();
+    return _linearVel + _angularVel.cross(r) + _initialVel;
 }
 
 VolumeParticleEmitter3::Builder VolumeParticleEmitter3::builder() {

--- a/src/python/collider.cpp
+++ b/src/python/collider.cpp
@@ -32,7 +32,14 @@ void addCollider2(py::module& m) {
             )pbdoc")
         .def_property_readonly("surface", &Collider2::surface, R"pbdoc(
             The surface instance.
-            )pbdoc");
+            )pbdoc")
+        .def(
+            "velocityAt",
+            [](const Collider2& instance, py::object obj) {
+                return instance.velocityAt(objectToVector2D(obj));
+            },
+            R"pbdoc(Returns the velocity of the collider at given point.)pbdoc",
+            py::arg("point"));
 }
 
 void addCollider3(py::module& m) {
@@ -54,5 +61,12 @@ void addCollider3(py::module& m) {
             )pbdoc")
         .def_property_readonly("surface", &Collider3::surface, R"pbdoc(
             The surface instance.
-            )pbdoc");
+            )pbdoc")
+        .def(
+            "velocityAt",
+            [](const Collider3& instance, py::object obj) {
+                return instance.velocityAt(objectToVector3D(obj));
+            },
+            R"pbdoc(Returns the velocity of the collider at given point.)pbdoc",
+            py::arg("point"));
 }

--- a/src/python/collider_set.cpp
+++ b/src/python/collider_set.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2018 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include "collider_set.h"
+#include "pybind11_utils.h"
+
+#include <jet/collider_set2.h>
+#include <jet/collider_set3.h>
+
+namespace py = pybind11;
+using namespace jet;
+
+void addColliderSet2(py::module& m) {
+    py::class_<ColliderSet2, ColliderSet2Ptr, Collider2>(m, "ColliderSet2",
+                                                         R"pbdoc(
+        Collection of 2-D colliders
+        )pbdoc")
+        .def(py::init([](py::args args) {
+                 if (args.size() == 1) {
+                     return new ColliderSet2(
+                         args[0].cast<std::vector<Collider2Ptr>>());
+                 } else if (args.size() == 0) {
+                     return new ColliderSet2();
+                 }
+                 throw std::invalid_argument("Invalid number of arguments.");
+             }),
+             R"pbdoc(
+             Constructs ColliderSet2
+
+             This method constructs ColliderSet2 with other colliders.
+
+             Parameters
+             ----------
+             - `*args` : List of other colliders. Must be size of 0 or 1.
+             )pbdoc")
+        .def("addCollider", &ColliderSet2::addCollider,
+             R"pbdoc(Adds a collider to the set.)pbdoc")
+        .def_property_readonly("numberOfColliders",
+                               &ColliderSet2::numberOfColliders,
+                               R"pbdoc(Number of colliders.)pbdoc")
+        .def("collider", &ColliderSet2::collider,
+             R"pbdoc(Returns collider at index i.)pbdoc");
+}
+
+void addColliderSet3(py::module& m) {
+    py::class_<ColliderSet3, ColliderSet3Ptr, Collider3>(m, "ColliderSet3",
+                                                         R"pbdoc(
+        Collection of 3-D colliders
+        )pbdoc")
+        .def(py::init([](py::args args) {
+                 if (args.size() == 1) {
+                     return new ColliderSet3(
+                         args[0].cast<std::vector<Collider3Ptr>>());
+                 } else if (args.size() == 0) {
+                     return new ColliderSet3();
+                 }
+                 throw std::invalid_argument("Invalid number of arguments.");
+             }),
+             R"pbdoc(
+             Constructs ColliderSet3
+
+             This method constructs ColliderSet3 with other colliders.
+
+             Parameters
+             ----------
+             - `*args` : List of other colliders. Must be size of 0 or 1.
+             )pbdoc")
+        .def("addCollider", &ColliderSet3::addCollider,
+             R"pbdoc(Adds a collider to the set.)pbdoc")
+        .def_property_readonly("numberOfColliders",
+                               &ColliderSet3::numberOfColliders,
+                               R"pbdoc(Number of colliders.)pbdoc")
+        .def("collider", &ColliderSet3::collider,
+             R"pbdoc(Returns collider at index i.)pbdoc");
+}

--- a/src/python/collider_set.h
+++ b/src/python/collider_set.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef SRC_PYTHON_COLLIDER_SET_H_
+#define SRC_PYTHON_COLLIDER_SET_H_
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+void addColliderSet2(pybind11::module& m);
+void addColliderSet3(pybind11::module& m);
+
+#endif  // SRC_PYTHON_COLLIDER_SET_H_

--- a/src/python/grid_fluid_solver.cpp
+++ b/src/python/grid_fluid_solver.cpp
@@ -72,6 +72,15 @@ void addGridFluidSolver2(py::module& m) {
               DIRECTION_LEFT, DIRECTION_RIGHT, DIRECTION_DOWN, DIRECTION_UP,
               and DIRECTION_BACK.
               )pbdoc")
+        .def_property_readonly("gridSystemData",
+                               &GridFluidSolver2::gridSystemData,
+                               R"pbdoc(
+             The grid system data.
+
+             This function returns the grid system data. The grid system data stores
+             the core fluid flow fields such as velocity. By default, the data
+             instance has velocity field only.
+             )pbdoc")
         .def("resizeGrid",
              [](GridFluidSolver2& instance, py::args args, py::kwargs kwargs) {
                  Size2 resolution{1, 1};
@@ -208,6 +217,15 @@ void addGridFluidSolver3(py::module& m) {
               DIRECTION_LEFT, DIRECTION_RIGHT, DIRECTION_DOWN, DIRECTION_UP,
               DIRECTION_BACK, and DIRECTION_FRONT. Default is DIRECTION_ALL.
               )pbdoc")
+        .def_property_readonly("gridSystemData",
+                               &GridFluidSolver3::gridSystemData,
+                               R"pbdoc(
+             The grid system data.
+
+             This function returns the grid system data. The grid system data stores
+             the core fluid flow fields such as velocity. By default, the data
+             instance has velocity field only.
+             )pbdoc")
         .def("resizeGrid",
              [](GridFluidSolver3& instance, py::args args, py::kwargs kwargs) {
                  Size3 resolution{1, 1, 1};

--- a/src/python/grid_system_data.cpp
+++ b/src/python/grid_system_data.cpp
@@ -24,7 +24,15 @@ void addGridSystemData2(py::module& m) {
         face-centered (MAC) grid by default. It can also have additional scalar or
         vector attributes by adding extra data layer.
         )pbdoc")
-        .def(py::init<>());
+        .def(py::init<>())
+        .def_property_readonly("resolution", &GridSystemData2::resolution,
+                               R"pbdoc(Resolution of the grid.)pbdoc")
+        .def_property_readonly("origin", &GridSystemData2::origin,
+                               R"pbdoc(Origin of the grid.)pbdoc")
+        .def_property_readonly("gridSpacing", &GridSystemData2::gridSpacing,
+                               R"pbdoc(Spacing between grid points.)pbdoc")
+        .def_property_readonly("boundingBox", &GridSystemData2::boundingBox,
+                               R"pbdoc(Bounding box of the entire grid.)pbdoc");
 }
 
 void addGridSystemData3(py::module& m) {
@@ -38,5 +46,13 @@ void addGridSystemData3(py::module& m) {
         face-centered (MAC) grid by default. It can also have additional scalar or
         vector attributes by adding extra data layer.
         )pbdoc")
-        .def(py::init<>());
+        .def(py::init<>())
+        .def_property_readonly("resolution", &GridSystemData3::resolution,
+                               R"pbdoc(Resolution of the grid.)pbdoc")
+        .def_property_readonly("origin", &GridSystemData3::origin,
+                               R"pbdoc(Origin of the grid.)pbdoc")
+        .def_property_readonly("gridSpacing", &GridSystemData3::gridSpacing,
+                               R"pbdoc(Spacing between grid points.)pbdoc")
+        .def_property_readonly("boundingBox", &GridSystemData3::boundingBox,
+                               R"pbdoc(Bounding box of the entire grid.)pbdoc");
 }

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -14,6 +14,7 @@
 #include "cell_centered_scalar_grid.h"
 #include "cell_centered_vector_grid.h"
 #include "collider.h"
+#include "collider_set.h"
 #include "collocated_vector_grid.h"
 #include "constant_scalar_field.h"
 #include "constant_vector_field.h"
@@ -221,6 +222,8 @@ PYBIND11_MODULE(pyjet, m) {
     // Colliders
     addCollider2(m);
     addCollider3(m);
+    addColliderSet2(m);
+    addColliderSet3(m);
     addRigidBodyCollider2(m);
     addRigidBodyCollider3(m);
 

--- a/src/python/rigid_body_collider.cpp
+++ b/src/python/rigid_body_collider.cpp
@@ -15,7 +15,12 @@ using namespace jet;
 
 void addRigidBodyCollider2(py::module& m) {
     py::class_<RigidBodyCollider2, RigidBodyCollider2Ptr, Collider2>(
-        m, "RigidBodyCollider2")
+        m, "RigidBodyCollider2", R"pbdoc(
+        2-D rigid body collider class.
+
+        This class implements 2-D rigid body collider. The collider can only take
+        rigid body motion with linear and rotational velocities.
+        )pbdoc")
         .def("__init__",
              [](RigidBodyCollider2& instance, const Surface2Ptr& surface,
                 py::object linearVelocity, double angularVelocity) {
@@ -45,7 +50,12 @@ void addRigidBodyCollider2(py::module& m) {
 
 void addRigidBodyCollider3(py::module& m) {
     py::class_<RigidBodyCollider3, RigidBodyCollider3Ptr, Collider3>(
-        m, "RigidBodyCollider3")
+        m, "RigidBodyCollider3", R"pbdoc(
+        3-D rigid body collider class.
+
+        This class implements 3-D rigid body collider. The collider can only take
+        rigid body motion with linear and rotational velocities.
+        )pbdoc")
         .def("__init__",
              [](RigidBodyCollider3& instance, const Surface3Ptr& surface,
                 py::object linearVelocity, py::object angularVelocity) {

--- a/src/python/rigid_body_collider.cpp
+++ b/src/python/rigid_body_collider.cpp
@@ -40,14 +40,7 @@ void addRigidBodyCollider2(py::module& m) {
                       },
                       R"pbdoc(Linear velocity of the collider.)pbdoc")
         .def_readwrite("angularVelocity", &RigidBodyCollider2::angularVelocity,
-                       R"pbdoc(Angular velocity of the collider.)pbdoc")
-        .def(
-            "velocityAt",
-            [](const RigidBodyCollider2& instance, py::object obj) {
-                return instance.velocityAt(objectToVector2D(obj));
-            },
-            R"pbdoc(Returns the velocity of the collider at given point.)pbdoc",
-            py::arg("point"));
+                       R"pbdoc(Angular velocity of the collider.)pbdoc");
 }
 
 void addRigidBodyCollider3(py::module& m) {
@@ -83,12 +76,5 @@ void addRigidBodyCollider3(py::module& m) {
                       [](RigidBodyCollider3& instance, py::object obj) {
                           instance.angularVelocity = objectToVector3D(obj);
                       },
-                      R"pbdoc(Angular velocity of the collider.)pbdoc")
-        .def(
-            "velocityAt",
-            [](const RigidBodyCollider3& instance, py::object obj) {
-                return instance.velocityAt(objectToVector3D(obj));
-            },
-            R"pbdoc(Returns the velocity of the collider at given point.)pbdoc",
-            py::arg("point"));
+                      R"pbdoc(Angular velocity of the collider.)pbdoc");
 }

--- a/src/python/volume_particle_emitter.cpp
+++ b/src/python/volume_particle_emitter.cpp
@@ -27,6 +27,8 @@ void addVolumeParticleEmitter2(py::module& m) {
                  BoundingBox2D maxRegion;
                  double spacing = 0.1;
                  Vector2D initialVel;
+                 Vector2D linearVel;
+                 double angularVel = 0.0;
                  size_t maxNumberOfParticles = kMaxSize;
                  double jitter = 0.0;
                  bool isOneShot = true;
@@ -51,7 +53,7 @@ void addVolumeParticleEmitter2(py::module& m) {
                      }
                  };
 
-                 if (args.size() >= 3 && args.size() <= 9) {
+                 if (args.size() >= 3 && args.size() <= 11) {
                      parseImplicitSurface(args[0]);
 
                      maxRegion = args[1].cast<BoundingBox2D>();
@@ -61,19 +63,25 @@ void addVolumeParticleEmitter2(py::module& m) {
                          initialVel = objectToVector2D(py::object(args[3]));
                      }
                      if (args.size() > 4) {
-                         maxNumberOfParticles = args[4].cast<size_t>();
+                         linearVel = objectToVector2D(py::object(args[4]));
                      }
                      if (args.size() > 5) {
-                         jitter = args[5].cast<double>();
+                         angularVel = args[5].cast<double>();
                      }
                      if (args.size() > 6) {
-                         isOneShot = args[6].cast<bool>();
+                         maxNumberOfParticles = args[6].cast<size_t>();
                      }
                      if (args.size() > 7) {
-                         allowOverlapping = args[7].cast<bool>();
+                         jitter = args[7].cast<double>();
                      }
                      if (args.size() > 8) {
-                         seed = args[8].cast<uint32_t>();
+                         isOneShot = args[8].cast<bool>();
+                     }
+                     if (args.size() > 9) {
+                         allowOverlapping = args[9].cast<bool>();
+                     }
+                     if (args.size() > 10) {
+                         seed = args[10].cast<uint32_t>();
                      }
                  } else if (args.size() > 0) {
                      throw std::invalid_argument("Too few/many arguments.");
@@ -95,6 +103,12 @@ void addVolumeParticleEmitter2(py::module& m) {
                  if (kwargs.contains("initialVelocity")) {
                      initialVel = objectToVector2D(kwargs["initialVelocity"]);
                  }
+                 if (kwargs.contains("linearVelocity")) {
+                     linearVel = objectToVector2D(kwargs["linearVelocity"]);
+                 }
+                 if (kwargs.contains("angularVelocity")) {
+                     angularVel = kwargs["angularVelocity"].cast<double>();
+                 }
                  if (kwargs.contains("maxNumberOfParticles")) {
                      maxNumberOfParticles =
                          kwargs["maxNumberOfParticles"].cast<size_t>();
@@ -113,9 +127,9 @@ void addVolumeParticleEmitter2(py::module& m) {
                  }
 
                  new (&instance) VolumeParticleEmitter2(
-                     implicitSurface, maxRegion, spacing, initialVel,
-                     maxNumberOfParticles, jitter, isOneShot, allowOverlapping,
-                     seed);
+                     implicitSurface, maxRegion, spacing, initialVel, linearVel,
+                     angularVel, maxNumberOfParticles, jitter, isOneShot,
+                     allowOverlapping, seed);
              },
              R"pbdoc(
              Constructs VolumeParticleEmitter2
@@ -161,7 +175,7 @@ void addVolumeParticleEmitter2(py::module& m) {
              True if particles can be overlapped.
              )pbdoc")
         .def_property(
-            "allowOverlapping", &VolumeParticleEmitter2::maxNumberOfParticles,
+            "maxNumberOfParticles", &VolumeParticleEmitter2::maxNumberOfParticles,
             &VolumeParticleEmitter2::setMaxNumberOfParticles, R"pbdoc(
              Max number of particles to be emitted.
              )pbdoc")
@@ -207,6 +221,8 @@ void addVolumeParticleEmitter3(py::module& m) {
                  BoundingBox3D maxRegion;
                  double spacing = 0.1;
                  Vector3D initialVel;
+                 Vector3D linearVel;
+                 Vector3D angularVel;
                  size_t maxNumberOfParticles = kMaxSize;
                  double jitter = 0.0;
                  bool isOneShot = true;
@@ -231,7 +247,7 @@ void addVolumeParticleEmitter3(py::module& m) {
                      }
                  };
 
-                 if (args.size() >= 3 && args.size() <= 9) {
+                 if (args.size() >= 3 && args.size() <= 11) {
                      parseImplicitSurface(args[0]);
 
                      maxRegion = args[1].cast<BoundingBox3D>();
@@ -241,19 +257,25 @@ void addVolumeParticleEmitter3(py::module& m) {
                          initialVel = objectToVector3D(py::object(args[3]));
                      }
                      if (args.size() > 4) {
-                         maxNumberOfParticles = args[4].cast<size_t>();
+                         linearVel = objectToVector3D(py::object(args[4]));
                      }
                      if (args.size() > 5) {
-                         jitter = args[5].cast<double>();
+                         angularVel = objectToVector3D(py::object(args[5]));
                      }
                      if (args.size() > 6) {
-                         isOneShot = args[6].cast<bool>();
+                         maxNumberOfParticles = args[6].cast<size_t>();
                      }
                      if (args.size() > 7) {
-                         allowOverlapping = args[7].cast<bool>();
+                         jitter = args[7].cast<double>();
                      }
                      if (args.size() > 8) {
-                         seed = args[8].cast<uint32_t>();
+                         isOneShot = args[8].cast<bool>();
+                     }
+                     if (args.size() > 9) {
+                         allowOverlapping = args[9].cast<bool>();
+                     }
+                     if (args.size() > 10) {
+                         seed = args[10].cast<uint32_t>();
                      }
                  } else if (args.size() > 0) {
                      throw std::invalid_argument("Too few/many arguments.");
@@ -275,6 +297,12 @@ void addVolumeParticleEmitter3(py::module& m) {
                  if (kwargs.contains("initialVelocity")) {
                      initialVel = objectToVector3D(kwargs["initialVelocity"]);
                  }
+                 if (kwargs.contains("linearVelocity")) {
+                     linearVel = objectToVector3D(kwargs["linearVelocity"]);
+                 }
+                 if (kwargs.contains("angularVelocity")) {
+                     angularVel = objectToVector3D(kwargs["angularVelocity"]);
+                 }
                  if (kwargs.contains("maxNumberOfParticles")) {
                      maxNumberOfParticles =
                          kwargs["maxNumberOfParticles"].cast<size_t>();
@@ -293,9 +321,9 @@ void addVolumeParticleEmitter3(py::module& m) {
                  }
 
                  new (&instance) VolumeParticleEmitter3(
-                     implicitSurface, maxRegion, spacing, initialVel,
-                     maxNumberOfParticles, jitter, isOneShot, allowOverlapping,
-                     seed);
+                     implicitSurface, maxRegion, spacing, initialVel, linearVel,
+                     angularVel, maxNumberOfParticles, jitter, isOneShot,
+                     allowOverlapping, seed);
              },
              R"pbdoc(
              Constructs VolumeParticleEmitter3
@@ -341,7 +369,7 @@ void addVolumeParticleEmitter3(py::module& m) {
              True if particles can be overlapped.
              )pbdoc")
         .def_property(
-            "allowOverlapping", &VolumeParticleEmitter3::maxNumberOfParticles,
+            "maxNumberOfParticles", &VolumeParticleEmitter3::maxNumberOfParticles,
             &VolumeParticleEmitter3::setMaxNumberOfParticles, R"pbdoc(
              Max number of particles to be emitted.
              )pbdoc")

--- a/src/tests/python_tests/test_collider_set.py
+++ b/src/tests/python_tests/test_collider_set.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) 2018 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+import pyjet
+
+
+def create_collider2():
+    sphere = pyjet.Sphere2()
+    collider = pyjet.RigidBodyCollider2(surface=sphere)
+    return collider
+
+
+def create_collider3():
+    sphere = pyjet.Sphere3()
+    collider = pyjet.RigidBodyCollider3(surface=sphere)
+    return collider
+
+
+def test_collider_set2():
+    collider_set = pyjet.ColliderSet2()
+    assert collider_set.numberOfColliders == 0
+
+    collider1 = create_collider2()
+    collider2 = create_collider2()
+    collider3 = create_collider2()
+    collider_set.addCollider(collider1)
+    collider_set.addCollider(collider2)
+    collider_set.addCollider(collider3)
+    assert collider_set.numberOfColliders == 3
+
+    assert collider1 == collider_set.collider(0)
+    assert collider2 == collider_set.collider(1)
+    assert collider3 == collider_set.collider(2)
+
+
+def test_collider_set3():
+    collider_set = pyjet.ColliderSet3()
+    assert collider_set.numberOfColliders == 0
+
+    collider1 = create_collider3()
+    collider2 = create_collider3()
+    collider3 = create_collider3()
+    collider_set.addCollider(collider1)
+    collider_set.addCollider(collider2)
+    collider_set.addCollider(collider3)
+    assert collider_set.numberOfColliders == 3
+
+    assert collider1 == collider_set.collider(0)
+    assert collider2 == collider_set.collider(1)
+    assert collider3 == collider_set.collider(2)

--- a/src/tests/python_tests/test_volume_particle_emitter.py
+++ b/src/tests/python_tests/test_volume_particle_emitter.py
@@ -1,0 +1,116 @@
+"""
+Copyright (c) 2018 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+import pyjet
+from pytest_utils import *
+
+
+def test_volume_particle_emitter2():
+    sphere = pyjet.Sphere2()
+    emitter = pyjet.VolumeParticleEmitter2(
+        sphere,
+        pyjet.BoundingBox2D((-1, -2), (4, 2)),
+        0.1,
+        (-1, 0.5),
+        (3, 4),
+        5.0,
+        30,
+        0.01,
+        False,
+        True,
+        42)
+
+    assert emitter.surface != None
+    assert_bounding_box_similar(
+        emitter.maxRegion, pyjet.BoundingBox2D((-1, -2), (4, 2)))
+    assert emitter.spacing == 0.1
+    assert_vector_similar(emitter.initialVelocity, (-1, 0.5))
+    assert_vector_similar(emitter.linearVelocity, (3, 4))
+    assert emitter.angularVelocity == 5.0
+    assert emitter.maxNumberOfParticles == 30
+    assert emitter.jitter == 0.01
+    assert emitter.isOneShot == False
+    assert emitter.allowOverlapping == True
+
+    emitter2 = pyjet.VolumeParticleEmitter2(
+        implicitSurface=sphere,
+        maxRegion=pyjet.BoundingBox2D((-1, -2), (4, 2)),
+        spacing=0.1,
+        initialVelocity=(-1, 0.5),
+        linearVelocity=(3, 4),
+        angularVelocity=5.0,
+        maxNumberOfParticles=30,
+        jitter=0.01,
+        isOneShot=False,
+        allowOverlapping=True,
+        seed=42)
+
+    assert emitter2.surface != None
+    assert_bounding_box_similar(
+        emitter2.maxRegion, pyjet.BoundingBox2D((-1, -2), (4, 2)))
+    assert emitter2.spacing == 0.1
+    assert_vector_similar(emitter2.initialVelocity, (-1, 0.5))
+    assert_vector_similar(emitter2.linearVelocity, (3, 4))
+    assert emitter2.angularVelocity == 5.0
+    assert emitter2.maxNumberOfParticles == 30
+    assert emitter2.jitter == 0.01
+    assert emitter2.isOneShot == False
+    assert emitter2.allowOverlapping == True
+
+
+def test_volume_particle_emitter3():
+    sphere = pyjet.Sphere3()
+    emitter = pyjet.VolumeParticleEmitter3(
+        sphere,
+        pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)),
+        0.1,
+        (-1, 0.5, 2),
+        (3, 4, 5),
+        (6, 7, 8),
+        30,
+        0.01,
+        False,
+        True,
+        42)
+
+    assert emitter.surface != None
+    assert_bounding_box_similar(
+        emitter.maxRegion, pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)))
+    assert emitter.spacing == 0.1
+    assert_vector_similar(emitter.initialVelocity, (-1, 0.5, 2))
+    assert_vector_similar(emitter.linearVelocity, (3, 4, 5))
+    assert_vector_similar(emitter.angularVelocity, (6, 7, 8))
+    assert emitter.maxNumberOfParticles == 30
+    assert emitter.jitter == 0.01
+    assert emitter.isOneShot == False
+    assert emitter.allowOverlapping == True
+
+    emitter2 = pyjet.VolumeParticleEmitter3(
+        implicitSurface=sphere,
+        maxRegion=pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)),
+        spacing=0.1,
+        initialVelocity=(-1, 0.5, 2),
+        linearVelocity=(3, 4, 5),
+        angularVelocity=(6, 7, 8),
+        maxNumberOfParticles=30,
+        jitter=0.01,
+        isOneShot=False,
+        allowOverlapping=True,
+        seed=42)
+
+    assert emitter2.surface != None
+    assert_bounding_box_similar(
+        emitter2.maxRegion, pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)))
+    assert emitter2.spacing == 0.1
+    assert_vector_similar(emitter2.initialVelocity, (-1, 0.5, 2))
+    assert_vector_similar(emitter2.linearVelocity, (3, 4, 5))
+    assert_vector_similar(emitter2.angularVelocity, (6, 7, 8))
+    assert emitter2.maxNumberOfParticles == 30
+    assert emitter2.jitter == 0.01
+    assert emitter2.isOneShot == False
+    assert emitter2.allowOverlapping == True

--- a/src/tests/unit_tests/unit_tests_utils.h
+++ b/src/tests/unit_tests/unit_tests_utils.h
@@ -7,54 +7,54 @@
 #ifndef SRC_TESTS_UNIT_TESTS_UNIT_TESTS_UTILS_H_
 #define SRC_TESTS_UNIT_TESTS_UNIT_TESTS_UTILS_H_
 
-#include <jet/vector3.h>
 #include <gtest/gtest.h>
+#include <jet/vector3.h>
 
-#define EXPECT_VECTOR2_EQ(expected, actual) \
-    EXPECT_DOUBLE_EQ(expected.x, actual.x); \
-    EXPECT_DOUBLE_EQ(expected.y, actual.y); \
+#define EXPECT_VECTOR2_EQ(expected, actual)     \
+    EXPECT_DOUBLE_EQ((expected).x, (actual).x); \
+    EXPECT_DOUBLE_EQ((expected).y, (actual).y);
 
 #define EXPECT_VECTOR2_NEAR(expected, actual, eps) \
-    EXPECT_NEAR(expected.x, actual.x, eps); \
-    EXPECT_NEAR(expected.y, actual.y, eps); \
+    EXPECT_NEAR((expected).x, (actual).x, eps);    \
+    EXPECT_NEAR((expected).y, (actual).y, eps);
 
-#define EXPECT_VECTOR3_EQ(expected, actual) \
-    EXPECT_DOUBLE_EQ(expected.x, actual.x); \
-    EXPECT_DOUBLE_EQ(expected.y, actual.y); \
-    EXPECT_DOUBLE_EQ(expected.z, actual.z); \
+#define EXPECT_VECTOR3_EQ(expected, actual)     \
+    EXPECT_DOUBLE_EQ((expected).x, (actual).x); \
+    EXPECT_DOUBLE_EQ((expected).y, (actual).y); \
+    EXPECT_DOUBLE_EQ((expected).z, (actual).z);
 
 #define EXPECT_VECTOR3_NEAR(expected, actual, eps) \
-    EXPECT_NEAR(expected.x, actual.x, eps); \
-    EXPECT_NEAR(expected.y, actual.y, eps); \
-    EXPECT_NEAR(expected.z, actual.z, eps); \
+    EXPECT_NEAR((expected).x, (actual).x, eps);    \
+    EXPECT_NEAR((expected).y, (actual).y, eps);    \
+    EXPECT_NEAR((expected).z, (actual).z, eps);
 
-#define EXPECT_VECTOR4_EQ(expected, actual) \
-    EXPECT_DOUBLE_EQ(expected.x, actual.x); \
-    EXPECT_DOUBLE_EQ(expected.y, actual.y); \
-    EXPECT_DOUBLE_EQ(expected.z, actual.z); \
-    EXPECT_DOUBLE_EQ(expected.w, actual.w); \
+#define EXPECT_VECTOR4_EQ(expected, actual)     \
+    EXPECT_DOUBLE_EQ((expected).x, (actual).x); \
+    EXPECT_DOUBLE_EQ((expected).y, (actual).y); \
+    EXPECT_DOUBLE_EQ((expected).z, (actual).z); \
+    EXPECT_DOUBLE_EQ((expected).w, (actual).w);
 
 #define EXPECT_VECTOR4_NEAR(expected, actual, eps) \
-    EXPECT_NEAR(expected.x, actual.x, eps); \
-    EXPECT_NEAR(expected.y, actual.y, eps); \
-    EXPECT_NEAR(expected.z, actual.z, eps); \
-    EXPECT_NEAR(expected.w, actual.w, eps); \
+    EXPECT_NEAR((expected).x, (actual).x, eps);    \
+    EXPECT_NEAR((expected).y, (actual).y, eps);    \
+    EXPECT_NEAR((expected).z, (actual).z, eps);    \
+    EXPECT_NEAR((expected).w, (actual).w, eps);
 
-#define EXPECT_BOUNDING_BOX2_EQ(expected, actual) \
-    EXPECT_VECTOR2_EQ(expected.lowerCorner, actual.lowerCorner); \
-    EXPECT_VECTOR2_EQ(expected.upperCorner, actual.upperCorner); \
+#define EXPECT_BOUNDING_BOX2_EQ(expected, actual)                    \
+    EXPECT_VECTOR2_EQ((expected).lowerCorner, (actual).lowerCorner); \
+    EXPECT_VECTOR2_EQ((expected).upperCorner, (actual).upperCorner);
 
-#define EXPECT_BOUNDING_BOX2_NEAR(expected, actual, eps) \
-    EXPECT_VECTOR2_NEAR(expected.lowerCorner, actual.lowerCorner, eps); \
-    EXPECT_VECTOR2_NEAR(expected.upperCorner, actual.upperCorner, eps); \
+#define EXPECT_BOUNDING_BOX2_NEAR(expected, actual, eps)                    \
+    EXPECT_VECTOR2_NEAR((expected).lowerCorner, (actual).lowerCorner, eps); \
+    EXPECT_VECTOR2_NEAR((expected).upperCorner, (actual).upperCorner, eps);
 
-#define EXPECT_BOUNDING_BOX3_EQ(expected, actual) \
-    EXPECT_VECTOR3_EQ(expected.lowerCorner, actual.lowerCorner); \
-    EXPECT_VECTOR3_EQ(expected.upperCorner, actual.upperCorner); \
+#define EXPECT_BOUNDING_BOX3_EQ(expected, actual)                    \
+    EXPECT_VECTOR3_EQ((expected).lowerCorner, (actual).lowerCorner); \
+    EXPECT_VECTOR3_EQ((expected).upperCorner, (actual).upperCorner);
 
-#define EXPECT_BOUNDING_BOX3_NEAR(expected, actual, eps) \
-    EXPECT_VECTOR3_NEAR(expected.lowerCorner, actual.lowerCorner, eps); \
-    EXPECT_VECTOR3_NEAR(expected.upperCorner, actual.upperCorner, eps); \
+#define EXPECT_BOUNDING_BOX3_NEAR(expected, actual, eps)                    \
+    EXPECT_VECTOR3_NEAR((expected).lowerCorner, (actual).lowerCorner, eps); \
+    EXPECT_VECTOR3_NEAR((expected).upperCorner, (actual).upperCorner, eps);
 
 namespace jet {
 


### PR DESCRIPTION
This revision adds new Python APIs including:
* Exposing parameters for animating `VolumeParticleEmitter{2|3}`
* ColliderSet{2|3}
* Minor API fixes

This PR addresses Issue #224 and #227.