### PR TITLE
Add boundary connectivity flag to marchingCubes

### DIFF
--- a/include/jet/marching_cubes.h
+++ b/include/jet/marching_cubes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -16,25 +16,26 @@ namespace jet {
 //!
 //! \brief      Computes marching cubes and extract triangle mesh from grid.
 //!
-//! This function comptues the marching cube algorithm to extract triangle mesh
+//! This function computes the marching cube algorithm to extract triangle mesh
 //! from the scalar grid field. The triangle mesh will be the iso surface, and
-//! the iso value can be specified. For the boundaries (or the walls), it can be
-//! specified wheather to close or open.
+//! the iso value can be specified. For the boundaries (the walls), it can be
+//! specified whether to close or open with \p bndClose (default: close all).
+//! Another boundary flag \p bndConnectivity can be used for specifying
+//! topological connectivity of the boundary meshes (default: disconnect all).
 //!
-//! \param[in]  grid     The grid.
-//! \param[in]  gridSize The grid size.
-//! \param[in]  origin   The origin.
-//! \param      mesh     The output triangle mesh.
-//! \param[in]  isoValue The iso-surface value.
-//! \param[in]  bndFlag  The boundary direction flag.
+//! \param[in]  grid            The grid.
+//! \param[in]  gridSize        The grid size.
+//! \param[in]  origin          The origin.
+//! \param[out] mesh            The output triangle mesh.
+//! \param[in]  isoValue        The iso-surface value.
+//! \param[in]  bndClose        The boundary open flag.
+//! \param[in]  bndConnectivity The boundary connectivity flag.
 //!
-void marchingCubes(
-    const ConstArrayAccessor3<double>& grid,
-    const Vector3D& gridSize,
-    const Vector3D& origin,
-    TriangleMesh3* mesh,
-    double isoValue = 0,
-    int bndFlag = kDirectionAll);
+void marchingCubes(const ConstArrayAccessor3<double>& grid,
+                   const Vector3D& gridSize, const Vector3D& origin,
+                   TriangleMesh3* mesh, double isoValue = 0,
+                   int bndClose = kDirectionAll,
+                   int bndConnectivity = kDirectionNone);
 
 }  // namespace jet
 

--- a/src/python/marching_cubes.cpp
+++ b/src/python/marching_cubes.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -16,11 +16,13 @@ using namespace jet;
 void addMarchingCubes(pybind11::module& m) {
     m.def("marchingCubes",
           [](ScalarGrid3Ptr grid, py::object gridSize, py::object origin,
-             double isoValue, int bndFlag) -> TriangleMesh3Ptr {
+             double isoValue, int bndClose,
+             int bndConnectivity) -> TriangleMesh3Ptr {
               auto mesh = TriangleMesh3::builder().makeShared();
-              marchingCubes(
-                  grid->constDataAccessor(), objectToVector3D(gridSize),
-                  objectToVector3D(origin), mesh.get(), isoValue, bndFlag);
+              marchingCubes(grid->constDataAccessor(),
+                            objectToVector3D(gridSize),
+                            objectToVector3D(origin), mesh.get(), isoValue,
+                            bndClose, bndConnectivity);
               return mesh;
           },
           R"pbdoc(

--- a/src/tests/manual_tests/marching_cubes_tests.cpp
+++ b/src/tests/manual_tests/marching_cubes_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -33,6 +33,7 @@ JET_BEGIN_TEST_F(MarchingCubes, SingleCube) {
         Vector3D(),
         &triMesh,
         0,
+        kDirectionAll,
         kDirectionAll);
 
     saveTriangleMeshData(triMesh, "single_cube.obj");

--- a/src/tests/python_tests/test_marching_cubes.py
+++ b/src/tests/python_tests/test_marching_cubes.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2019 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+import pyjet
+from pytest import approx
+from pytest_utils import *
+
+
+def test_marching_cubes_connectivity():
+    grid = pyjet.VertexCenteredScalarGrid3((1, 1, 1))
+    grid[(0, 0, 0)] = -0.5
+    grid[(0, 0, 1)] = -0.5
+    grid[(0, 1, 0)] = 0.5
+    grid[(0, 1, 1)] = 0.5
+    grid[(1, 0, 0)] = -0.5
+    grid[(1, 0, 1)] = -0.5
+    grid[(1, 1, 0)] = 0.5
+    grid[(1, 1, 1)] = 0.5
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_NONE)
+    assert mesh.numberOfPoints() == 24
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_BACK)
+    assert mesh.numberOfPoints() == 22
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_FRONT)
+    assert mesh.numberOfPoints() == 22
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_LEFT)
+    assert mesh.numberOfPoints() == 22
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_RIGHT)
+    assert mesh.numberOfPoints() == 22
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_DOWN)
+    assert mesh.numberOfPoints() == 24
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_UP)
+    assert mesh.numberOfPoints() == 24
+
+    mesh = pyjet.marchingCubes(grid, (1, 1, 1), (0, 0, 0), 0.0, pyjet.DIRECTION_ALL, pyjet.DIRECTION_ALL)
+    assert mesh.numberOfPoints() == 8

--- a/src/tests/unit_tests/marching_cubes_tests.cpp
+++ b/src/tests/unit_tests/marching_cubes_tests.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <unit_tests_utils.h>
+
+#include <jet/array3.h>
+#include <jet/marching_cubes.h>
+#include <jet/vertex_centered_scalar_grid3.h>
+
+using namespace jet;
+
+TEST(MarchingCubes, Connectivity) {
+    TriangleMesh3 triMesh;
+
+    Array3<double> grid(2, 2, 2);
+    grid(0, 0, 0) = -0.5;
+    grid(0, 0, 1) = -0.5;
+    grid(0, 1, 0) = 0.5;
+    grid(0, 1, 1) = 0.5;
+    grid(1, 0, 0) = -0.5;
+    grid(1, 0, 1) = -0.5;
+    grid(1, 1, 0) = 0.5;
+    grid(1, 1, 1) = 0.5;
+
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionNone);
+    EXPECT_EQ(24u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionBack);
+    EXPECT_EQ(22u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionFront);
+    EXPECT_EQ(22u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionLeft);
+    EXPECT_EQ(22u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionRight);
+    EXPECT_EQ(22u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionDown);
+    EXPECT_EQ(24u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionUp);
+    EXPECT_EQ(24u, triMesh.numberOfPoints());
+
+    triMesh.clear();
+    marchingCubes(grid, Vector3D(1, 1, 1), Vector3D(), &triMesh, 0,
+                  kDirectionAll, kDirectionAll);
+    EXPECT_EQ(8u, triMesh.numberOfPoints());
+}


### PR DESCRIPTION
This revision improves `marchibeCubes` API by adding boundary connectivity flag as suggested in Issue #241. With this change, it is now possible to attach/detach wall boundaries from the marching cubes-generates mesh. By default, it still detaches the boundary mesh for backward API compatibility.