### PR TITLE
Fix isBound function for surface set classes

### DIFF
--- a/include/jet/implicit_surface_set2.h
+++ b/include/jet/implicit_surface_set2.h
@@ -44,6 +44,9 @@ class ImplicitSurfaceSet2 final : public ImplicitSurface2 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
     //! Returns true if the surface is a valid geometry.
     bool isValidGeometry() const override;
 

--- a/include/jet/implicit_surface_set3.h
+++ b/include/jet/implicit_surface_set3.h
@@ -44,6 +44,9 @@ class ImplicitSurfaceSet3 final : public ImplicitSurface3 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
     //! Returns true if the surface is a valid geometry.
     bool isValidGeometry() const override;
 

--- a/include/jet/surface_set2.h
+++ b/include/jet/surface_set2.h
@@ -39,6 +39,9 @@ class SurfaceSet2 final : public Surface2 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
     //! Returns true if the surface is a valid geometry.
     bool isValidGeometry() const override;
 

--- a/include/jet/surface_set3.h
+++ b/include/jet/surface_set3.h
@@ -39,6 +39,9 @@ class SurfaceSet3 final : public Surface3 {
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
 
+    //! Returns true if bounding box can be defined.
+    bool isBounded() const override;
+
     //! Returns true if the surface is a valid geometry.
     bool isValidGeometry() const override;
 

--- a/src/jet/implicit_surface_set2.cpp
+++ b/src/jet/implicit_surface_set2.cpp
@@ -41,6 +41,18 @@ ImplicitSurfaceSet2::ImplicitSurfaceSet2(const ImplicitSurfaceSet2& other)
 
 void ImplicitSurfaceSet2::updateQueryEngine() { buildBvh(); }
 
+bool ImplicitSurfaceSet2::isBounded() const {
+    // All surfaces should be bounded.
+    for (auto surface : _surfaces) {
+        if (!surface->isBounded()) {
+            return false;
+        }
+    }
+
+    // Empty set is not bounded.
+    return !_surfaces.empty();
+}
+
 bool ImplicitSurfaceSet2::isValidGeometry() const {
     // All surfaces should be valid.
     for (auto surface : _surfaces) {

--- a/src/jet/implicit_surface_set3.cpp
+++ b/src/jet/implicit_surface_set3.cpp
@@ -41,6 +41,18 @@ ImplicitSurfaceSet3::ImplicitSurfaceSet3(const ImplicitSurfaceSet3& other)
 
 void ImplicitSurfaceSet3::updateQueryEngine() { buildBvh(); }
 
+bool ImplicitSurfaceSet3::isBounded() const {
+    // All surfaces should be bounded.
+    for (auto surface : _surfaces) {
+        if (!surface->isBounded()) {
+            return false;
+        }
+    }
+
+    // Empty set is not bounded.
+    return !_surfaces.empty();
+}
+
 bool ImplicitSurfaceSet3::isValidGeometry() const {
     // All surfaces should be valid.
     for (auto surface : _surfaces) {

--- a/src/jet/surface2.cpp
+++ b/src/jet/surface2.cpp
@@ -60,7 +60,7 @@ bool Surface2::isBounded() const { return true; }
 bool Surface2::isValidGeometry() const { return true; }
 
 bool Surface2::isInside(const Vector2D& otherPoint) const {
-    return isInsideLocal(transform.toLocal(otherPoint));
+    return isNormalFlipped == !isInsideLocal(transform.toLocal(otherPoint));
 }
 
 bool Surface2::intersectsLocal(const Ray2D& rayLocal) const {

--- a/src/jet/surface3.cpp
+++ b/src/jet/surface3.cpp
@@ -65,7 +65,7 @@ bool Surface3::isBounded() const { return true; }
 bool Surface3::isValidGeometry() const { return true; }
 
 bool Surface3::isInside(const Vector3D& otherPoint) const {
-    return isInsideLocal(transform.toLocal(otherPoint));
+    return isNormalFlipped == !isInsideLocal(transform.toLocal(otherPoint));
 }
 
 double Surface3::closestDistanceLocal(const Vector3D& otherPointLocal) const {

--- a/src/jet/surface_set2.cpp
+++ b/src/jet/surface_set2.cpp
@@ -32,6 +32,18 @@ SurfaceSet2::SurfaceSet2(const SurfaceSet2& other)
 
 void SurfaceSet2::updateQueryEngine() { buildBvh(); }
 
+bool SurfaceSet2::isBounded() const {
+    // All surfaces should be bounded.
+    for (auto surface : _surfaces) {
+        if (!surface->isBounded()) {
+            return false;
+        }
+    }
+
+    // Empty set is not bounded.
+    return !_surfaces.empty();
+}
+
 bool SurfaceSet2::isValidGeometry() const {
     // All surfaces should be valid.
     for (auto surface : _surfaces) {

--- a/src/jet/surface_set3.cpp
+++ b/src/jet/surface_set3.cpp
@@ -32,6 +32,18 @@ SurfaceSet3::SurfaceSet3(const SurfaceSet3& other)
 
 void SurfaceSet3::updateQueryEngine() { buildBvh(); }
 
+bool SurfaceSet3::isBounded() const {
+    // All surfaces should be bounded.
+    for (auto surface : _surfaces) {
+        if (!surface->isBounded()) {
+            return false;
+        }
+    }
+
+    // Empty set is not bounded.
+    return !_surfaces.empty();
+}
+
 bool SurfaceSet3::isValidGeometry() const {
     // All surfaces should be valid.
     for (auto surface : _surfaces) {

--- a/src/tests/unit_tests/implicit_surface_set2_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set2_tests.cpp
@@ -4,6 +4,8 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "unit_tests_utils.h"
+
 #include <jet/box2.h>
 #include <jet/implicit_surface_set2.h>
 #include <jet/plane2.h>
@@ -25,6 +27,9 @@ TEST(ImplicitSurfaceSet2, Constructor) {
     ImplicitSurfaceSet2 sset2(sset);
     EXPECT_EQ(1u, sset2.numberOfSurfaces());
     EXPECT_TRUE(sset2.isNormalFlipped);
+
+    ImplicitSurfaceSet2 sset3({box});
+    EXPECT_EQ(1u, sset3.numberOfSurfaces());
 }
 
 TEST(ImplicitSurfaceSet2, NumberOfSurfaces) {
@@ -200,6 +205,31 @@ TEST(ImplicitSurfaceSet2, ClosestNormal) {
     Vector2D setNormal = sset->closestNormal(pt);
     EXPECT_DOUBLE_EQ(boxNormal.x, setNormal.x);
     EXPECT_DOUBLE_EQ(boxNormal.y, setNormal.y);
+}
+
+TEST(ImplicitSurfaceSet2, MixedBoundTypes) {
+    BoundingBox2D domain(Vector2D(), Vector2D(1, 2));
+
+    auto plane = Plane2::builder()
+            .withNormal({0, 1})
+            .withPoint({0.0, 0.25 * domain.height()})
+            .makeShared();
+
+    auto sphere = Sphere2::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet = ImplicitSurfaceSet2::builder()
+            .withExplicitSurfaces({plane, sphere})
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isBounded());
+
+    auto cp = surfaceSet->closestPoint(Vector2D(0.5, 0.4));
+    Vector2D answer(0.5, 0.5);
+
+    EXPECT_VECTOR2_NEAR(answer, cp, 1e-9);
 }
 
 TEST(ImplicitSurfaceSet2, IsValidGeometry) {

--- a/src/tests/unit_tests/implicit_surface_set3_tests.cpp
+++ b/src/tests/unit_tests/implicit_surface_set3_tests.cpp
@@ -4,6 +4,8 @@
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
+#include "unit_tests_utils.h"
+
 #include <jet/box3.h>
 #include <jet/implicit_surface_set3.h>
 #include <jet/plane3.h>
@@ -25,6 +27,9 @@ TEST(ImplicitSurfaceSet3, Constructor) {
     ImplicitSurfaceSet3 sset2(sset);
     EXPECT_EQ(1u, sset2.numberOfSurfaces());
     EXPECT_TRUE(sset2.isNormalFlipped);
+
+    ImplicitSurfaceSet3 sset3({box});
+    EXPECT_EQ(1u, sset3.numberOfSurfaces());
 }
 
 TEST(ImplicitSurfaceSet3, NumberOfSurfaces) {
@@ -204,6 +209,31 @@ TEST(ImplicitSurfaceSet3, ClosestNormal) {
     EXPECT_DOUBLE_EQ(boxNormal.x, setNormal.x);
     EXPECT_DOUBLE_EQ(boxNormal.y, setNormal.y);
     EXPECT_DOUBLE_EQ(boxNormal.z, setNormal.z);
+}
+
+TEST(ImplicitSurfaceSet3, MixedBoundTypes) {
+    BoundingBox3D domain(Vector3D(), Vector3D(1, 2, 1));
+
+    auto plane = Plane3::builder()
+            .withNormal({0, 1, 0})
+            .withPoint({0, 0.25 * domain.height(), 0})
+            .makeShared();
+
+    auto sphere = Sphere3::builder()
+            .withCenter(domain.midPoint())
+            .withRadius(0.15 * domain.width())
+            .makeShared();
+
+    auto surfaceSet = ImplicitSurfaceSet3::builder()
+            .withExplicitSurfaces({plane, sphere})
+            .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isBounded());
+
+    auto cp = surfaceSet->closestPoint(Vector3D(0.5, 0.4, 0.5));
+    Vector3D answer(0.5, 0.5, 0.5);
+
+    EXPECT_VECTOR3_NEAR(answer, cp, 1e-9);
 }
 
 TEST(ImplicitSurfaceSet3, IsValidGeometry) {

--- a/src/tests/unit_tests/surface_set2_tests.cpp
+++ b/src/tests/unit_tests/surface_set2_tests.cpp
@@ -37,6 +37,17 @@ TEST(SurfaceSet2, Constructors) {
                       false);
     EXPECT_EQ(Vector2D(1, 2), sset3.transform.translation());
     EXPECT_EQ(0.5, sset3.transform.orientation());
+
+    SurfaceSet2 sset4(sset3);
+    EXPECT_EQ(3u, sset4.numberOfSurfaces());
+    EXPECT_EQ(sph1->radius,
+              std::dynamic_pointer_cast<Sphere2>(sset4.surfaceAt(0))->radius);
+    EXPECT_EQ(sph2->radius,
+              std::dynamic_pointer_cast<Sphere2>(sset4.surfaceAt(1))->radius);
+    EXPECT_EQ(sph3->radius,
+              std::dynamic_pointer_cast<Sphere2>(sset4.surfaceAt(2))->radius);
+    EXPECT_EQ(Vector2D(1, 2), sset4.transform.translation());
+    EXPECT_EQ(0.5, sset4.transform.orientation());
 }
 
 TEST(SurfaceSet2, AddSurface) {
@@ -377,7 +388,7 @@ TEST(SurfaceSet2, MixedBoundTypes) {
 
     auto plane = Plane2::builder()
             .withNormal({0, 1})
-            .withPoint({0, 0.25 * domain.height()})
+            .withPoint({0.0, 0.25 * domain.height()})
             .makeShared();
 
     auto sphere = Sphere2::builder()
@@ -388,6 +399,8 @@ TEST(SurfaceSet2, MixedBoundTypes) {
     auto surfaceSet = SurfaceSet2::builder()
             .withSurfaces({plane, sphere})
             .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isBounded());
 
     auto cp = surfaceSet->closestPoint(Vector2D(0.5, 0.4));
     Vector2D answer(0.5, 0.5);

--- a/src/tests/unit_tests/surface_set3_tests.cpp
+++ b/src/tests/unit_tests/surface_set3_tests.cpp
@@ -38,6 +38,17 @@ TEST(SurfaceSet3, Constructors) {
         Transform3(Vector3D(1, 2, 3), QuaternionD({1, 0, 0}, 0.5)), false);
     EXPECT_EQ(Vector3D(1, 2, 3), sset3.transform.translation());
     EXPECT_EQ(QuaternionD({1, 0, 0}, 0.5), sset3.transform.orientation());
+
+    SurfaceSet3 sset4(sset3);
+    EXPECT_EQ(3u, sset4.numberOfSurfaces());
+    EXPECT_EQ(sph1->radius,
+              std::dynamic_pointer_cast<Sphere3>(sset4.surfaceAt(0))->radius);
+    EXPECT_EQ(sph2->radius,
+              std::dynamic_pointer_cast<Sphere3>(sset4.surfaceAt(1))->radius);
+    EXPECT_EQ(sph3->radius,
+              std::dynamic_pointer_cast<Sphere3>(sset4.surfaceAt(2))->radius);
+    EXPECT_EQ(Vector3D(1, 2, 3), sset4.transform.translation());
+    EXPECT_EQ(QuaternionD({1, 0, 0}, 0.5), sset4.transform.orientation());
 }
 
 TEST(SurfaceSet3, AddSurface) {
@@ -390,6 +401,8 @@ TEST(SurfaceSet3, MixedBoundTypes) {
     auto surfaceSet = SurfaceSet3::builder()
             .withSurfaces({plane, sphere})
             .makeShared();
+
+    EXPECT_FALSE(surfaceSet->isBounded());
 
     auto cp = surfaceSet->closestPoint(Vector3D(0.5, 0.4, 0.5));
     Vector3D answer(0.5, 0.5, 0.5);


### PR DESCRIPTION
This revision fixes Issue #234 which is a regression bug caused by recent API addition around surface and collider classes. When a surface set instance holds one or more unbounded surface object, it should also report unbounded.