### PR TITLE
Winding number-based signed-distance function for TriangleMesh3

### DIFF
--- a/3RD_PARTY.md
+++ b/3RD_PARTY.md
@@ -142,6 +142,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
+Jet uses portion of Christopher Batty's example code from http://www.cs.ubc.ca/labs/imager/tr/2007/Batty_VariationalFluids/ and https://github.com/christopherbatty/FluidRigidCoupling2D
+
+---
+
 Jet uses FlatBuffers for serialization
 
 

--- a/3RD_PARTY.md
+++ b/3RD_PARTY.md
@@ -142,24 +142,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
-Jet uses portion of SDFGen
-
-The MIT License (MIT)
-
-Copyright (c) 2015, Christopher Batty
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----
-
-Jet uses portion of Christopher Batty's example code from http://www.cs.ubc.ca/labs/imager/tr/2007/Batty_VariationalFluids/ and https://github.com/christopherbatty/FluidRigidCoupling2D
-
----
-
 Jet uses FlatBuffers for serialization
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Doyub Kim
+# Copyright (c) 2019 Doyub Kim
 #
 # I am making my contributions/submissions to this project solely in my personal
 # capacity and am not conveying any rights to any intellectual property of any
@@ -15,6 +15,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Declare project
 project(jet)
 
+# Useful paths
+set(EXTERNAL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external)
+
 # Set output directories
 set(DEFAULT_CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
@@ -25,7 +28,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 include_directories(include)
 include_directories(external)
 include_directories(external/pybind11/include)
-include_directories(external/googletest/googletest/include)
 include_directories(external/Clara/include)
 include_directories(external/tinyobj)
 include_directories(src/examples)
@@ -72,7 +74,7 @@ add_custom_target(unzip_py ALL
 
 # Project modules
 set(BUILD_GTEST ON CACHE BOOL "" FORCE)
-set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(external/googletest EXCLUDE_FROM_ALL)
 if ((CMAKE_VERSION VERSION_EQUAL 3.3) OR (CMAKE_VERSION VERSION_GREATER 3.3))

--- a/include/jet/bvh2.h
+++ b/include/jet/bvh2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -26,9 +26,9 @@ template <typename T>
 class Bvh2 final : public IntersectionQueryEngine2<T>,
                    public NearestNeighborQueryEngine2<T> {
  public:
-    typedef std::vector<T> ContainerType;
-    typedef typename ContainerType::iterator Iterator;
-    typedef typename ContainerType::const_iterator ConstIterator;
+    using ContainerType = std::vector<T>;
+    using Iterator = typename ContainerType::iterator;
+    using ConstIterator = typename ContainerType::const_iterator;
 
     //! Default constructor.
     Bvh2();
@@ -89,6 +89,24 @@ class Bvh2 final : public IntersectionQueryEngine2<T>,
 
     //! Returns the item at \p i.
     const T& item(size_t i) const;
+
+    //! Returns the number of nodes.
+    size_t numberOfNodes() const;
+
+    //! Returns the children indices of \p i-th node.
+    std::pair<size_t, size_t> children(size_t i) const;
+
+    //! Returns true if \p i-th node is a leaf node.
+    bool isLeaf(size_t i) const;
+
+    //! Returns bounding box of \p i-th node.
+    const BoundingBox2D& nodeBound(size_t i) const;
+
+    //! Returns item of \p i-th node.
+    Iterator itemOfNode(size_t i);
+
+    //! Returns item of \p i-th node.
+    ConstIterator itemOfNode(size_t i) const;
 
  private:
     struct Node {

--- a/include/jet/bvh3.h
+++ b/include/jet/bvh3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -26,9 +26,9 @@ template <typename T>
 class Bvh3 final : public IntersectionQueryEngine3<T>,
                    public NearestNeighborQueryEngine3<T> {
  public:
-    typedef std::vector<T> ContainerType;
-    typedef typename ContainerType::iterator Iterator;
-    typedef typename ContainerType::const_iterator ConstIterator;
+    using ContainerType = std::vector<T>;
+    using Iterator = typename ContainerType::iterator;
+    using ConstIterator = typename ContainerType::const_iterator;
 
     //! Default constructor.
     Bvh3();
@@ -89,6 +89,24 @@ class Bvh3 final : public IntersectionQueryEngine3<T>,
 
     //! Returns the item at \p i.
     const T& item(size_t i) const;
+
+    //! Returns the number of nodes.
+    size_t numberOfNodes() const;
+
+    //! Returns the children indices of \p i-th node.
+    std::pair<size_t, size_t> children(size_t i) const;
+
+    //! Returns true if \p i-th node is a leaf node.
+    bool isLeaf(size_t i) const;
+
+    //! Returns bounding box of \p i-th node.
+    const BoundingBox3D& nodeBound(size_t i) const;
+
+    //! Returns item of \p i-th node.
+    Iterator itemOfNode(size_t i);
+
+    //! Returns item of \p i-th node.
+    ConstIterator itemOfNode(size_t i) const;
 
  private:
     struct Node {

--- a/include/jet/constants.h
+++ b/include/jet/constants.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -73,7 +73,6 @@ constexpr float kEpsilonF = std::numeric_limits<float>::epsilon();
 //! Double-type epsilon.
 constexpr double kEpsilonD = std::numeric_limits<double>::epsilon();
 
-
 // MARK: Max
 
 //! Max size_t.
@@ -87,7 +86,6 @@ constexpr float kMaxF = std::numeric_limits<float>::max();
 
 //! Max double.
 constexpr double kMaxD = std::numeric_limits<double>::max();
-
 
 // MARK: Pi
 
@@ -115,7 +113,6 @@ constexpr double pi<double>() {
     return kPiD;
 }
 
-
 // MARK: Pi/2
 
 //! Float-type pi/2.
@@ -141,7 +138,6 @@ template <>
 constexpr double halfPi<double>() {
     return kHalfPiD;
 }
-
 
 // MARK: Pi/4
 
@@ -195,6 +191,32 @@ constexpr double twoPi<double>() {
     return kTwoPiD;
 }
 
+// MARK: 4*Pi
+
+//! Float-type 4*pi.
+constexpr float kFourPiF = static_cast<float>(4.0 * kPiD);
+
+//! Double-type 4*pi.
+constexpr double kFourPiD = 4.0 * kPiD;
+
+//! 4*pi for type T.
+template <typename T>
+constexpr T fourPi() {
+    return static_cast<T>(kFourPiD);
+}
+
+//! 4*pi for float.
+template <>
+constexpr float fourPi<float>() {
+    return kFourPiF;
+}
+
+//! 4*pi for double.
+template <>
+constexpr double fourPi<double>() {
+    return kFourPiD;
+}
+
 // MARK: 1/Pi
 
 //! Float-type 1/pi.
@@ -220,7 +242,6 @@ template <>
 constexpr double invPi<double>() {
     return kInvPiD;
 }
-
 
 // MARK: 1/2*Pi
 
@@ -248,6 +269,31 @@ constexpr double invTwoPi<double>() {
     return kInvTwoPiD;
 }
 
+// MARK: 1/4*Pi
+
+//! Float-type 1/4*pi.
+constexpr float kInvFourPiF = static_cast<float>(0.25 / kPiD);
+
+//! Double-type 1/4*pi.
+constexpr double kInvFourPiD = 0.25 / kPiD;
+
+//! 1/4*pi for type T.
+template <typename T>
+constexpr T invFourPi() {
+    return static_cast<T>(kInvFourPiD);
+}
+
+//! 1/4*pi for float.
+template <>
+constexpr float invFourPi<float>() {
+    return kInvFourPiF;
+}
+
+//! 1/4*pi for double.
+template <>
+constexpr double invFourPi<double>() {
+    return kInvFourPiD;
+}
 
 // MARK: Physics
 
@@ -259,7 +305,6 @@ constexpr double kWaterDensity = 1000.0;
 
 //! Speed of sound in water at 20 degrees celcius.
 constexpr double kSpeedOfSoundInWater = 1482.0;
-
 
 // MARK: Common enums
 
@@ -285,10 +330,9 @@ constexpr int kDirectionBack = 1 << 4;
 constexpr int kDirectionFront = 1 << 5;
 
 //! All direction.
-constexpr int kDirectionAll
-    = kDirectionLeft | kDirectionRight
-    | kDirectionDown | kDirectionUp
-    | kDirectionBack | kDirectionFront;
+constexpr int kDirectionAll = kDirectionLeft | kDirectionRight |
+                              kDirectionDown | kDirectionUp | kDirectionBack |
+                              kDirectionFront;
 
 }  // namespace jet
 

--- a/include/jet/detail/bvh2-inl.h
+++ b/include/jet/detail/bvh2-inl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -160,8 +160,9 @@ inline NearestNeighborQueryResult2<T> Bvh2<T>::nearest(
 }
 
 template <typename T>
-inline bool Bvh2<T>::intersects(const BoundingBox2D& box,
-                                const BoxIntersectionTestFunc2<T>& testFunc) const {
+inline bool Bvh2<T>::intersects(
+    const BoundingBox2D& box,
+    const BoxIntersectionTestFunc2<T>& testFunc) const {
     if (!_bound.overlaps(box)) {
         return false;
     }
@@ -211,8 +212,8 @@ inline bool Bvh2<T>::intersects(const BoundingBox2D& box,
 }
 
 template <typename T>
-inline bool Bvh2<T>::intersects(const Ray2D& ray,
-                                const RayIntersectionTestFunc2<T>& testFunc) const {
+inline bool Bvh2<T>::intersects(
+    const Ray2D& ray, const RayIntersectionTestFunc2<T>& testFunc) const {
     if (!_bound.intersects(ray)) {
         return false;
     }
@@ -472,6 +473,48 @@ size_t Bvh2<T>::numberOfItems() const {
 template <typename T>
 const T& Bvh2<T>::item(size_t i) const {
     return _items[i];
+}
+
+template <typename T>
+size_t Bvh2<T>::numberOfNodes() const {
+    return _nodes.size();
+}
+
+template <typename T>
+std::pair<size_t, size_t> Bvh2<T>::children(size_t i) const {
+    if (isLeaf(i)) {
+        return std::make_pair(kMaxSize, kMaxSize);
+    } else {
+        return std::make_pair(i + 1, _nodes[i].child);
+    }
+}
+
+template <typename T>
+bool Bvh2<T>::isLeaf(size_t i) const {
+    return _nodes[i].isLeaf();
+}
+
+template <typename T>
+const BoundingBox2D& Bvh2<T>::nodeBound(size_t i) const {
+    return _nodes[i].bound;
+}
+
+template <typename T>
+typename Bvh2<T>::Iterator Bvh2<T>::itemOfNode(size_t i) {
+    if (isLeaf(i)) {
+        return _nodes[i].item + begin();
+    } else {
+        return end();
+    }
+}
+
+template <typename T>
+typename Bvh2<T>::ConstIterator Bvh2<T>::itemOfNode(size_t i) const {
+    if (isLeaf(i)) {
+        return _nodes[i].item + begin();
+    } else {
+        return end();
+    }
 }
 
 template <typename T>

--- a/include/jet/detail/bvh3-inl.h
+++ b/include/jet/detail/bvh3-inl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -160,8 +160,9 @@ inline NearestNeighborQueryResult3<T> Bvh3<T>::nearest(
 }
 
 template <typename T>
-inline bool Bvh3<T>::intersects(const BoundingBox3D& box,
-                                const BoxIntersectionTestFunc3<T>& testFunc) const {
+inline bool Bvh3<T>::intersects(
+    const BoundingBox3D& box,
+    const BoxIntersectionTestFunc3<T>& testFunc) const {
     if (!_bound.overlaps(box)) {
         return false;
     }
@@ -211,8 +212,8 @@ inline bool Bvh3<T>::intersects(const BoundingBox3D& box,
 }
 
 template <typename T>
-inline bool Bvh3<T>::intersects(const Ray3D& ray,
-                                const RayIntersectionTestFunc3<T>& testFunc) const {
+inline bool Bvh3<T>::intersects(
+    const Ray3D& ray, const RayIntersectionTestFunc3<T>& testFunc) const {
     if (!_bound.intersects(ray)) {
         return false;
     }
@@ -472,6 +473,48 @@ size_t Bvh3<T>::numberOfItems() const {
 template <typename T>
 const T& Bvh3<T>::item(size_t i) const {
     return _items[i];
+}
+
+template <typename T>
+size_t Bvh3<T>::numberOfNodes() const {
+    return _nodes.size();
+}
+
+template <typename T>
+std::pair<size_t, size_t> Bvh3<T>::children(size_t i) const {
+    if (isLeaf(i)) {
+        return std::make_pair(kMaxSize, kMaxSize);
+    } else {
+        return std::make_pair(i + 1, _nodes[i].child);
+    }
+}
+
+template <typename T>
+bool Bvh3<T>::isLeaf(size_t i) const {
+    return _nodes[i].isLeaf();
+}
+
+template <typename T>
+const BoundingBox3D& Bvh3<T>::nodeBound(size_t i) const {
+    return _nodes[i].bound;
+}
+
+template <typename T>
+typename Bvh3<T>::Iterator Bvh3<T>::itemOfNode(size_t i) {
+    if (isLeaf(i)) {
+        return _nodes[i].item + begin();
+    } else {
+        return end();
+    }
+}
+
+template <typename T>
+typename Bvh3<T>::ConstIterator Bvh3<T>::itemOfNode(size_t i) const {
+    if (isLeaf(i)) {
+        return _nodes[i].item + begin();
+    } else {
+        return end();
+    }
 }
 
 template <typename T>

--- a/include/jet/surface_to_implicit2.h
+++ b/include/jet/surface_to_implicit2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -33,6 +33,9 @@ class SurfaceToImplicit2 final : public ImplicitSurface2 {
 
     //! Copy constructor.
     SurfaceToImplicit2(const SurfaceToImplicit2& other);
+
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
 
     //! Returns true if bounding box can be defined.
     bool isBounded() const override;

--- a/include/jet/surface_to_implicit3.h
+++ b/include/jet/surface_to_implicit3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -34,6 +34,9 @@ class SurfaceToImplicit3 final : public ImplicitSurface3 {
 
     //! Copy constructor.
     SurfaceToImplicit3(const SurfaceToImplicit3& other);
+
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() override;
 
     //! Returns true if bounding box can be defined.
     bool isBounded() const override;

--- a/include/jet/triangle_mesh3.h
+++ b/include/jet/triangle_mesh3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -53,6 +53,9 @@ class TriangleMesh3 final : public Surface3 {
 
     //! Updates internal spatial query engine.
     void updateQueryEngine() override;
+
+    //! Updates internal spatial query engine.
+    void updateQueryEngine() const;
 
     //! Clears all content.
     void clear();
@@ -207,6 +210,8 @@ class TriangleMesh3 final : public Surface3 {
     SurfaceRayIntersection3 closestIntersectionLocal(
         const Ray3D& ray) const override;
 
+    bool isInsideLocal(const Vector3D& otherPoint) const override;
+
  private:
     PointArray _points;
     NormalArray _normals;
@@ -218,9 +223,22 @@ class TriangleMesh3 final : public Surface3 {
     mutable Bvh3<size_t> _bvh;
     mutable bool _bvhInvalidated = true;
 
-    void invalidateBvh();
+    mutable Array1<Vector3D> _wnAreaWeightedNormalSums;
+    mutable Array1<Vector3D> _wnAreaWeightedAvgPositions;
+    mutable bool _wnInvalidated = true;
+
+    void invalidateCache();
 
     void buildBvh() const;
+
+    void buildWindingNumbers() const;
+
+    double windingNumber(const Vector3D& queryPoint, size_t triIndex) const;
+
+    double fastWindingNumber(const Vector3D& queryPoint, double accuracy) const;
+
+    double fastWindingNumber(const Vector3D& queryPoint, size_t rootNodeIndex,
+                             double accuracy) const;
 };
 
 //! Shared pointer for the TriangleMesh3 type.

--- a/include/jet/triangle_mesh_to_sdf.h
+++ b/include/jet/triangle_mesh_to_sdf.h
@@ -1,68 +1,32 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
-//
-// This code is ported from Christopher Batty's SDFGen software.
-// (https://github.com/christopherbatty/SDFGen)
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2015, Christopher Batty
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
 
 #ifndef INCLUDE_JET_TRIANGLE_MESH_TO_SDF_H_
 #define INCLUDE_JET_TRIANGLE_MESH_TO_SDF_H_
 
-#include <jet/triangle_mesh3.h>
 #include <jet/scalar_grid3.h>
+#include <jet/triangle_mesh3.h>
 
 namespace jet {
 
 //!
-//! \brief      Generates signed-distance field out of given triangle mesh.
+//! \brief Generates signed-distance field out of given triangle mesh.
 //!
-//! This function generates signed-distance field from a triangle mesh. The mesh
-//! should be water-tight, meaning there should be no gap. A gap can make the
-//! evaluation of the signs impossible. The output signed-distance field will be
-//! assigned to the scalar field, \p sdf, which can be any type of scalar field
-//! (vertex-centered vs. cell-centered). To accelerate the calculation, this
-//! function also takes extra parameter, \p exactBand, which defines the
-//! bandwidth around the mesh in a number of grid points. This bandwidth is the
-//! region where the exact distance to the mesh will be computed. Distance
-//! values of the areas that are farther from the mesh surface will be
-//! approximated using fast sweeping method. The sign of the signed-distance
-//! field is determined by assuming the boundig box of the output scalar grid
-//! is the exterior of the mesh.
+//! This function generates signed-distance field from a triangle mesh. The sign
+//! is determined by TriangleMesh3::isInside (negative means inside).
 //!
-//! This function is a port of Christopher Batty's SDFGen software.
-//!
-//! \see https://github.com/christopherbatty/SDFGen
+//! \warning Parameter \p exactBand is no longer used and will be deprecated in
+//! next release (v2.x).
 //!
 //! \param[in]      mesh      The mesh.
 //! \param[in,out]  sdf       The output signed-distance field.
-//! \param[in]      exactBand The bandwidth for exact distance computation.
+//! \param[in]      exactBand This parameter is no longer used.
 //!
-void triangleMeshToSdf(
-    const TriangleMesh3& mesh,
-    ScalarGrid3* sdf,
-    const unsigned int exactBand = 1);
+void triangleMeshToSdf(const TriangleMesh3& mesh, ScalarGrid3* sdf,
+                       const unsigned int exactBand = 1);
 
 }  // namespace jet
 

--- a/src/jet/implicit_surface2.cpp
+++ b/src/jet/implicit_surface2.cpp
@@ -24,7 +24,8 @@ ImplicitSurface2::~ImplicitSurface2() {
 }
 
 double ImplicitSurface2::signedDistance(const Vector2D& otherPoint) const {
-    return signedDistanceLocal(transform.toLocal(otherPoint));
+    double sd = signedDistanceLocal(transform.toLocal(otherPoint));
+    return (isNormalFlipped) ? -sd : sd;
 }
 
 double ImplicitSurface2::closestDistanceLocal(

--- a/src/jet/implicit_surface3.cpp
+++ b/src/jet/implicit_surface3.cpp
@@ -24,7 +24,8 @@ ImplicitSurface3::~ImplicitSurface3() {
 }
 
 double ImplicitSurface3::signedDistance(const Vector3D& otherPoint) const {
-    return signedDistanceLocal(transform.toLocal(otherPoint));
+    double sd = signedDistanceLocal(transform.toLocal(otherPoint));
+    return (isNormalFlipped) ? -sd : sd;
 }
 
 double ImplicitSurface3::closestDistanceLocal(

--- a/src/jet/surface_to_implicit2.cpp
+++ b/src/jet/surface_to_implicit2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -18,6 +18,8 @@ SurfaceToImplicit2::SurfaceToImplicit2(const SurfaceToImplicit2& other)
     : ImplicitSurface2(other), _surface(other._surface) {}
 
 bool SurfaceToImplicit2::isBounded() const { return _surface->isBounded(); }
+
+void SurfaceToImplicit2::updateQueryEngine() { _surface->updateQueryEngine(); }
 
 bool SurfaceToImplicit2::isValidGeometry() const {
     return _surface->isValidGeometry();
@@ -62,13 +64,8 @@ bool SurfaceToImplicit2::isInsideLocal(const Vector2D& otherPoint) const {
 double SurfaceToImplicit2::signedDistanceLocal(
     const Vector2D& otherPoint) const {
     Vector2D x = _surface->closestPoint(otherPoint);
-    Vector2D n = _surface->closestNormal(otherPoint);
-    n = (isNormalFlipped) ? -n : n;
-    if (n.dot(otherPoint - x) < 0.0) {
-        return -x.distanceTo(otherPoint);
-    } else {
-        return x.distanceTo(otherPoint);
-    }
+    bool inside = _surface->isInside(otherPoint);
+    return (inside) ? -x.distanceTo(otherPoint) : x.distanceTo(otherPoint);
 }
 
 SurfaceToImplicit2::Builder& SurfaceToImplicit2::Builder::withSurface(

--- a/src/jet/surface_to_implicit3.cpp
+++ b/src/jet/surface_to_implicit3.cpp
@@ -13,12 +13,20 @@ using namespace jet;
 SurfaceToImplicit3::SurfaceToImplicit3(const Surface3Ptr& surface,
                                        const Transform3& transform,
                                        bool isNormalFlipped)
-    : ImplicitSurface3(transform, isNormalFlipped), _surface(surface) {}
+    : ImplicitSurface3(transform, isNormalFlipped), _surface(surface) {
+    if (std::dynamic_pointer_cast<TriangleMesh3>(surface) != nullptr) {
+        JET_WARN << "Using TriangleMesh3 with SurfaceToImplicit3 is accurate "
+                    "but slow. ImplicitTriangleMesh3 can provide faster but "
+                    "approximated results.";
+    }
+}
 
 SurfaceToImplicit3::SurfaceToImplicit3(const SurfaceToImplicit3& other)
     : ImplicitSurface3(other), _surface(other._surface) {}
 
 bool SurfaceToImplicit3::isBounded() const { return _surface->isBounded(); }
+
+void SurfaceToImplicit3::updateQueryEngine() { _surface->updateQueryEngine(); }
 
 bool SurfaceToImplicit3::isValidGeometry() const {
     return _surface->isValidGeometry();
@@ -59,13 +67,8 @@ BoundingBox3D SurfaceToImplicit3::boundingBoxLocal() const {
 double SurfaceToImplicit3::signedDistanceLocal(
     const Vector3D& otherPoint) const {
     Vector3D x = _surface->closestPoint(otherPoint);
-    Vector3D n = _surface->closestNormal(otherPoint);
-    n = (isNormalFlipped) ? -n : n;
-    if (n.dot(otherPoint - x) < 0.0) {
-        return -x.distanceTo(otherPoint);
-    } else {
-        return x.distanceTo(otherPoint);
-    }
+    bool inside = _surface->isInside(otherPoint);
+    return (inside) ? -x.distanceTo(otherPoint) : x.distanceTo(otherPoint);
 }
 
 bool SurfaceToImplicit3::isInsideLocal(const Vector3D& otherPoint) const {

--- a/src/jet/surface_to_implicit3.cpp
+++ b/src/jet/surface_to_implicit3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -13,12 +13,7 @@ using namespace jet;
 SurfaceToImplicit3::SurfaceToImplicit3(const Surface3Ptr& surface,
                                        const Transform3& transform,
                                        bool isNormalFlipped)
-    : ImplicitSurface3(transform, isNormalFlipped), _surface(surface) {
-    if (std::dynamic_pointer_cast<TriangleMesh3>(surface) != nullptr) {
-        JET_WARN << "Using TriangleMesh3 with SurfaceToImplicit3 can cause "
-                 << "undefined behavior. Use ImplicitTriangleMesh3 instead.";
-    }
-}
+    : ImplicitSurface3(transform, isNormalFlipped), _surface(surface) {}
 
 SurfaceToImplicit3::SurfaceToImplicit3(const SurfaceToImplicit3& other)
     : ImplicitSurface3(other), _surface(other._surface) {}

--- a/src/jet/triangle_mesh_to_sdf.cpp
+++ b/src/jet/triangle_mesh_to_sdf.cpp
@@ -1,36 +1,15 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
-//
-// This code is ported from Christopher Batty's SDFGen software.
-// (https://github.com/christopherbatty/SDFGen)
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2015, Christopher Batty
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
 
 #include <pch.h>
-#include <jet/array_utils.h>
+
 #include <jet/array3.h>
+#include <jet/array_utils.h>
 #include <jet/triangle_mesh_to_sdf.h>
+
 #include <algorithm>
 #include <vector>
 
@@ -38,301 +17,21 @@ using namespace jet;
 
 namespace jet {
 
-static void checkNeighbor(
-    const TriangleMesh3& mesh,
-    const Vector3D& gx,
-    ssize_t i0,
-    ssize_t j0,
-    ssize_t k0,
-    ssize_t i1,
-    ssize_t j1,
-    ssize_t k1,
-    ScalarGrid3* sdf,
-    Array3<size_t>* closestTri) {
-    if ((*closestTri)(i1, j1, k1) != kMaxSize) {
-        size_t t = (*closestTri)(i1, j1, k1);
-        Triangle3 tri = mesh.triangle(t);
-
-        double d = tri.closestDistance(gx);
-
-        if (d < (*sdf)(i0, j0, k0)) {
-            (*sdf)(i0, j0, k0) = d;
-            (*closestTri)(i0, j0, k0) = (*closestTri)(i1, j1, k1);
-        }
-    }
-}
-
-static void sweep(
-    const TriangleMesh3& mesh,
-    int di,
-    int dj,
-    int dk,
-    ScalarGrid3* sdf,
-    Array3<size_t>* closestTri) {
-    Size3 size = sdf->dataSize();
-    Vector3D h = sdf->gridSpacing();
-    Vector3D origin = sdf->dataOrigin();
-
-    ssize_t ni = static_cast<ssize_t>(size.x);
-    ssize_t nj = static_cast<ssize_t>(size.y);
-    ssize_t nk = static_cast<ssize_t>(size.z);
-
-    ssize_t i0, i1;
-    if (di > 0) {
-        i0 = 1;
-        i1 = ni;
-    } else {
-        i0 = ni - 2;
-        i1 = -1;
-    }
-
-    ssize_t j0, j1;
-    if (dj > 0) {
-        j0 = 1;
-        j1 = nj;
-    } else {
-        j0 = nj - 2;
-        j1 = -1;
-    }
-
-    ssize_t k0, k1;
-    if (dk > 0) {
-        k0 = 1;
-        k1 = nk;
-    } else {
-        k0 = nk - 2;
-        k1 = -1;
-    }
-
-    for (ssize_t k = k0; k != k1; k += dk) {
-        for (ssize_t j = j0; j != j1; j += dj) {
-            for (ssize_t i = i0; i != i1; i += di) {
-                Vector3D gx({ i, j, k });
-                gx *= h;
-                gx += origin;
-
-                checkNeighbor(
-                    mesh, gx, i, j, k, i - di, j, k, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i, j - dj, k, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i - di, j - dj, k, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i, j, k - dk, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i - di, j, k - dk, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i, j - dj, k - dk, sdf, closestTri);
-                checkNeighbor(
-                    mesh, gx, i, j, k, i - di, j - dj, k - dk, sdf, closestTri);
-            }
-        }
-    }
-}
-
-// calculate twice signed area of triangle (0,0)-(x1,y1)-(x2,y2)
-// return an SOS-determined sign (-1, +1, or 0 only if it's a truly degenerate
-// triangle)
-static int orientation(
-    double x1,
-    double y1,
-    double x2,
-    double y2,
-    double* twiceSignedArea) {
-    (*twiceSignedArea) = y1 * x2 - x1 * y2;
-
-    if ((*twiceSignedArea) > 0) {
-        return 1;
-    } else if ((*twiceSignedArea) < 0) {
-        return -1;
-    } else if (y2 > y1) {
-        return 1;
-    } else if (y2 < y1) {
-        return -1;
-    } else if (x1 > x2) {
-        return 1;
-    } else if (x1 < x2) {
-        return -1;
-    } else {
-        // only true when x1==x2 and y1==y2
-        return 0;
-    }
-}
-
-// robust test of (x0,y0) in the triangle (x1,y1)-(x2,y2)-(x3,y3)
-// if true is returned, the barycentric coordinates are set in a,b,c.
-static bool pointInTriangle2D(
-    double x0, double y0,
-    double x1, double y1, double x2, double y2, double x3, double y3,
-    double* a, double* b, double* c) {
-    x1 -= x0;
-    x2 -= x0;
-    x3 -= x0;
-    y1 -= y0;
-    y2 -= y0;
-    y3 -= y0;
-
-    int signa = orientation(x2, y2, x3, y3, a);
-    if (signa == 0) {
-        return false;
-    }
-
-    int signb = orientation(x3, y3, x1, y1, b);
-    if (signb != signa) {
-        return false;
-    }
-
-    int signc = orientation(x1, y1, x2, y2, c);
-    if (signc != signa) {
-        return false;
-    }
-
-    double sum = (*a) + (*b) + (*c);
-
-    // if the SOS signs match and are nonkero, there's no way all of a, b, and c
-    // are zero.
-    JET_ASSERT(sum != 0);
-
-    *a /= sum;
-    *b /= sum;
-    *c /= sum;
-    return true;
-}
-
-void triangleMeshToSdf(
-    const TriangleMesh3& mesh,
-    ScalarGrid3* sdf,
-    const unsigned int exactBand) {
+void triangleMeshToSdf(const TriangleMesh3& mesh, ScalarGrid3* sdf,
+                       const unsigned int) {
     Size3 size = sdf->dataSize();
     if (size.x * size.y * size.z == 0) {
         return;
     }
 
-    // Upper bound on distance
-    sdf->fill(sdf->boundingBox().diagonalLength());
-    Vector3D h = sdf->gridSpacing();
-    Vector3D origin = sdf->dataOrigin();
-
-    Array3<size_t> closestTri(size, kMaxSize);
-
-    // Intersection_count(i,j,k) is # of tri intersections in (i-1,i]x{j}x{k}
-    Array3<unsigned int> intersectionCount(size, 0);
-
-    // We begin by initializing distances near the mesh, and figuring out
-    // intersection counts
-
-    auto gridPos = sdf->dataPosition();
-
-    size_t nTri = mesh.numberOfTriangles();
-    ssize_t bandwidth = static_cast<ssize_t>(exactBand);
-    ssize_t maxSizeX = static_cast<ssize_t>(size.x);
-    ssize_t maxSizeY = static_cast<ssize_t>(size.y);
-    ssize_t maxSizeZ = static_cast<ssize_t>(size.z);
-    for (size_t t = 0; t < nTri; ++t) {
-        Point3UI indices = mesh.pointIndex(t);
-
-        Triangle3 tri = mesh.triangle(t);
-
-        Vector3D pt1 = mesh.point(indices.x);
-        Vector3D pt2 = mesh.point(indices.y);
-        Vector3D pt3 = mesh.point(indices.z);
-
-        // Normalize coordinates
-        Vector3D f1 = (pt1 - origin) / h;
-        Vector3D f2 = (pt2 - origin) / h;
-        Vector3D f3 = (pt3 - origin) / h;
-
-        // Do distances nearby
-        ssize_t i0 = static_cast<ssize_t>(min3<double>(f1.x, f2.x, f3.x));
-        i0 = clamp(i0 - bandwidth, kZeroSSize, maxSizeX - 1);
-        ssize_t i1 = static_cast<ssize_t>(max3<double>(f1.x, f2.x, f3.x));
-        i1 = clamp(i1 + bandwidth + 1, kZeroSSize, maxSizeX - 1);
-
-        ssize_t j0 = static_cast<ssize_t>(min3<double>(f1.y, f2.y, f3.y));
-        j0 = clamp(j0 - bandwidth, kZeroSSize, maxSizeY - 1);
-        ssize_t j1 = static_cast<ssize_t>(max3<double>(f1.y, f2.y, f3.y));
-        j1 = clamp(j1 + bandwidth + 1, kZeroSSize, maxSizeY - 1);
-
-        ssize_t k0 = static_cast<ssize_t>(min3<double>(f1.z, f2.z, f3.z));
-        k0 = clamp(k0 - bandwidth, kZeroSSize, maxSizeZ - 1);
-        ssize_t k1 = static_cast<ssize_t>(max3<double>(f1.z, f2.z, f3.z));
-        k1 = clamp(k1 + bandwidth + 1, kZeroSSize, maxSizeZ - 1);
-
-        for (ssize_t k = k0; k <= k1; ++k) {
-            for (ssize_t j = j0; j <= j1; ++j) {
-                for (ssize_t i = i0; i <= i1; ++i) {
-                    Vector3D gx = gridPos(i, j, k);
-                    double d = tri.closestDistance(gx);
-                    if (d < (*sdf)(i, j, k)) {
-                        (*sdf)(i, j, k) = d;
-                        closestTri(i, j, k) = t;
-                    }
-                }
-            }
-        }
-
-        // Do intersection counts
-        j0 = static_cast<ssize_t>(std::ceil(min3<double>(f1.y, f2.y, f3.y)));
-        j0 = clamp(j0 - bandwidth, kZeroSSize, maxSizeY - 1);
-        j1 = static_cast<ssize_t>(std::floor(max3<double>(f1.y, f2.y, f3.y)));
-        j1 = clamp(j1 + bandwidth + 1, kZeroSSize, maxSizeY - 1);
-        k0 = static_cast<ssize_t>(std::ceil(min3<double>(f1.z, f2.z, f3.z)));
-        k0 = clamp(k0 - bandwidth, kZeroSSize, maxSizeZ - 1);
-        k1 = static_cast<ssize_t>(std::floor(max3<double>(f1.z, f2.z, f3.z)));
-        k1 = clamp(k1 + bandwidth + 1, kZeroSSize, maxSizeZ - 1);
-
-        for (ssize_t k = k0; k <= k1; ++k) {
-            for (ssize_t j = j0; j <= j1; ++j) {
-                double a, b, c;
-                double jD = static_cast<double>(j);
-                double kD = static_cast<double>(k);
-                if (pointInTriangle2D(
-                    jD, kD, f1.y, f1.z, f2.y, f2.z, f3.y, f3.z, &a, &b, &c)) {
-                    // intersection i coordinate
-                    double fi = a * f1.x + b * f2.x + c * f3.x;
-
-                    // intersection is in (iInterval - 1, iInterval]
-                    int iInterval = static_cast<int>(std::ceil(fi));
-                    if (iInterval < 0) {
-                        // we enlarge the first interval to include everything
-                        // to the -x direction
-                        ++intersectionCount(0, j, k);
-                    } else if (iInterval < static_cast<int>(size.x)) {
-                        ++intersectionCount(iInterval, j, k);
-                    }
-                    // we ignore intersections that are beyond the +x side of
-                    // the grid
-                }
-            }
-        }
-    }
-
-    // and now we fill in the rest of the distances with fast sweeping
-    for (unsigned int pass = 0; pass < 2; ++pass) {
-        sweep(mesh, +1, +1, +1, sdf, &closestTri);
-        sweep(mesh, -1, -1, -1, sdf, &closestTri);
-        sweep(mesh, +1, +1, -1, sdf, &closestTri);
-        sweep(mesh, -1, -1, +1, sdf, &closestTri);
-        sweep(mesh, +1, -1, +1, sdf, &closestTri);
-        sweep(mesh, -1, +1, -1, sdf, &closestTri);
-        sweep(mesh, +1, -1, -1, sdf, &closestTri);
-        sweep(mesh, -1, +1, +1, sdf, &closestTri);
-    }
-
-    // then figure out signs (inside/outside) from intersection counts
-    for (size_t k = 0; k < size.z; ++k) {
-        for (size_t j = 0; j < size.y; ++j) {
-            unsigned int totalCount = 0U;
-            for (size_t i = 0; i < size.x; ++i) {
-                totalCount += intersectionCount(i, j, k);
-                // if parity of intersections so far is odd,
-                if (totalCount % 2 == 1) {
-                    // we are inside the mesh
-                    (*sdf)(i, j, k) = -(*sdf)(i, j, k);
-                }
-            }
-        }
-    }
+    const auto pos = sdf->dataPosition();
+    mesh.updateQueryEngine();
+    sdf->parallelForEachDataPointIndex([&](size_t i, size_t j, size_t k) {
+        const Vector3D p = pos(i, j, k);
+        const double d = mesh.closestDistance(p);
+        const double sd = mesh.isInside(p) ? -d : d;
+        (*sdf)(i, j, k) = sd;
+    });
 }
 
 }  // namespace jet

--- a/src/jet/volume_particle_emitter2.cpp
+++ b/src/jet/volume_particle_emitter2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -107,6 +107,7 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
+        size_t numNewParticles = 0;
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector2D& point) {
             double newAngleInRadian = (random() - 0.5) * kTwoPiD;
             Matrix2x2D rotationMatrix =
@@ -114,13 +115,14 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
             Vector2D randomDir = rotationMatrix * Vector2D();
             Vector2D offset = maxJitterDist * randomDir;
             Vector2D candidate = point + offset;
-            if (_implicitSurface->signedDistance(candidate) <= 0.0 &&
+            if (_implicitSurface->isInside(candidate) &&
                 (!_allowOverlapping &&
                  !neighborSearcher.hasNearbyPoint(candidate, _spacing))) {
                 if (_numberOfEmittedParticles < _maxNumberOfParticles) {
                     newPositions->append(candidate);
                     neighborSearcher.add(candidate);
                     ++_numberOfEmittedParticles;
+                    ++numNewParticles;
                 } else {
                     return false;
                 }
@@ -128,6 +130,9 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
 
             return true;
         });
+
+        JET_INFO << "Number of newly generated particles: " << numNewParticles;
+        JET_INFO << "Number of total generated particles: " << _numberOfEmittedParticles;
     }
 
     newVelocities->resize(newPositions->size());

--- a/src/jet/volume_particle_emitter3.cpp
+++ b/src/jet/volume_particle_emitter3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -103,17 +103,19 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
+        size_t numNewParticles = 0;
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector3D& point) {
             Vector3D randomDir = uniformSampleSphere(random(), random());
             Vector3D offset = maxJitterDist * randomDir;
             Vector3D candidate = point + offset;
-            if (_implicitSurface->signedDistance(candidate) <= 0.0 &&
+            if (_implicitSurface->isInside(candidate) &&
                 (!_allowOverlapping &&
                  !neighborSearcher.hasNearbyPoint(candidate, _spacing))) {
                 if (_numberOfEmittedParticles < _maxNumberOfParticles) {
                     newPositions->append(candidate);
                     neighborSearcher.add(candidate);
                     ++_numberOfEmittedParticles;
+                    ++numNewParticles;
                 } else {
                     return false;
                 }
@@ -121,6 +123,9 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
 
             return true;
         });
+
+        JET_INFO << "Number of newly generated particles: " << numNewParticles;
+        JET_INFO << "Number of total generated particles: " << _numberOfEmittedParticles;
     }
 
     newVelocities->resize(newPositions->size());

--- a/src/tests/manual_tests/CMakeLists.txt
+++ b/src/tests/manual_tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Doyub Kim
+# Copyright (c) 2019 Doyub Kim
 #
 # I am making my contributions/submissions to this project solely in my personal
 # capacity and am not conveying any rights to any intellectual property of any
@@ -10,7 +10,10 @@
 set(target manual_tests)
 
 # Includes
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${EXTERNAL_DIR}/googletest/googlemock/include
+    ${EXTERNAL_DIR}/googletest/googletest/include)
 
 # Sources
 file(GLOB sources

--- a/src/tests/time_perf_tests/triangle_mesh3_tests.cpp
+++ b/src/tests/time_perf_tests/triangle_mesh3_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -37,3 +37,11 @@ BENCHMARK_DEFINE_F(TriangleMesh3, ClosestPoint)(benchmark::State& state) {
 }
 
 BENCHMARK_REGISTER_F(TriangleMesh3, ClosestPoint);
+
+BENCHMARK_DEFINE_F(TriangleMesh3, IsInside)(benchmark::State& state) {
+    while (state.KeepRunning()) {
+        benchmark::DoNotOptimize(triMesh.isInside(makeVec()));
+    }
+}
+
+BENCHMARK_REGISTER_F(TriangleMesh3, IsInside);

--- a/src/tests/time_perf_tests/triangle_mesh_to_sdf_tests.cpp
+++ b/src/tests/time_perf_tests/triangle_mesh_to_sdf_tests.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2019 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/triangle_mesh_to_sdf.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+
+using jet::Vector3D;
+
+class TriangleMeshToSdf : public ::benchmark::Fixture {
+ protected:
+    std::mt19937 rng{0};
+    std::uniform_real_distribution<> dist{0.0, 1.0};
+    jet::TriangleMesh3 triMesh;
+    jet::VertexCenteredScalarGrid3 grid;
+
+    void SetUp(const ::benchmark::State&) {
+        std::ifstream file(RESOURCES_DIR "/bunny.obj");
+
+        if (file) {
+            triMesh.readObj(&file);
+            file.close();
+        }
+
+        jet::BoundingBox3D box = triMesh.boundingBox();
+        Vector3D scale(box.width(), box.height(), box.depth());
+        box.lowerCorner -= 0.2 * scale;
+        box.upperCorner += 0.2 * scale;
+
+        grid.resize(100, 100, 100, box.width() / 100,
+             box.height() / 100, box.depth() / 100,
+             box.lowerCorner.x, box.lowerCorner.y,
+             box.lowerCorner.z);
+    }
+};
+
+BENCHMARK_DEFINE_F(TriangleMeshToSdf, Call)(benchmark::State& state) {
+    while (state.KeepRunning()) {
+        triangleMeshToSdf(triMesh, &grid);
+    }
+}
+
+BENCHMARK_REGISTER_F(TriangleMeshToSdf, Call)->Unit(benchmark::kMillisecond);

--- a/src/tests/unit_tests/CMakeLists.txt
+++ b/src/tests/unit_tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Doyub Kim
+# Copyright (c) 2019 Doyub Kim
 #
 # I am making my contributions/submissions to this project solely in my personal
 # capacity and am not conveying any rights to any intellectual property of any
@@ -10,7 +10,10 @@
 set(target unit_tests)
 
 # Includes
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${EXTERNAL_DIR}/googletest/googlemock/include
+    ${EXTERNAL_DIR}/googletest/googletest/include)
 
 # Sources
 file(GLOB sources
@@ -50,4 +53,5 @@ target_link_libraries(${target}
     PRIVATE
     ${DEFAULT_LINKER_OPTIONS}
     jet
+    gmock
     gtest)

--- a/src/tests/unit_tests/bvh2_tests.cpp
+++ b/src/tests/unit_tests/bvh2_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -13,6 +13,40 @@ using namespace jet;
 TEST(Bvh2, Constructors) {
     Bvh2<Vector2D> bvh;
     EXPECT_EQ(bvh.begin(), bvh.end());
+}
+
+TEST(Bvh2, BasicGetters) {
+    Bvh2<Vector2D> bvh;
+
+    std::vector<Vector2D> points{Vector2D(0, 0), Vector2D(1, 1)};
+    std::vector<BoundingBox2D> bounds(points.size());
+    size_t i = 0;
+    BoundingBox2D rootBounds;
+    std::generate(bounds.begin(), bounds.end(), [&]() {
+        auto c = points[i++];
+        BoundingBox2D box(c, c);
+        box.expand(0.1);
+        rootBounds.merge(box);
+        return box;
+    });
+
+    bvh.build(points, bounds);
+
+    EXPECT_EQ(2u, bvh.numberOfItems());
+    EXPECT_VECTOR2_EQ(points[0], bvh.item(0));
+    EXPECT_VECTOR2_EQ(points[1], bvh.item(1));
+    EXPECT_EQ(3u, bvh.numberOfNodes());
+    EXPECT_EQ(1u, bvh.children(0).first);
+    EXPECT_EQ(2u, bvh.children(0).second);
+    EXPECT_FALSE(bvh.isLeaf(0));
+    EXPECT_TRUE(bvh.isLeaf(1));
+    EXPECT_TRUE(bvh.isLeaf(2));
+    EXPECT_BOUNDING_BOX2_EQ(rootBounds, bvh.nodeBound(0));
+    EXPECT_BOUNDING_BOX2_EQ(bounds[0], bvh.nodeBound(1));
+    EXPECT_BOUNDING_BOX2_EQ(bounds[1], bvh.nodeBound(2));
+    EXPECT_EQ(bvh.end(), bvh.itemOfNode(0));
+    EXPECT_EQ(bvh.begin(), bvh.itemOfNode(1));
+    EXPECT_EQ(bvh.begin() + 1, bvh.itemOfNode(2));
 }
 
 TEST(Bvh2, Nearest) {

--- a/src/tests/unit_tests/bvh3_tests.cpp
+++ b/src/tests/unit_tests/bvh3_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -13,6 +13,40 @@ using namespace jet;
 TEST(Bvh3, Constructors) {
     Bvh3<Vector3D> bvh;
     EXPECT_EQ(bvh.begin(), bvh.end());
+}
+
+TEST(Bvh3, BasicGetters) {
+    Bvh3<Vector3D> bvh;
+
+    std::vector<Vector3D> points{Vector3D(0, 0, 0), Vector3D(1, 1, 1)};
+    std::vector<BoundingBox3D> bounds(points.size());
+    size_t i = 0;
+    BoundingBox3D rootBounds;
+    std::generate(bounds.begin(), bounds.end(), [&]() {
+        auto c = points[i++];
+        BoundingBox3D box(c, c);
+        box.expand(0.1);
+        rootBounds.merge(box);
+        return box;
+    });
+
+    bvh.build(points, bounds);
+
+    EXPECT_EQ(2u, bvh.numberOfItems());
+    EXPECT_VECTOR3_EQ(points[0], bvh.item(0));
+    EXPECT_VECTOR3_EQ(points[1], bvh.item(1));
+    EXPECT_EQ(3u, bvh.numberOfNodes());
+    EXPECT_EQ(1u, bvh.children(0).first);
+    EXPECT_EQ(2u, bvh.children(0).second);
+    EXPECT_FALSE(bvh.isLeaf(0));
+    EXPECT_TRUE(bvh.isLeaf(1));
+    EXPECT_TRUE(bvh.isLeaf(2));
+    EXPECT_BOUNDING_BOX3_EQ(rootBounds, bvh.nodeBound(0));
+    EXPECT_BOUNDING_BOX3_EQ(bounds[0], bvh.nodeBound(1));
+    EXPECT_BOUNDING_BOX3_EQ(bounds[1], bvh.nodeBound(2));
+    EXPECT_EQ(bvh.end(), bvh.itemOfNode(0));
+    EXPECT_EQ(bvh.begin(), bvh.itemOfNode(1));
+    EXPECT_EQ(bvh.begin() + 1, bvh.itemOfNode(2));
 }
 
 TEST(Bvh3, Nearest) {

--- a/src/tests/unit_tests/main.cpp
+++ b/src/tests/unit_tests/main.cpp
@@ -5,12 +5,16 @@
 // property of any third parties.
 
 #include <jet/jet.h>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include <fstream>
 
 using namespace jet;
 
 int main(int argc, char** argv) {
+    ::testing::InitGoogleMock(&argc, argv);
     ::testing::InitGoogleTest(&argc, argv);
 
     std::ofstream logFile("unit_tests.log");

--- a/src/tests/unit_tests/surface_to_implicit2_tests.cpp
+++ b/src/tests/unit_tests/surface_to_implicit2_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -9,9 +9,30 @@
 #include <jet/surface_set2.h>
 #include <jet/surface_to_implicit2.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace jet;
+
+namespace {
+
+class MockSurface2 final : public Surface2 {
+ public:
+    MockSurface2() = default;
+
+    ~MockSurface2() = default;
+
+    MOCK_METHOD0(updateQueryEngine, void());
+
+ protected:
+    MOCK_CONST_METHOD1(closestPointLocal, Vector2D(const Vector2D&));
+    MOCK_CONST_METHOD0(boundingBoxLocal, BoundingBox2D());
+    MOCK_CONST_METHOD1(closestIntersectionLocal,
+                       SurfaceRayIntersection2(const Ray2D&));
+    MOCK_CONST_METHOD1(closestNormalLocal, Vector2D(const Vector2D&));
+};
+
+}  // namespace
 
 TEST(SurfaceToImplicit2, Constructor) {
     auto box = std::make_shared<Box2>(BoundingBox2D({0, 0}, {1, 2}));
@@ -23,6 +44,15 @@ TEST(SurfaceToImplicit2, Constructor) {
     SurfaceToImplicit2 s2i2(s2i);
     EXPECT_EQ(box, s2i2.surface());
     EXPECT_TRUE(s2i2.isNormalFlipped);
+}
+
+TEST(SurfaceToImplicit2, UpdateQueryEngine) {
+    auto mockSurface2 = std::make_shared<MockSurface2>();
+    SurfaceToImplicit2 s2i(mockSurface2);
+
+    EXPECT_CALL(*mockSurface2, updateQueryEngine()).Times(1);
+
+    s2i.updateQueryEngine();
 }
 
 TEST(SurfaceToImplicit2, ClosestPoint) {

--- a/src/tests/unit_tests/surface_to_implicit3_tests.cpp
+++ b/src/tests/unit_tests/surface_to_implicit3_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -9,9 +9,30 @@
 #include <jet/surface_set3.h>
 #include <jet/surface_to_implicit3.h>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace jet;
+
+namespace {
+
+class MockSurface3 final : public Surface3 {
+ public:
+    MockSurface3() = default;
+
+    ~MockSurface3() = default;
+
+    MOCK_METHOD0(updateQueryEngine, void());
+
+ protected:
+    MOCK_CONST_METHOD1(closestPointLocal, Vector3D(const Vector3D&));
+    MOCK_CONST_METHOD0(boundingBoxLocal, BoundingBox3D());
+    MOCK_CONST_METHOD1(closestIntersectionLocal,
+                       SurfaceRayIntersection3(const Ray3D&));
+    MOCK_CONST_METHOD1(closestNormalLocal, Vector3D(const Vector3D&));
+};
+
+}  // namespace
 
 TEST(SurfaceToImplicit3, Constructor) {
     auto box = std::make_shared<Box3>(BoundingBox3D({0, 0, 0}, {1, 2, 3}));
@@ -23,6 +44,15 @@ TEST(SurfaceToImplicit3, Constructor) {
     SurfaceToImplicit3 s2i2(s2i);
     EXPECT_EQ(box, s2i2.surface());
     EXPECT_TRUE(s2i2.isNormalFlipped);
+}
+
+TEST(SurfaceToImplicit3, UpdateQueryEngine) {
+    auto mockSurface3 = std::make_shared<MockSurface3>();
+    SurfaceToImplicit3 s2i(mockSurface3);
+
+    EXPECT_CALL(*mockSurface3, updateQueryEngine()).Times(1);
+
+    s2i.updateQueryEngine();
 }
 
 TEST(SurfaceToImplicit3, ClosestPoint) {

--- a/src/tests/unit_tests/triangle_mesh3_tests.cpp
+++ b/src/tests/unit_tests/triangle_mesh3_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -176,6 +176,23 @@ TEST(TriangleMesh3, ClosestIntersection) {
         EXPECT_VECTOR3_EQ(expected.point, actual.point);
         EXPECT_VECTOR3_EQ(expected.normal, actual.normal);
         EXPECT_EQ(expected.isIntersecting, actual.isIntersecting);
+    }
+}
+
+TEST(TriangleMesh3, IsInside) {
+    std::string objStr = getCubeTriMesh3x3x3Obj();
+    std::istringstream objStream(objStr);
+
+    TriangleMesh3 mesh;
+    mesh.readObj(&objStream);
+
+    size_t numSamples = getNumberOfSamplePoints3();
+
+    for (size_t i = 0; i < numSamples; ++i) {
+        Vector3D p = getSamplePoints3()[i];
+        auto actual = mesh.isInside(p);
+        auto expected = mesh.boundingBox().contains(p);
+        EXPECT_EQ(expected, actual);
     }
 }
 

--- a/src/tests/unit_tests/volume_particle_emitter3_tests.cpp
+++ b/src/tests/unit_tests/volume_particle_emitter3_tests.cpp
@@ -86,7 +86,7 @@ TEST(VolumeParticleEmitter3, Emit) {
     emitter.setMaxNumberOfParticles(80);
     emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
 
-    EXPECT_EQ(69u, particles->numberOfParticles());
+    EXPECT_EQ(79u, particles->numberOfParticles());
 
     pos = particles->positions();
     for (size_t i = 0; i < particles->numberOfParticles(); ++i) {
@@ -95,7 +95,7 @@ TEST(VolumeParticleEmitter3, Emit) {
 
     ++frame;
     emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
-    EXPECT_LT(69u, particles->numberOfParticles());
+    EXPECT_LT(79u, particles->numberOfParticles());
 }
 
 TEST(VolumeParticleEmitter3, Builder) {


### PR DESCRIPTION
This revision implements winding number calculation for `TriangleMesh3`. This enables robust signed-distance function for `TriangleMesh3` without caching the values to a grid such as `ImplicitTriangleMesh3`. This also enables `triangleMeshToSdf` implementation much simpler based on `TriangleMesh3::isInside`. As a result, API can be much simpler (most problematic `ImplicitTriangleMesh3` can be deprecated in the future) with performance benefit (3x faster for `triangleMeshToSdf` on Stanford Bunny).

**References**

* Robust Inside-Outside Segmentation using Generalized Winding Numbers
https://igl.ethz.ch/projects/winding-number/

* Fast Winding Numbers for Soups and Clouds
http://www.dgp.toronto.edu/projects/fast-winding-numbers/