### PR TITLE
Adding isInside to the surface classes

### DIFF
--- a/include/jet/implicit_surface2.h
+++ b/include/jet/implicit_surface2.h
@@ -35,6 +35,8 @@ class ImplicitSurface2 : public Surface2 {
 
  private:
     double closestDistanceLocal(const Vector2D& otherPoint) const override;
+
+    bool isInsideLocal(const Vector2D& otherPoint) const override;
 };
 
 //! Shared pointer type for the ImplicitSurface2.

--- a/include/jet/implicit_surface3.h
+++ b/include/jet/implicit_surface3.h
@@ -35,6 +35,8 @@ class ImplicitSurface3 : public Surface3 {
 
  private:
     double closestDistanceLocal(const Vector3D& otherPoint) const override;
+
+    bool isInsideLocal(const Vector3D& otherPoint) const override;
 };
 
 //! Shared pointer type for the ImplicitSurface3.

--- a/include/jet/implicit_surface_set2.h
+++ b/include/jet/implicit_surface_set2.h
@@ -83,6 +83,8 @@ class ImplicitSurfaceSet2 final : public ImplicitSurface2 {
     SurfaceRayIntersection2 closestIntersectionLocal(
         const Ray2D& ray) const override;
 
+    bool isInsideLocal(const Vector2D& otherPoint) const override;
+
     // ImplicitSurface2 implementations
 
     double signedDistanceLocal(const Vector2D& otherPoint) const override;

--- a/include/jet/implicit_surface_set3.h
+++ b/include/jet/implicit_surface_set3.h
@@ -83,6 +83,8 @@ class ImplicitSurfaceSet3 final : public ImplicitSurface3 {
     SurfaceRayIntersection3 closestIntersectionLocal(
         const Ray3D& ray) const override;
 
+    bool isInsideLocal(const Vector3D& otherPoint) const override;
+
     // ImplicitSurface3 implementations
 
     double signedDistanceLocal(const Vector3D& otherPoint) const override;

--- a/include/jet/surface2.h
+++ b/include/jet/surface2.h
@@ -72,6 +72,10 @@ class Surface2 {
     //! Returns true if the surface is a valid geometry.
     virtual bool isValidGeometry() const;
 
+    //! Returns true if \p otherPoint is inside the volume defined by the
+    //! surface.
+    bool isInside(const Vector2D& otherPoint) const;
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.
@@ -95,6 +99,10 @@ class Surface2 {
     //! Returns the closest distance from the given point \p otherPoint to the
     //! point on the surface in local frame.
     virtual double closestDistanceLocal(const Vector2D& otherPoint) const;
+
+    //! Returns true if \p otherPoint is inside by given \p depth the volume
+    //! defined by the surface in local frame.
+    virtual bool isInsideLocal(const Vector2D& otherPoint) const;
 };
 
 //! Shared pointer for the Surface2 type.

--- a/include/jet/surface3.h
+++ b/include/jet/surface3.h
@@ -72,6 +72,10 @@ class Surface3 {
     //! Returns true if the surface is a valid geometry.
     virtual bool isValidGeometry() const;
 
+    //! Returns true if \p otherPoint is inside the volume defined by the
+    //! surface.
+    bool isInside(const Vector3D& otherPoint) const;
+
  protected:
     //! Returns the closest point from the given point \p otherPoint to the
     //! surface in local frame.
@@ -95,6 +99,10 @@ class Surface3 {
     //! Returns the closest distance from the given point \p otherPoint to the
     //! point on the surface in local frame.
     virtual double closestDistanceLocal(const Vector3D& otherPoint) const;
+
+    //! Returns true if \p otherPoint is inside by given \p depth the volume
+    //! defined by the surface in local frame.
+    virtual bool isInsideLocal(const Vector3D& otherPoint) const;
 };
 
 //! Shared pointer for the Surface3 type.

--- a/include/jet/surface_set2.h
+++ b/include/jet/surface_set2.h
@@ -75,6 +75,8 @@ class SurfaceSet2 final : public Surface2 {
     SurfaceRayIntersection2 closestIntersectionLocal(
         const Ray2D& ray) const override;
 
+    bool isInsideLocal(const Vector2D& otherPoint) const override;
+
     void invalidateBvh();
 
     void buildBvh() const;
@@ -86,7 +88,8 @@ typedef std::shared_ptr<SurfaceSet2> SurfaceSet2Ptr;
 //!
 //! \brief Front-end to create SurfaceSet2 objects step by step.
 //!
-class SurfaceSet2::Builder final : public SurfaceBuilderBase2<SurfaceSet2> {
+class SurfaceSet2::Builder final
+    : public SurfaceBuilderBase2<SurfaceSet2::Builder> {
  public:
     //! Returns builder with other surfaces.
     Builder& withSurfaces(const std::vector<Surface2Ptr>& others);

--- a/include/jet/surface_set3.h
+++ b/include/jet/surface_set3.h
@@ -75,6 +75,8 @@ class SurfaceSet3 final : public Surface3 {
     SurfaceRayIntersection3 closestIntersectionLocal(
         const Ray3D& ray) const override;
 
+    bool isInsideLocal(const Vector3D& otherPoint) const override;
+
     void invalidateBvh();
 
     void buildBvh() const;
@@ -86,7 +88,8 @@ typedef std::shared_ptr<SurfaceSet3> SurfaceSet3Ptr;
 //!
 //! \brief Front-end to create SurfaceSet3 objects step by step.
 //!
-class SurfaceSet3::Builder final : public SurfaceBuilderBase3<SurfaceSet3> {
+class SurfaceSet3::Builder final
+    : public SurfaceBuilderBase3<SurfaceSet3::Builder> {
  public:
     //! Returns builder with other surfaces.
     Builder& withSurfaces(const std::vector<Surface3Ptr>& others);

--- a/src/jet/collider2.cpp
+++ b/src/jet/collider2.cpp
@@ -96,11 +96,10 @@ void Collider2::getClosestPoint(const Surface2Ptr& surface,
 
 bool Collider2::isPenetrating(const ColliderQueryResult& colliderPoint,
                               const Vector2D& position, double radius) {
-    // If the new candidate position of the particle is on the other side of
-    // the surface OR the new distance to the surface is less than the
-    // particle's radius, this particle is in colliding state.
-    return (position - colliderPoint.point).dot(colliderPoint.normal) < 0.0 ||
-           colliderPoint.distance < radius;
+    // If the new candidate position of the particle is inside
+    // the volume defined by the surface OR the new distance to the surface is
+    // less than the particle's radius, this particle is in colliding state.
+    return _surface->isInside(position) || colliderPoint.distance < radius;
 }
 
 void Collider2::update(double currentTimeInSeconds,

--- a/src/jet/collider3.cpp
+++ b/src/jet/collider3.cpp
@@ -96,11 +96,10 @@ void Collider3::getClosestPoint(const Surface3Ptr& surface,
 
 bool Collider3::isPenetrating(const ColliderQueryResult& colliderPoint,
                               const Vector3D& position, double radius) {
-    // If the new candidate position of the particle is on the other side of
-    // the surface OR the new distance to the surface is less than the
-    // particle's radius, this particle is in colliding state.
-    return (position - colliderPoint.point).dot(colliderPoint.normal) < 0.0 ||
-           colliderPoint.distance < radius;
+    // If the new candidate position of the particle is inside
+    // the volume defined by the surface OR the new distance to the surface is
+    // less than the particle's radius, this particle is in colliding state.
+    return _surface->isInside(position) || colliderPoint.distance < radius;
 }
 
 void Collider3::update(double currentTimeInSeconds,

--- a/src/jet/implicit_surface2.cpp
+++ b/src/jet/implicit_surface2.cpp
@@ -5,7 +5,9 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/implicit_surface2.h>
+#include <jet/level_set_utils.h>
 
 using namespace jet;
 
@@ -28,4 +30,8 @@ double ImplicitSurface2::signedDistance(const Vector2D& otherPoint) const {
 double ImplicitSurface2::closestDistanceLocal(
     const Vector2D& otherPoint) const {
     return std::fabs(signedDistanceLocal(otherPoint));
+}
+
+bool ImplicitSurface2::isInsideLocal(const Vector2D& otherPoint) const {
+    return isInsideSdf(signedDistanceLocal(otherPoint));
 }

--- a/src/jet/implicit_surface3.cpp
+++ b/src/jet/implicit_surface3.cpp
@@ -5,7 +5,9 @@
 // property of any third parties.
 
 #include <pch.h>
+
 #include <jet/implicit_surface3.h>
+#include <jet/level_set_utils.h>
 
 using namespace jet;
 
@@ -28,4 +30,8 @@ double ImplicitSurface3::signedDistance(const Vector3D& otherPoint) const {
 double ImplicitSurface3::closestDistanceLocal(
     const Vector3D& otherPoint) const {
     return std::fabs(signedDistanceLocal(otherPoint));
+}
+
+bool ImplicitSurface3::isInsideLocal(const Vector3D& otherPoint) const {
+    return isInsideSdf(signedDistanceLocal(otherPoint));
 }

--- a/src/jet/implicit_surface_set2.cpp
+++ b/src/jet/implicit_surface_set2.cpp
@@ -201,6 +201,16 @@ BoundingBox2D ImplicitSurfaceSet2::boundingBoxLocal() const {
     return _bvh.boundingBox();
 }
 
+bool ImplicitSurfaceSet2::isInsideLocal(const Vector2D& otherPoint) const {
+    for (auto surface : _surfaces) {
+        if (surface->isInside(otherPoint)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 double ImplicitSurfaceSet2::signedDistanceLocal(
     const Vector2D& otherPoint) const {
     double sdf = kMaxD;

--- a/src/jet/implicit_surface_set3.cpp
+++ b/src/jet/implicit_surface_set3.cpp
@@ -201,6 +201,16 @@ BoundingBox3D ImplicitSurfaceSet3::boundingBoxLocal() const {
     return _bvh.boundingBox();
 }
 
+bool ImplicitSurfaceSet3::isInsideLocal(const Vector3D& otherPoint) const {
+    for (auto surface : _surfaces) {
+        if (surface->isInside(otherPoint)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 double ImplicitSurfaceSet3::signedDistanceLocal(
     const Vector3D& otherPoint) const {
     double sdf = kMaxD;

--- a/src/jet/surface2.cpp
+++ b/src/jet/surface2.cpp
@@ -55,12 +55,12 @@ void Surface2::updateQueryEngine() {
     // Do nothing
 }
 
-bool Surface2::isBounded() const {
-    return true;
-}
+bool Surface2::isBounded() const { return true; }
 
-bool Surface2::isValidGeometry() const {
-    return true;
+bool Surface2::isValidGeometry() const { return true; }
+
+bool Surface2::isInside(const Vector2D& otherPoint) const {
+    return isInsideLocal(transform.toLocal(otherPoint));
 }
 
 bool Surface2::intersectsLocal(const Ray2D& rayLocal) const {
@@ -70,4 +70,10 @@ bool Surface2::intersectsLocal(const Ray2D& rayLocal) const {
 
 double Surface2::closestDistanceLocal(const Vector2D& otherPointLocal) const {
     return otherPointLocal.distanceTo(closestPointLocal(otherPointLocal));
+}
+
+bool Surface2::isInsideLocal(const Vector2D& otherPointLocal) const {
+    Vector2D cpLocal = closestPointLocal(otherPointLocal);
+    Vector2D normalLocal = closestNormalLocal(otherPointLocal);
+    return (otherPointLocal - cpLocal).dot(normalLocal) < 0.0;
 }

--- a/src/jet/surface3.cpp
+++ b/src/jet/surface3.cpp
@@ -60,14 +60,20 @@ void Surface3::updateQueryEngine() {
     // Do nothing
 }
 
-bool Surface3::isBounded() const {
-    return true;
-}
+bool Surface3::isBounded() const { return true; }
 
-bool Surface3::isValidGeometry() const {
-    return true;
+bool Surface3::isValidGeometry() const { return true; }
+
+bool Surface3::isInside(const Vector3D& otherPoint) const {
+    return isInsideLocal(transform.toLocal(otherPoint));
 }
 
 double Surface3::closestDistanceLocal(const Vector3D& otherPointLocal) const {
     return otherPointLocal.distanceTo(closestPointLocal(otherPointLocal));
+}
+
+bool Surface3::isInsideLocal(const Vector3D& otherPointLocal) const {
+    Vector3D cpLocal = closestPointLocal(otherPointLocal);
+    Vector3D normalLocal = closestNormalLocal(otherPointLocal);
+    return (otherPointLocal - cpLocal).dot(normalLocal) < 0.0;
 }

--- a/src/jet/surface_set2.cpp
+++ b/src/jet/surface_set2.cpp
@@ -183,6 +183,16 @@ BoundingBox2D SurfaceSet2::boundingBoxLocal() const {
     return _bvh.boundingBox();
 }
 
+bool SurfaceSet2::isInsideLocal(const Vector2D& otherPoint) const {
+    for (auto surface : _surfaces) {
+        if (surface->isInside(otherPoint)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void SurfaceSet2::invalidateBvh() { _bvhInvalidated = true; }
 
 void SurfaceSet2::buildBvh() const {

--- a/src/jet/surface_set3.cpp
+++ b/src/jet/surface_set3.cpp
@@ -183,6 +183,16 @@ BoundingBox3D SurfaceSet3::boundingBoxLocal() const {
     return _bvh.boundingBox();
 }
 
+bool SurfaceSet3::isInsideLocal(const Vector3D& otherPoint) const {
+    for (auto surface : _surfaces) {
+        if (surface->isInside(otherPoint)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void SurfaceSet3::invalidateBvh() { _bvhInvalidated = true; }
 
 void SurfaceSet3::buildBvh() const {

--- a/src/tests/unit_tests/implicit_surface_set2_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set2_tests.cpp
@@ -6,6 +6,8 @@
 
 #include <jet/box2.h>
 #include <jet/implicit_surface_set2.h>
+#include <jet/plane2.h>
+#include <jet/sphere2.h>
 #include <jet/surface_to_implicit2.h>
 
 #include <gtest/gtest.h>
@@ -214,4 +216,28 @@ TEST(ImplicitSurfaceSet2, IsValidGeometry) {
     surfaceSet2->addSurface(surfaceSet);
 
     EXPECT_FALSE(surfaceSet2->isValidGeometry());
+}
+
+TEST(ImplicitSurfaceSet2, IsInside) {
+    BoundingBox2D domain(Vector2D(), Vector2D(1, 2));
+    Vector2D offset(1, 2);
+
+    auto plane = Plane2::builder()
+                     .withNormal({0, 1})
+                     .withPoint({0, 0.25 * domain.height()})
+                     .makeShared();
+
+    auto sphere = Sphere2::builder()
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
+
+    auto surfaceSet = ImplicitSurfaceSet2::builder()
+                          .withExplicitSurfaces({plane, sphere})
+                          .withTransform(Transform2(offset, 0.0))
+                          .makeShared();
+
+    EXPECT_TRUE(surfaceSet->isInside(Vector2D(0.5, 0.25) + offset));
+    EXPECT_TRUE(surfaceSet->isInside(Vector2D(0.5, 1.0) + offset));
+    EXPECT_FALSE(surfaceSet->isInside(Vector2D(0.5, 1.5) + offset));
 }

--- a/src/tests/unit_tests/implicit_surface_set3_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set3_tests.cpp
@@ -6,6 +6,8 @@
 
 #include <jet/box3.h>
 #include <jet/implicit_surface_set3.h>
+#include <jet/plane3.h>
+#include <jet/sphere3.h>
 #include <jet/surface_to_implicit3.h>
 
 #include <gtest/gtest.h>
@@ -218,4 +220,28 @@ TEST(ImplicitSurfaceSet3, IsValidGeometry) {
     surfaceSet2->addSurface(surfaceSet);
 
     EXPECT_FALSE(surfaceSet2->isValidGeometry());
+}
+
+TEST(ImplicitSurfaceSet3, IsInside) {
+    BoundingBox3D domain(Vector3D(), Vector3D(1, 2, 1));
+    Vector3D offset(1, 2, 3);
+
+    auto plane = Plane3::builder()
+                     .withNormal({0, 1, 0})
+                     .withPoint({0, 0.25 * domain.height(), 0})
+                     .makeShared();
+
+    auto sphere = Sphere3::builder()
+                      .withCenter(domain.midPoint())
+                      .withRadius(0.15 * domain.width())
+                      .makeShared();
+
+    auto surfaceSet = ImplicitSurfaceSet3::builder()
+                          .withExplicitSurfaces({plane, sphere})
+                          .withTransform(Transform3(offset, QuaternionD()))
+                          .makeShared();
+
+    EXPECT_TRUE(surfaceSet->isInside(Vector3D(0.5, 0.25, 0.5) + offset));
+    EXPECT_TRUE(surfaceSet->isInside(Vector3D(0.5, 1.0, 0.5) + offset));
+    EXPECT_FALSE(surfaceSet->isInside(Vector3D(0.5, 1.5, 0.5) + offset));
 }

--- a/src/tests/unit_tests/surface_set2_tests.cpp
+++ b/src/tests/unit_tests/surface_set2_tests.cpp
@@ -423,3 +423,27 @@ TEST(SurfaceSet2, IsValidGeometry) {
 
     EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }
+
+TEST(SurfaceSet2, IsInside) {
+    BoundingBox2D domain(Vector2D(), Vector2D(1, 2));
+    Vector2D offset(1, 2);
+
+    auto plane = Plane2::builder()
+            .withNormal({0, 1})
+            .withPoint({0, 0.25 * domain.height()})
+            .makeShared();
+
+    auto sphere = Sphere2::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet = SurfaceSet2::builder()
+            .withSurfaces({plane, sphere})
+            .withTransform(Transform2(offset, 0.0))
+            .makeShared();
+
+    EXPECT_TRUE(surfaceSet->isInside(Vector2D(0.5, 0.25) + offset));
+    EXPECT_TRUE(surfaceSet->isInside(Vector2D(0.5, 1.0) + offset));
+    EXPECT_FALSE(surfaceSet->isInside(Vector2D(0.5, 1.5) + offset));
+}

--- a/src/tests/unit_tests/surface_set3_tests.cpp
+++ b/src/tests/unit_tests/surface_set3_tests.cpp
@@ -425,3 +425,27 @@ TEST(SurfaceSet3, IsValidGeometry) {
 
     EXPECT_FALSE(surfaceSet2->isValidGeometry());
 }
+
+TEST(SurfaceSet3, IsInside) {
+    BoundingBox3D domain(Vector3D(), Vector3D(1, 2, 1));
+    Vector3D offset(1, 2, 3);
+
+    auto plane = Plane3::builder()
+            .withNormal({0, 1, 0})
+            .withPoint({0, 0.25 * domain.height(), 0})
+            .makeShared();
+
+    auto sphere = Sphere3::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet = SurfaceSet3::builder()
+            .withSurfaces({plane, sphere})
+            .withTransform(Transform3(offset, QuaternionD()))
+            .makeShared();
+
+    EXPECT_TRUE(surfaceSet->isInside(Vector3D(0.5, 0.25, 0.5) + offset));
+    EXPECT_TRUE(surfaceSet->isInside(Vector3D(0.5, 1.0, 0.5) + offset));
+    EXPECT_FALSE(surfaceSet->isInside(Vector3D(0.5, 1.5, 0.5) + offset));
+}


### PR DESCRIPTION
This revision adds `isInside` function to the surface classes. This enables the sub-classes for Surface2 and 3 to implement inside/outside check so that Collider2 and 3 can use the best possible inside/outside tests. For instance, if we know a surface is a signed-distance field, we can simply check its sign to perform the test. This will fix Issue #230 since the root cause of #230 is the approximated far-field SDF making inaccurate gradient descent for closest point query which was originally used for inside/outside testing from colliders.