### PR TITLE
Adding missing overrides for SurfaceToImplicit2 and 3

### DIFF
--- a/include/jet/surface_to_implicit2.h
+++ b/include/jet/surface_to_implicit2.h
@@ -34,6 +34,12 @@ class SurfaceToImplicit2 final : public ImplicitSurface2 {
     //! Copy constructor.
     SurfaceToImplicit2(const SurfaceToImplicit2& other);
 
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
+
     //! Returns the raw surface instance.
     Surface2Ptr surface() const;
 
@@ -56,6 +62,8 @@ class SurfaceToImplicit2 final : public ImplicitSurface2 {
 
     SurfaceRayIntersection2 closestIntersectionLocal(
         const Ray2D& ray) const override;
+
+    bool isInsideLocal(const Vector2D& otherPoint) const override;
 
  private:
     Surface2Ptr _surface;

--- a/include/jet/surface_to_implicit3.h
+++ b/include/jet/surface_to_implicit3.h
@@ -28,13 +28,18 @@ class SurfaceToImplicit3 final : public ImplicitSurface3 {
     class Builder;
 
     //! Constructs an instance with generic Surface3 instance.
-    SurfaceToImplicit3(
-        const Surface3Ptr& surface,
-        const Transform3& transform = Transform3(),
-        bool isNormalFlipped = false);
+    SurfaceToImplicit3(const Surface3Ptr& surface,
+                       const Transform3& transform = Transform3(),
+                       bool isNormalFlipped = false);
 
     //! Copy constructor.
     SurfaceToImplicit3(const SurfaceToImplicit3& other);
+
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
+    //! Returns true if the surface is a valid geometry.
+    bool isValidGeometry() const override;
 
     //! Returns the raw surface instance.
     Surface3Ptr surface() const;
@@ -51,13 +56,14 @@ class SurfaceToImplicit3 final : public ImplicitSurface3 {
 
     BoundingBox3D boundingBoxLocal() const override;
 
-    Vector3D closestNormalLocal(
-        const Vector3D& otherPoint) const override;
+    Vector3D closestNormalLocal(const Vector3D& otherPoint) const override;
 
     double signedDistanceLocal(const Vector3D& otherPoint) const override;
 
     SurfaceRayIntersection3 closestIntersectionLocal(
         const Ray3D& ray) const override;
+
+    bool isInsideLocal(const Vector3D& otherPoint) const override;
 
  private:
     Surface3Ptr _surface;
@@ -65,7 +71,6 @@ class SurfaceToImplicit3 final : public ImplicitSurface3 {
 
 //! Shared pointer for the SurfaceToImplicit3 type.
 typedef std::shared_ptr<SurfaceToImplicit3> SurfaceToImplicit3Ptr;
-
 
 //!
 //! \brief Front-end to create SurfaceToImplicit3 objects step by step.

--- a/src/jet/surface_to_implicit2.cpp
+++ b/src/jet/surface_to_implicit2.cpp
@@ -4,27 +4,28 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <pch.h>
 #include <jet/surface_to_implicit2.h>
+#include <pch.h>
 
 using namespace jet;
 
-SurfaceToImplicit2::SurfaceToImplicit2(
-    const Surface2Ptr& surface,
-    const Transform2& transform,
-    bool isNormalFlipped)
-: ImplicitSurface2(transform, isNormalFlipped)
-, _surface(surface) {
+SurfaceToImplicit2::SurfaceToImplicit2(const Surface2Ptr& surface,
+                                       const Transform2& transform,
+                                       bool isNormalFlipped)
+    : ImplicitSurface2(transform, isNormalFlipped), _surface(surface) {}
+
+SurfaceToImplicit2::SurfaceToImplicit2(const SurfaceToImplicit2& other)
+    : ImplicitSurface2(other), _surface(other._surface) {}
+
+bool SurfaceToImplicit2::isBounded() const { return _surface->isBounded(); }
+
+bool SurfaceToImplicit2::isValidGeometry() const {
+    return _surface->isValidGeometry();
 }
 
-SurfaceToImplicit2::SurfaceToImplicit2(const SurfaceToImplicit2& other) :
-    ImplicitSurface2(other),
-    _surface(other._surface) {
-}
+Surface2Ptr SurfaceToImplicit2::surface() const { return _surface; }
 
-Surface2Ptr SurfaceToImplicit2::surface() const {
-    return _surface;
-}
+SurfaceToImplicit2::Builder SurfaceToImplicit2::builder() { return Builder(); }
 
 Vector2D SurfaceToImplicit2::closestPointLocal(
     const Vector2D& otherPoint) const {
@@ -54,6 +55,10 @@ BoundingBox2D SurfaceToImplicit2::boundingBoxLocal() const {
     return _surface->boundingBox();
 }
 
+bool SurfaceToImplicit2::isInsideLocal(const Vector2D& otherPoint) const {
+    return _surface->isInside(otherPoint);
+}
+
 double SurfaceToImplicit2::signedDistanceLocal(
     const Vector2D& otherPoint) const {
     Vector2D x = _surface->closestPoint(otherPoint);
@@ -66,26 +71,18 @@ double SurfaceToImplicit2::signedDistanceLocal(
     }
 }
 
-
-SurfaceToImplicit2::Builder&
-SurfaceToImplicit2::Builder::withSurface(const Surface2Ptr& surface) {
+SurfaceToImplicit2::Builder& SurfaceToImplicit2::Builder::withSurface(
+    const Surface2Ptr& surface) {
     _surface = surface;
     return *this;
 }
 
-SurfaceToImplicit2
-SurfaceToImplicit2::Builder::build() const {
+SurfaceToImplicit2 SurfaceToImplicit2::Builder::build() const {
     return SurfaceToImplicit2(_surface, _transform, _isNormalFlipped);
 }
 
-SurfaceToImplicit2Ptr
-SurfaceToImplicit2::Builder::makeShared() const {
+SurfaceToImplicit2Ptr SurfaceToImplicit2::Builder::makeShared() const {
     return std::shared_ptr<SurfaceToImplicit2>(
-        new SurfaceToImplicit2(
-            _surface,
-            _transform,
-            _isNormalFlipped),
-        [] (SurfaceToImplicit2* obj) {
-            delete obj;
-        });
+        new SurfaceToImplicit2(_surface, _transform, _isNormalFlipped),
+        [](SurfaceToImplicit2* obj) { delete obj; });
 }

--- a/src/jet/surface_to_implicit3.cpp
+++ b/src/jet/surface_to_implicit3.cpp
@@ -4,32 +4,34 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
-#include <pch.h>
 #include <jet/surface_to_implicit3.h>
 #include <jet/triangle_mesh3.h>
+#include <pch.h>
 
 using namespace jet;
 
-SurfaceToImplicit3::SurfaceToImplicit3(
-    const Surface3Ptr& surface,
-    const Transform3& transform,
-    bool isNormalFlipped)
-: ImplicitSurface3(transform, isNormalFlipped)
-, _surface(surface) {
+SurfaceToImplicit3::SurfaceToImplicit3(const Surface3Ptr& surface,
+                                       const Transform3& transform,
+                                       bool isNormalFlipped)
+    : ImplicitSurface3(transform, isNormalFlipped), _surface(surface) {
     if (std::dynamic_pointer_cast<TriangleMesh3>(surface) != nullptr) {
         JET_WARN << "Using TriangleMesh3 with SurfaceToImplicit3 can cause "
                  << "undefined behavior. Use ImplicitTriangleMesh3 instead.";
     }
 }
 
-SurfaceToImplicit3::SurfaceToImplicit3(const SurfaceToImplicit3& other) :
-    ImplicitSurface3(other),
-    _surface(other._surface) {
+SurfaceToImplicit3::SurfaceToImplicit3(const SurfaceToImplicit3& other)
+    : ImplicitSurface3(other), _surface(other._surface) {}
+
+bool SurfaceToImplicit3::isBounded() const { return _surface->isBounded(); }
+
+bool SurfaceToImplicit3::isValidGeometry() const {
+    return _surface->isValidGeometry();
 }
 
-Surface3Ptr SurfaceToImplicit3::surface() const {
-    return _surface;
-}
+Surface3Ptr SurfaceToImplicit3::surface() const { return _surface; }
+
+SurfaceToImplicit3::Builder SurfaceToImplicit3::builder() { return Builder(); }
 
 Vector3D SurfaceToImplicit3::closestPointLocal(
     const Vector3D& otherPoint) const {
@@ -71,26 +73,22 @@ double SurfaceToImplicit3::signedDistanceLocal(
     }
 }
 
+bool SurfaceToImplicit3::isInsideLocal(const Vector3D& otherPoint) const {
+    return _surface->isInside(otherPoint);
+}
 
-SurfaceToImplicit3::Builder&
-SurfaceToImplicit3::Builder::withSurface(const Surface3Ptr& surface) {
+SurfaceToImplicit3::Builder& SurfaceToImplicit3::Builder::withSurface(
+    const Surface3Ptr& surface) {
     _surface = surface;
     return *this;
 }
 
-SurfaceToImplicit3
-SurfaceToImplicit3::Builder::build() const {
+SurfaceToImplicit3 SurfaceToImplicit3::Builder::build() const {
     return SurfaceToImplicit3(_surface, _transform, _isNormalFlipped);
 }
 
-SurfaceToImplicit3Ptr
-SurfaceToImplicit3::Builder::makeShared() const {
+SurfaceToImplicit3Ptr SurfaceToImplicit3::Builder::makeShared() const {
     return std::shared_ptr<SurfaceToImplicit3>(
-        new SurfaceToImplicit3(
-            _surface,
-            _transform,
-            _isNormalFlipped),
-        [] (SurfaceToImplicit3* obj) {
-            delete obj;
-        });
+        new SurfaceToImplicit3(_surface, _transform, _isNormalFlipped),
+        [](SurfaceToImplicit3* obj) { delete obj; });
 }

--- a/src/tests/unit_tests/surface_to_implicit2_tests.cpp
+++ b/src/tests/unit_tests/surface_to_implicit2_tests.cpp
@@ -5,6 +5,8 @@
 // property of any third parties.
 
 #include <jet/box2.h>
+#include <jet/plane2.h>
+#include <jet/surface_set2.h>
 #include <jet/surface_to_implicit2.h>
 
 #include <gtest/gtest.h>
@@ -128,4 +130,31 @@ TEST(SurfaceToImplicit2, ClosestNormal) {
     Vector2D s2iNormal = s2i.closestNormal(pt);
     EXPECT_DOUBLE_EQ(boxNormal.x, s2iNormal.x);
     EXPECT_DOUBLE_EQ(boxNormal.y, s2iNormal.y);
+}
+
+TEST(SurfaceToImplicit2, IsBounded) {
+    Plane2Ptr plane =
+        Plane2::builder().withPoint({0, 0}).withNormal({0, 1}).makeShared();
+    SurfaceToImplicit2Ptr s2i =
+        SurfaceToImplicit2::builder().withSurface(plane).makeShared();
+    EXPECT_FALSE(s2i->isBounded());
+}
+
+TEST(SurfaceToImplicit2, IsValidGeometry) {
+    SurfaceSet2Ptr sset = SurfaceSet2::builder().makeShared();
+    SurfaceToImplicit2Ptr s2i =
+        SurfaceToImplicit2::builder().withSurface(sset).makeShared();
+    EXPECT_FALSE(s2i->isValidGeometry());
+}
+
+TEST(SurfaceToImplicit2, IsInside) {
+    Plane2Ptr plane = Plane2::builder()
+                          .withPoint({0, 0})
+                          .withNormal({0, 1})
+                          .withTranslation({0, -1})
+                          .makeShared();
+    SurfaceToImplicit2Ptr s2i =
+        SurfaceToImplicit2::builder().withSurface(plane).makeShared();
+    EXPECT_FALSE(s2i->isInside({0, -0.5}));
+    EXPECT_TRUE(s2i->isInside({0, -1.5}));
 }

--- a/src/tests/unit_tests/surface_to_implicit3_tests.cpp
+++ b/src/tests/unit_tests/surface_to_implicit3_tests.cpp
@@ -5,6 +5,8 @@
 // property of any third parties.
 
 #include <jet/box3.h>
+#include <jet/plane3.h>
+#include <jet/surface_set3.h>
 #include <jet/surface_to_implicit3.h>
 
 #include <gtest/gtest.h>
@@ -132,4 +134,33 @@ TEST(SurfaceToImplicit3, ClosestNormal) {
     EXPECT_DOUBLE_EQ(boxNormal.x, s2iNormal.x);
     EXPECT_DOUBLE_EQ(boxNormal.y, s2iNormal.y);
     EXPECT_DOUBLE_EQ(boxNormal.z, s2iNormal.z);
+}
+
+TEST(SurfaceToImplicit3, IsBounded) {
+    Plane3Ptr plane = Plane3::builder()
+                          .withPoint({0, 0, 0})
+                          .withNormal({0, 1, 0})
+                          .makeShared();
+    SurfaceToImplicit3Ptr s2i =
+        SurfaceToImplicit3::builder().withSurface(plane).makeShared();
+    EXPECT_FALSE(s2i->isBounded());
+}
+
+TEST(SurfaceToImplicit3, IsValidGeometry) {
+    SurfaceSet3Ptr sset = SurfaceSet3::builder().makeShared();
+    SurfaceToImplicit3Ptr s2i =
+        SurfaceToImplicit3::builder().withSurface(sset).makeShared();
+    EXPECT_FALSE(s2i->isValidGeometry());
+}
+
+TEST(SurfaceToImplicit3, IsInside) {
+    Plane3Ptr plane = Plane3::builder()
+                          .withPoint({0, 0, 0})
+                          .withNormal({0, 1, 0})
+                          .withTranslation({0, -1, 0})
+                          .makeShared();
+    SurfaceToImplicit3Ptr s2i =
+        SurfaceToImplicit3::builder().withSurface(plane).makeShared();
+    EXPECT_FALSE(s2i->isInside({0, -0.5, 0}));
+    EXPECT_TRUE(s2i->isInside({0, -1.5, 0}));
 }


### PR DESCRIPTION
This revision includes adds missing overrides to SurfaceToImplicit2 and 3. These virtual functions were introduced from the recent commits and were not fully implemented in SurfaceToImplicit classes.