### PR TITLE
Reusable emitter after emitting once

### DIFF
--- a/include/jet/grid_emitter2.h
+++ b/include/jet/grid_emitter2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -39,6 +39,12 @@ class GridEmitter2 {
     //! time-step.
     void update(double currentTimeInSeconds, double timeIntervalInSeconds);
 
+    //! Returns true if the emitter is enabled.
+    bool isEnabled() const;
+
+    //! Sets true/false to enable/disable the emitter.
+    void setIsEnabled(bool enabled);
+
     //!
     //! \brief      Sets the callback function to be called when
     //!             GridEmitter2::update function is invoked.
@@ -56,6 +62,7 @@ class GridEmitter2 {
                           double timeIntervalInSeconds) = 0;
 
  private:
+    bool _isEnabled = true;
     OnBeginUpdateCallback _onBeginUpdateCallback;
 };
 

--- a/include/jet/grid_emitter3.h
+++ b/include/jet/grid_emitter3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -39,6 +39,12 @@ class GridEmitter3 {
     //! time-step.
     void update(double currentTimeInSeconds, double timeIntervalInSeconds);
 
+    //! Returns true if the emitter is enabled.
+    bool isEnabled() const;
+
+    //! Sets true/false to enable/disable the emitter.
+    void setIsEnabled(bool enabled);
+
     //!
     //! \brief      Sets the callback function to be called when
     //!             GridEmitter3::update function is invoked.
@@ -56,6 +62,7 @@ class GridEmitter3 {
                           double timeIntervalInSeconds) = 0;
 
  private:
+    bool _isEnabled = true;
     OnBeginUpdateCallback _onBeginUpdateCallback;
 };
 

--- a/include/jet/particle_emitter2.h
+++ b/include/jet/particle_emitter2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2010 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -42,6 +42,12 @@ class ParticleEmitter2 {
     //! Sets the target particle system to emit.
     void setTarget(const ParticleSystemData2Ptr& particles);
 
+    //! Returns true if the emitter is enabled.
+    bool isEnabled() const;
+
+    //! Sets true/false to enable/disable the emitter.
+    void setIsEnabled(bool enabled);
+
     //!
     //! \brief      Sets the callback function to be called when
     //!             ParticleEmitter2::update function is invoked.
@@ -64,6 +70,7 @@ class ParticleEmitter2 {
         double timeIntervalInSeconds) = 0;
 
  private:
+    bool _isEnabled = true;
     ParticleSystemData2Ptr _particles;
     OnBeginUpdateCallback _onBeginUpdateCallback;
 };

--- a/include/jet/particle_emitter3.h
+++ b/include/jet/particle_emitter3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -42,6 +42,12 @@ class ParticleEmitter3 {
     //! Sets the target particle system to emit.
     void setTarget(const ParticleSystemData3Ptr& particles);
 
+    //! Returns true if the emitter is enabled.
+    bool isEnabled() const;
+
+    //! Sets true/false to enable/disable the emitter.
+    void setIsEnabled(bool enabled);
+
     //!
     //! \brief      Sets the callback function to be called when
     //!             ParticleEmitter3::update function is invoked.
@@ -64,6 +70,7 @@ class ParticleEmitter3 {
         double timeIntervalInSeconds) = 0;
 
  private:
+    bool _isEnabled = true;
     ParticleSystemData3Ptr _particles;
     OnBeginUpdateCallback _onBeginUpdateCallback;
 };

--- a/include/jet/volume_grid_emitter2.h
+++ b/include/jet/volume_grid_emitter2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -31,7 +31,12 @@ class VolumeGridEmitter2 final : public GridEmitter2 {
     typedef std::function<Vector2D(double, const Vector2D&, const Vector2D&)>
         VectorMapper;
 
-    //! Constructs an emitter with a source and is-one-shot flag.
+    //!
+    //! \brief      Constructs an emitter with a source and is-one-shot flag.
+    //!
+    //! \param[in]  sourceRegion    Emitting region given by the SDF.
+    //! \param[in]  isOneShot       True if emitter gets disabled after one shot.
+    //!
     explicit VolumeGridEmitter2(
         const ImplicitSurface2Ptr& sourceRegion,
         bool isOneShot = true);

--- a/include/jet/volume_grid_emitter3.h
+++ b/include/jet/volume_grid_emitter3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -31,7 +31,12 @@ class VolumeGridEmitter3 final : public GridEmitter3 {
     typedef std::function<Vector3D(double, const Vector3D&, const Vector3D&)>
         VectorMapper;
 
-    //! Constructs an emitter with a source and is-one-shot flag.
+    //!
+    //! \brief      Constructs an emitter with a source and is-one-shot flag.
+    //!
+    //! \param[in]  sourceRegion    Emitting region given by the SDF.
+    //! \param[in]  isOneShot       True if emitter gets disabled after one shot.
+    //!
     explicit VolumeGridEmitter3(
         const ImplicitSurface3Ptr& sourceRegion,
         bool isOneShot = true);

--- a/include/jet/volume_particle_emitter2.h
+++ b/include/jet/volume_particle_emitter2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -28,7 +28,6 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
  public:
     class Builder;
 
-    //!
     //! Constructs an emitter that spawns particles from given implicit surface
     //! which defines the volumetric geometry. Provided bounding box limits
     //! the particle generation region.
@@ -42,8 +41,7 @@ class VolumeParticleEmitter2 final : public ParticleEmitter2 {
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
     //!                                     emitted.
     //! \param[in]  jitter                  The jitter amount between 0 and 1.
-    //! \param[in]  isOneShot               Set true if particles are emitted
-    //!                                     just once.
+    //! \param[in]  isOneShot               True if emitter gets disabled after one shot.
     //! \param[in]  allowOverlapping        True if particles can be overlapped.
     //! \param[in]  seed                    The random seed.
     //!

--- a/include/jet/volume_particle_emitter3.h
+++ b/include/jet/volume_particle_emitter3.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -41,8 +41,7 @@ class VolumeParticleEmitter3 final : public ParticleEmitter3 {
     //! \param[in]  maxNumberOfParticles    The max number of particles to be
     //!                                     emitted.
     //! \param[in]  jitter                  The jitter amount between 0 and 1.
-    //! \param[in]  isOneShot               Set true if particles are emitted
-    //!                                     just once.
+    //! \param[in]  isOneShot               True if emitter gets disabled after one shot.
     //! \param[in]  allowOverlapping        True if particles can be overlapped.
     //! \param[in]  seed                    The random seed.
     //!

--- a/src/jet/grid_emitter2.cpp
+++ b/src/jet/grid_emitter2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -22,6 +22,10 @@ void GridEmitter2::update(double currentTimeInSeconds,
 
     onUpdate(currentTimeInSeconds, timeIntervalInSeconds);
 }
+
+bool GridEmitter2::isEnabled() const { return _isEnabled; }
+
+void GridEmitter2::setIsEnabled(bool enabled) { _isEnabled = enabled; }
 
 void GridEmitter2::setOnBeginUpdateCallback(
     const OnBeginUpdateCallback& callback) {

--- a/src/jet/grid_emitter3.cpp
+++ b/src/jet/grid_emitter3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -22,6 +22,10 @@ void GridEmitter3::update(double currentTimeInSeconds,
 
     onUpdate(currentTimeInSeconds, timeIntervalInSeconds);
 }
+
+bool GridEmitter3::isEnabled() const { return _isEnabled; }
+
+void GridEmitter3::setIsEnabled(bool enabled) { _isEnabled = enabled; }
 
 void GridEmitter3::setOnBeginUpdateCallback(
     const OnBeginUpdateCallback& callback) {

--- a/src/jet/grid_emitter_set2.cpp
+++ b/src/jet/grid_emitter_set2.cpp
@@ -1,47 +1,45 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
 #include <pch.h>
-#include <jet/grid_emitter_set2.h>
+
 #include <vector>
+
+#include <jet/grid_emitter_set2.h>
 
 using namespace jet;
 
-GridEmitterSet2::GridEmitterSet2() {
-}
+GridEmitterSet2::GridEmitterSet2() {}
 
-GridEmitterSet2::GridEmitterSet2(
-    const std::vector<GridEmitter2Ptr>& emitters) {
+GridEmitterSet2::GridEmitterSet2(const std::vector<GridEmitter2Ptr>& emitters) {
     for (const auto& e : emitters) {
         addEmitter(e);
     }
 }
 
-GridEmitterSet2::~GridEmitterSet2() {
-}
+GridEmitterSet2::~GridEmitterSet2() {}
 
 void GridEmitterSet2::addEmitter(const GridEmitter2Ptr& emitter) {
     _emitters.push_back(emitter);
 }
 
-void GridEmitterSet2::onUpdate(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void GridEmitterSet2::onUpdate(double currentTimeInSeconds,
+                               double timeIntervalInSeconds) {
+    if (!isEnabled()) {
+        return;
+    }
+
     for (auto& emitter : _emitters) {
         emitter->update(currentTimeInSeconds, timeIntervalInSeconds);
     }
 }
 
-GridEmitterSet2::Builder GridEmitterSet2::builder() {
-    return Builder();
-}
+GridEmitterSet2::Builder GridEmitterSet2::builder() { return Builder(); }
 
-
-GridEmitterSet2::Builder&
-GridEmitterSet2::Builder::withEmitters(
+GridEmitterSet2::Builder& GridEmitterSet2::Builder::withEmitters(
     const std::vector<GridEmitter2Ptr>& emitters) {
     _emitters = emitters;
     return *this;
@@ -54,7 +52,5 @@ GridEmitterSet2 GridEmitterSet2::Builder::build() const {
 GridEmitterSet2Ptr GridEmitterSet2::Builder::makeShared() const {
     return std::shared_ptr<GridEmitterSet2>(
         new GridEmitterSet2(_emitters),
-        [] (GridEmitterSet2* obj) {
-            delete obj;
-        });
+        [](GridEmitterSet2* obj) { delete obj; });
 }

--- a/src/jet/grid_emitter_set3.cpp
+++ b/src/jet/grid_emitter_set3.cpp
@@ -1,47 +1,45 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
 #include <pch.h>
-#include <jet/grid_emitter_set3.h>
+
 #include <vector>
+
+#include <jet/grid_emitter_set3.h>
 
 using namespace jet;
 
-GridEmitterSet3::GridEmitterSet3() {
-}
+GridEmitterSet3::GridEmitterSet3() {}
 
-GridEmitterSet3::GridEmitterSet3(
-    const std::vector<GridEmitter3Ptr>& emitters) {
+GridEmitterSet3::GridEmitterSet3(const std::vector<GridEmitter3Ptr>& emitters) {
     for (const auto& e : emitters) {
         addEmitter(e);
     }
 }
 
-GridEmitterSet3::~GridEmitterSet3() {
-}
+GridEmitterSet3::~GridEmitterSet3() {}
 
 void GridEmitterSet3::addEmitter(const GridEmitter3Ptr& emitter) {
     _emitters.push_back(emitter);
 }
 
-void GridEmitterSet3::onUpdate(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void GridEmitterSet3::onUpdate(double currentTimeInSeconds,
+                               double timeIntervalInSeconds) {
+    if (!isEnabled()) {
+        return;
+    }
+
     for (auto& emitter : _emitters) {
         emitter->update(currentTimeInSeconds, timeIntervalInSeconds);
     }
 }
 
-GridEmitterSet3::Builder GridEmitterSet3::builder() {
-    return Builder();
-}
+GridEmitterSet3::Builder GridEmitterSet3::builder() { return Builder(); }
 
-
-GridEmitterSet3::Builder&
-GridEmitterSet3::Builder::withEmitters(
+GridEmitterSet3::Builder& GridEmitterSet3::Builder::withEmitters(
     const std::vector<GridEmitter3Ptr>& emitters) {
     _emitters = emitters;
     return *this;
@@ -54,7 +52,5 @@ GridEmitterSet3 GridEmitterSet3::Builder::build() const {
 GridEmitterSet3Ptr GridEmitterSet3::Builder::makeShared() const {
     return std::shared_ptr<GridEmitterSet3>(
         new GridEmitterSet3(_emitters),
-        [] (GridEmitterSet3* obj) {
-            delete obj;
-        });
+        [](GridEmitterSet3* obj) { delete obj; });
 }

--- a/src/jet/particle_emitter2.cpp
+++ b/src/jet/particle_emitter2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -13,11 +13,9 @@
 
 namespace jet {
 
-ParticleEmitter2::ParticleEmitter2() {
-}
+ParticleEmitter2::ParticleEmitter2() {}
 
-ParticleEmitter2::~ParticleEmitter2() {
-}
+ParticleEmitter2::~ParticleEmitter2() {}
 
 const ParticleSystemData2Ptr& ParticleEmitter2::target() const {
     return _particles;
@@ -29,12 +27,15 @@ void ParticleEmitter2::setTarget(const ParticleSystemData2Ptr& particles) {
     onSetTarget(particles);
 }
 
-void ParticleEmitter2::update(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+bool ParticleEmitter2::isEnabled() const { return _isEnabled; }
+
+void ParticleEmitter2::setIsEnabled(bool enabled) { _isEnabled = enabled; }
+
+void ParticleEmitter2::update(double currentTimeInSeconds,
+                              double timeIntervalInSeconds) {
     if (_onBeginUpdateCallback) {
-        _onBeginUpdateCallback(
-            this, currentTimeInSeconds, timeIntervalInSeconds);
+        _onBeginUpdateCallback(this, currentTimeInSeconds,
+                               timeIntervalInSeconds);
     }
 
     onUpdate(currentTimeInSeconds, timeIntervalInSeconds);

--- a/src/jet/particle_emitter3.cpp
+++ b/src/jet/particle_emitter3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -13,11 +13,9 @@
 
 namespace jet {
 
-ParticleEmitter3::ParticleEmitter3() {
-}
+ParticleEmitter3::ParticleEmitter3() {}
 
-ParticleEmitter3::~ParticleEmitter3() {
-}
+ParticleEmitter3::~ParticleEmitter3() {}
 
 const ParticleSystemData3Ptr& ParticleEmitter3::target() const {
     return _particles;
@@ -29,12 +27,15 @@ void ParticleEmitter3::setTarget(const ParticleSystemData3Ptr& particles) {
     onSetTarget(particles);
 }
 
-void ParticleEmitter3::update(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+bool ParticleEmitter3::isEnabled() const { return _isEnabled; }
+
+void ParticleEmitter3::setIsEnabled(bool enabled) { _isEnabled = enabled; }
+
+void ParticleEmitter3::update(double currentTimeInSeconds,
+                              double timeIntervalInSeconds) {
     if (_onBeginUpdateCallback) {
-        _onBeginUpdateCallback(
-            this, currentTimeInSeconds, timeIntervalInSeconds);
+        _onBeginUpdateCallback(this, currentTimeInSeconds,
+                               timeIntervalInSeconds);
     }
 
     onUpdate(currentTimeInSeconds, timeIntervalInSeconds);

--- a/src/jet/particle_emitter_set2.cpp
+++ b/src/jet/particle_emitter_set2.cpp
@@ -1,25 +1,24 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
 #include <pch.h>
-#include <jet/particle_emitter_set2.h>
+
 #include <vector>
+
+#include <jet/particle_emitter_set2.h>
 
 using namespace jet;
 
-ParticleEmitterSet2::ParticleEmitterSet2() {
-}
+ParticleEmitterSet2::ParticleEmitterSet2() {}
 
 ParticleEmitterSet2::ParticleEmitterSet2(
     const std::vector<ParticleEmitter2Ptr>& emitters)
-: _emitters(emitters) {
-}
+    : _emitters(emitters) {}
 
-ParticleEmitterSet2::~ParticleEmitterSet2() {
-}
+ParticleEmitterSet2::~ParticleEmitterSet2() {}
 
 void ParticleEmitterSet2::addEmitter(const ParticleEmitter2Ptr& emitter) {
     _emitters.push_back(emitter);
@@ -31,9 +30,12 @@ void ParticleEmitterSet2::onSetTarget(const ParticleSystemData2Ptr& particles) {
     }
 }
 
-void ParticleEmitterSet2::onUpdate(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void ParticleEmitterSet2::onUpdate(double currentTimeInSeconds,
+                                   double timeIntervalInSeconds) {
+    if (!isEnabled()) {
+        return;
+    }
+
     for (auto& emitter : _emitters) {
         emitter->update(currentTimeInSeconds, timeIntervalInSeconds);
     }
@@ -43,9 +45,7 @@ ParticleEmitterSet2::Builder ParticleEmitterSet2::builder() {
     return Builder();
 }
 
-
-ParticleEmitterSet2::Builder&
-ParticleEmitterSet2::Builder::withEmitters(
+ParticleEmitterSet2::Builder& ParticleEmitterSet2::Builder::withEmitters(
     const std::vector<ParticleEmitter2Ptr>& emitters) {
     _emitters = emitters;
     return *this;
@@ -58,7 +58,5 @@ ParticleEmitterSet2 ParticleEmitterSet2::Builder::build() const {
 ParticleEmitterSet2Ptr ParticleEmitterSet2::Builder::makeShared() const {
     return std::shared_ptr<ParticleEmitterSet2>(
         new ParticleEmitterSet2(_emitters),
-        [] (ParticleEmitterSet2* obj) {
-            delete obj;
-        });
+        [](ParticleEmitterSet2* obj) { delete obj; });
 }

--- a/src/jet/particle_emitter_set3.cpp
+++ b/src/jet/particle_emitter_set3.cpp
@@ -1,25 +1,24 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
 // property of any third parties.
 
 #include <pch.h>
-#include <jet/particle_emitter_set3.h>
+
 #include <vector>
+
+#include <jet/particle_emitter_set3.h>
 
 using namespace jet;
 
-ParticleEmitterSet3::ParticleEmitterSet3() {
-}
+ParticleEmitterSet3::ParticleEmitterSet3() {}
 
 ParticleEmitterSet3::ParticleEmitterSet3(
     const std::vector<ParticleEmitter3Ptr>& emitters)
-: _emitters(emitters) {
-}
+    : _emitters(emitters) {}
 
-ParticleEmitterSet3::~ParticleEmitterSet3() {
-}
+ParticleEmitterSet3::~ParticleEmitterSet3() {}
 
 void ParticleEmitterSet3::addEmitter(const ParticleEmitter3Ptr& emitter) {
     _emitters.push_back(emitter);
@@ -31,9 +30,12 @@ void ParticleEmitterSet3::onSetTarget(const ParticleSystemData3Ptr& particles) {
     }
 }
 
-void ParticleEmitterSet3::onUpdate(
-    double currentTimeInSeconds,
-    double timeIntervalInSeconds) {
+void ParticleEmitterSet3::onUpdate(double currentTimeInSeconds,
+                                   double timeIntervalInSeconds) {
+    if (!isEnabled()) {
+        return;
+    }
+
     for (auto& emitter : _emitters) {
         emitter->update(currentTimeInSeconds, timeIntervalInSeconds);
     }
@@ -43,9 +45,7 @@ ParticleEmitterSet3::Builder ParticleEmitterSet3::builder() {
     return Builder();
 }
 
-
-ParticleEmitterSet3::Builder&
-ParticleEmitterSet3::Builder::withEmitters(
+ParticleEmitterSet3::Builder& ParticleEmitterSet3::Builder::withEmitters(
     const std::vector<ParticleEmitter3Ptr>& emitters) {
     _emitters = emitters;
     return *this;
@@ -58,7 +58,5 @@ ParticleEmitterSet3 ParticleEmitterSet3::Builder::build() const {
 ParticleEmitterSet3Ptr ParticleEmitterSet3::Builder::makeShared() const {
     return std::shared_ptr<ParticleEmitterSet3>(
         new ParticleEmitterSet3(_emitters),
-        [] (ParticleEmitterSet3* obj) {
-            delete obj;
-        });
+        [](ParticleEmitterSet3* obj) { delete obj; });
 }

--- a/src/jet/volume_grid_emitter2.cpp
+++ b/src/jet/volume_grid_emitter2.cpp
@@ -66,11 +66,11 @@ void VolumeGridEmitter2::onUpdate(double currentTimeInSeconds,
         return;
     }
 
-    if (_hasEmitted && _isOneShot) {
-        return;
-    }
-
     emit();
+
+    if (_isOneShot) {
+        setIsEnabled(false);
+    }
 
     _hasEmitted = true;
 }

--- a/src/jet/volume_grid_emitter2.cpp
+++ b/src/jet/volume_grid_emitter2.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -61,6 +61,10 @@ void VolumeGridEmitter2::onUpdate(double currentTimeInSeconds,
                                   double timeIntervalInSeconds) {
     UNUSED_VARIABLE(currentTimeInSeconds);
     UNUSED_VARIABLE(timeIntervalInSeconds);
+
+    if (!isEnabled()) {
+        return;
+    }
 
     if (_hasEmitted && _isOneShot) {
         return;

--- a/src/jet/volume_grid_emitter3.cpp
+++ b/src/jet/volume_grid_emitter3.cpp
@@ -66,11 +66,11 @@ void VolumeGridEmitter3::onUpdate(double currentTimeInSeconds,
         return;
     }
 
-    if (_hasEmitted && _isOneShot) {
-        return;
-    }
-
     emit();
+
+    if (_isOneShot) {
+        setIsEnabled(false);
+    }
 
     _hasEmitted = true;
 }

--- a/src/jet/volume_grid_emitter3.cpp
+++ b/src/jet/volume_grid_emitter3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -61,6 +61,11 @@ void VolumeGridEmitter3::onUpdate(double currentTimeInSeconds,
                                   double timeIntervalInSeconds) {
     UNUSED_VARIABLE(currentTimeInSeconds);
     UNUSED_VARIABLE(timeIntervalInSeconds);
+
+    if (!isEnabled()) {
+        return;
+    }
+
     if (_hasEmitted && _isOneShot) {
         return;
     }

--- a/src/jet/volume_particle_emitter2.cpp
+++ b/src/jet/volume_particle_emitter2.cpp
@@ -51,16 +51,16 @@ void VolumeParticleEmitter2::onUpdate(double currentTimeInSeconds,
         return;
     }
 
-    if (_numberOfEmittedParticles > 0 && _isOneShot) {
-        return;
-    }
-
     Array1<Vector2D> newPositions;
     Array1<Vector2D> newVelocities;
 
     emit(particles, &newPositions, &newVelocities);
 
     particles->addParticles(newPositions, newVelocities);
+
+    if (_isOneShot) {
+        setIsEnabled(false);
+    }
 }
 
 void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
@@ -82,6 +82,7 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
     // Reserving more space for jittering
     const double j = jitter();
     const double maxJitterDist = 0.5 * j * _spacing;
+    size_t numNewParticles = 0;
 
     if (_allowOverlapping || _isOneShot) {
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector2D& point) {
@@ -95,6 +96,7 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
                 if (_numberOfEmittedParticles < _maxNumberOfParticles) {
                     newPositions->append(candidate);
                     ++_numberOfEmittedParticles;
+                    ++numNewParticles;
                 } else {
                     return false;
                 }
@@ -111,7 +113,6 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
-        size_t numNewParticles = 0;
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector2D& point) {
             double newAngleInRadian = (random() - 0.5) * kTwoPiD;
             Matrix2x2D rotationMatrix =
@@ -134,10 +135,11 @@ void VolumeParticleEmitter2::emit(const ParticleSystemData2Ptr& particles,
 
             return true;
         });
-
-        JET_INFO << "Number of newly generated particles: " << numNewParticles;
-        JET_INFO << "Number of total generated particles: " << _numberOfEmittedParticles;
     }
+
+    JET_INFO << "Number of newly generated particles: " << numNewParticles;
+    JET_INFO << "Number of total generated particles: "
+             << _numberOfEmittedParticles;
 
     newVelocities->resize(newPositions->size());
     newVelocities->parallelForEachIndex([&](size_t i) {

--- a/src/jet/volume_particle_emitter2.cpp
+++ b/src/jet/volume_particle_emitter2.cpp
@@ -47,6 +47,10 @@ void VolumeParticleEmitter2::onUpdate(double currentTimeInSeconds,
         return;
     }
 
+    if (!isEnabled()) {
+        return;
+    }
+
     if (_numberOfEmittedParticles > 0 && _isOneShot) {
         return;
     }

--- a/src/jet/volume_particle_emitter3.cpp
+++ b/src/jet/volume_particle_emitter3.cpp
@@ -46,6 +46,10 @@ void VolumeParticleEmitter3::onUpdate(double currentTimeInSeconds,
         return;
     }
 
+    if (!isEnabled()) {
+        return;
+    }
+
     if (_numberOfEmittedParticles > 0 && _isOneShot) {
         return;
     }

--- a/src/jet/volume_particle_emitter3.cpp
+++ b/src/jet/volume_particle_emitter3.cpp
@@ -50,16 +50,16 @@ void VolumeParticleEmitter3::onUpdate(double currentTimeInSeconds,
         return;
     }
 
-    if (_numberOfEmittedParticles > 0 && _isOneShot) {
-        return;
-    }
-
     Array1<Vector3D> newPositions;
     Array1<Vector3D> newVelocities;
 
     emit(particles, &newPositions, &newVelocities);
 
     particles->addParticles(newPositions, newVelocities);
+
+    if (_isOneShot) {
+        setIsEnabled(false);
+    }
 }
 
 void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
@@ -81,6 +81,8 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
     // Reserving more space for jittering
     const double j = jitter();
     const double maxJitterDist = 0.5 * j * _spacing;
+    size_t numNewParticles = 0;
+
     if (_allowOverlapping || _isOneShot) {
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector3D& point) {
             Vector3D randomDir = uniformSampleSphere(random(), random());
@@ -90,6 +92,7 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
                 if (_numberOfEmittedParticles < _maxNumberOfParticles) {
                     newPositions->append(candidate);
                     ++_numberOfEmittedParticles;
+                    ++numNewParticles;
                 } else {
                     return false;
                 }
@@ -107,7 +110,6 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
             neighborSearcher.build(particles->positions());
         }
 
-        size_t numNewParticles = 0;
         _pointsGen->forEachPoint(region, _spacing, [&](const Vector3D& point) {
             Vector3D randomDir = uniformSampleSphere(random(), random());
             Vector3D offset = maxJitterDist * randomDir;
@@ -127,10 +129,11 @@ void VolumeParticleEmitter3::emit(const ParticleSystemData3Ptr& particles,
 
             return true;
         });
-
-        JET_INFO << "Number of newly generated particles: " << numNewParticles;
-        JET_INFO << "Number of total generated particles: " << _numberOfEmittedParticles;
     }
+
+    JET_INFO << "Number of newly generated particles: " << numNewParticles;
+    JET_INFO << "Number of total generated particles: "
+             << _numberOfEmittedParticles;
 
     newVelocities->resize(newPositions->size());
     newVelocities->parallelForEachIndex([&](size_t i) {

--- a/src/python/grid_emitter.cpp
+++ b/src/python/grid_emitter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -28,6 +28,9 @@ void addGridEmitter2(py::module& m) {
             - timeIntervalInSeconds : Time-step to advance.
             )pbdoc",
              py::arg("currentTimeInSeconds"), py::arg("timeIntervalInSeconds"))
+        .def_property(
+            "isEnabled", &GridEmitter2::isEnabled, &GridEmitter2::setIsEnabled,
+            R"pbdoc(True/false if the emitter is enabled/disabled.)pbdoc")
         .def("setOnBeginUpdateCallback",
              [](GridEmitter2& instance, py::function callback) {
                  instance.setOnBeginUpdateCallback(callback);
@@ -42,7 +45,8 @@ void addGridEmitter2(py::module& m) {
              Parameters
              ----------
              - callback : The callback function.
-             )pbdoc", py::arg("callback"));
+             )pbdoc",
+             py::arg("callback"));
 }
 
 void addGridEmitter3(py::module& m) {
@@ -60,6 +64,9 @@ void addGridEmitter3(py::module& m) {
             - timeIntervalInSeconds : Time-step to advance.
             )pbdoc",
              py::arg("currentTimeInSeconds"), py::arg("timeIntervalInSeconds"))
+        .def_property(
+            "isEnabled", &GridEmitter3::isEnabled, &GridEmitter3::setIsEnabled,
+            R"pbdoc(True/false if the emitter is enabled/disabled.)pbdoc")
         .def("setOnBeginUpdateCallback",
              [](GridEmitter3& instance, py::function callback) {
                  instance.setOnBeginUpdateCallback(callback);
@@ -74,5 +81,6 @@ void addGridEmitter3(py::module& m) {
              Parameters
              ----------
              - callback : The callback function.
-             )pbdoc", py::arg("callback"));
+             )pbdoc",
+             py::arg("callback"));
 }

--- a/src/python/particle_emitter.cpp
+++ b/src/python/particle_emitter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Doyub Kim
+// Copyright (c) 2019 Doyub Kim
 //
 // I am making my contributions/submissions to this project solely in my
 // personal capacity and am not conveying any rights to any intellectual
@@ -27,6 +27,10 @@ void addParticleEmitter2(py::module& m) {
                       &ParticleEmitter2::setTarget, R"pbdoc(
             The target particle system to emit.
             )pbdoc")
+        .def_property(
+            "isEnabled", &ParticleEmitter2::isEnabled,
+            &ParticleEmitter2::setIsEnabled,
+            R"pbdoc(True/false if the emitter is enabled/disabled.)pbdoc")
         .def("setOnBeginUpdateCallback",
              &ParticleEmitter2::setOnBeginUpdateCallback,
              R"pbdoc(
@@ -52,6 +56,10 @@ void addParticleEmitter3(py::module& m) {
                       &ParticleEmitter3::setTarget, R"pbdoc(
             The target particle system to emit.
             )pbdoc")
+        .def_property(
+            "isEnabled", &ParticleEmitter3::isEnabled,
+            &ParticleEmitter3::setIsEnabled,
+            R"pbdoc(True/false if the emitter is enabled/disabled.)pbdoc")
         .def("setOnBeginUpdateCallback",
              &ParticleEmitter3::setOnBeginUpdateCallback,
              R"pbdoc(

--- a/src/python/particle_system_solver.cpp
+++ b/src/python/particle_system_solver.cpp
@@ -89,9 +89,9 @@ void addParticleSystemSolver2(py::module& m) {
 }
 
 void addParticleSystemSolver3(py::module& m) {
-    py::class_<ParticleSystemSolver3, ParticleSystemSolver3Ptr>(
-        m, "ParticleSystemSolver3",
-        R"pbdoc(
+    py::class_<ParticleSystemSolver3, ParticleSystemSolver3Ptr,
+               PhysicsAnimation>(m, "ParticleSystemSolver3",
+                                 R"pbdoc(
         Basic 3-D particle system solver.
 
         This class implements basic particle system solver. It includes gravity,

--- a/src/tests/python_tests/test_volume_grid_emitter.py
+++ b/src/tests/python_tests/test_volume_grid_emitter.py
@@ -6,6 +6,128 @@ capacity and am not conveying any rights to any intellectual property of any
 third parties.
 """
 
+import numpy as np
 import pyjet
 from pytest_utils import *
 
+
+def test_volume_grid_emitter2():
+    # Basic ctor test
+    sphere = pyjet.Sphere2(center=(0.5, 0.5), radius=0.15)
+    emitter = pyjet.VolumeGridEmitter2(sphere, False)
+
+    assert emitter.sourceRegion
+    assert not emitter.isOneShot
+    assert emitter.isEnabled
+
+    # Another basic ctor test
+    emitter2 = pyjet.VolumeGridEmitter2(sourceRegion=sphere, isOneShot=False)
+
+    assert emitter2.sourceRegion
+    assert not emitter2.isOneShot
+    assert emitter2.isEnabled
+
+    # One-shot emitter
+    emitter3 = pyjet.VolumeGridEmitter2(sourceRegion=sphere, isOneShot=True)
+
+    assert emitter3.isOneShot
+
+    frame = pyjet.Frame()
+    solver = pyjet.GridSmokeSolver2(resolution=(32, 32), domainSizeX=1.0)
+    solver.emitter = emitter3
+    emitter3.addStepFunctionTarget(solver.smokeDensity, 0.0, 1.0)
+    emitter3.addStepFunctionTarget(solver.temperature, 0.0, 1.0)
+
+    # Emit some smoke
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    solver.update(frame)
+    frame.advance()
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff > 0.0
+    assert not emitter3.isEnabled
+
+    # Should not emit more smoke
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    emitter3.update(0, 0)
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff < 1e-20
+
+    # Re-enabling the emitter should make it emit one more time
+    emitter3.isEnabled = True
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    solver.update(frame)
+    frame.advance()
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff > 0.0
+    assert not emitter3.isEnabled
+
+    # ...and gets disabled again
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    emitter3.update(0, 0)
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff < 1e-20
+
+
+def test_volume_grid_emitter3():
+    # Basic ctor test
+    sphere = pyjet.Sphere3(center=(0.5, 0.5, 0.5), radius=0.15)
+    emitter = pyjet.VolumeGridEmitter3(sphere, False)
+
+    assert emitter.sourceRegion
+    assert not emitter.isOneShot
+    assert emitter.isEnabled
+
+    # Another basic ctor test
+    emitter2 = pyjet.VolumeGridEmitter3(sourceRegion=sphere, isOneShot=False)
+
+    assert emitter2.sourceRegion
+    assert not emitter2.isOneShot
+    assert emitter2.isEnabled
+
+    # One-shot emitter
+    emitter3 = pyjet.VolumeGridEmitter3(sourceRegion=sphere, isOneShot=True)
+
+    assert emitter3.isOneShot
+
+    frame = pyjet.Frame()
+    solver = pyjet.GridSmokeSolver3(resolution=(32, 32, 32), domainSizeX=1.0)
+    solver.emitter = emitter3
+    emitter3.addStepFunctionTarget(solver.smokeDensity, 0.0, 1.0)
+    emitter3.addStepFunctionTarget(solver.temperature, 0.0, 1.0)
+
+    # Emit some smoke
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    solver.update(frame)
+    frame.advance()
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff > 0.0
+    assert not emitter3.isEnabled
+
+    # Should not emit more smoke
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    emitter3.update(0, 0)
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff < 1e-20
+
+    # Re-enabling the emitter should make it emit one more time
+    emitter3.isEnabled = True
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    solver.update(frame)
+    frame.advance()
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff > 0.0
+    assert not emitter3.isEnabled
+
+    # ...and gets disabled again
+    old_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    emitter3.update(0, 0)
+    new_den = np.array(solver.smokeDensity.dataAccessor(), copy=True)
+    diff = np.linalg.norm(old_den - new_den)
+    assert diff < 1e-20

--- a/src/tests/python_tests/test_volume_grid_emitter.py
+++ b/src/tests/python_tests/test_volume_grid_emitter.py
@@ -1,0 +1,11 @@
+"""
+Copyright (c) 2019 Doyub Kim
+
+I am making my contributions/submissions to this project solely in my personal
+capacity and am not conveying any rights to any intellectual property of any
+third parties.
+"""
+
+import pyjet
+from pytest_utils import *
+

--- a/src/tests/python_tests/test_volume_particle_emitter.py
+++ b/src/tests/python_tests/test_volume_particle_emitter.py
@@ -11,6 +11,7 @@ from pytest_utils import *
 
 
 def test_volume_particle_emitter2():
+    # Basic ctor test
     sphere = pyjet.Sphere2()
     emitter = pyjet.VolumeParticleEmitter2(
         sphere,
@@ -25,7 +26,7 @@ def test_volume_particle_emitter2():
         True,
         42)
 
-    assert emitter.surface != None
+    assert emitter.surface
     assert_bounding_box_similar(
         emitter.maxRegion, pyjet.BoundingBox2D((-1, -2), (4, 2)))
     assert emitter.spacing == 0.1
@@ -34,10 +35,11 @@ def test_volume_particle_emitter2():
     assert emitter.angularVelocity == 5.0
     assert emitter.maxNumberOfParticles == 30
     assert emitter.jitter == 0.01
-    assert emitter.isOneShot == False
-    assert emitter.allowOverlapping == True
-    assert emitter.isEnabled == True
+    assert not emitter.isOneShot
+    assert emitter.allowOverlapping
+    assert emitter.isEnabled
 
+    # Another basic ctor test
     emitter2 = pyjet.VolumeParticleEmitter2(
         implicitSurface=sphere,
         maxRegion=pyjet.BoundingBox2D((-1, -2), (4, 2)),
@@ -45,31 +47,100 @@ def test_volume_particle_emitter2():
         initialVelocity=(-1, 0.5),
         linearVelocity=(3, 4),
         angularVelocity=5.0,
-        maxNumberOfParticles=30,
+        maxNumberOfParticles=3000,
         jitter=0.01,
         isOneShot=False,
         allowOverlapping=True,
         seed=42)
 
-    assert emitter2.surface != None
+    assert emitter2.surface
     assert_bounding_box_similar(
         emitter2.maxRegion, pyjet.BoundingBox2D((-1, -2), (4, 2)))
     assert emitter2.spacing == 0.1
     assert_vector_similar(emitter2.initialVelocity, (-1, 0.5))
     assert_vector_similar(emitter2.linearVelocity, (3, 4))
     assert emitter2.angularVelocity == 5.0
-    assert emitter2.maxNumberOfParticles == 30
+    assert emitter2.maxNumberOfParticles == 3000
     assert emitter2.jitter == 0.01
-    assert emitter2.isOneShot == False
-    assert emitter2.allowOverlapping == True
-    assert emitter2.isEnabled == True
+    assert not emitter2.isOneShot
+    assert emitter2.allowOverlapping
+    assert emitter2.isEnabled
+
+    # Emit some particles
+    frame = pyjet.Frame()
+    solver = pyjet.ParticleSystemSolver2()
+    solver.emitter = emitter2
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > 0
+
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # Disabling emitter should stop emitting particles
+    emitter2.isEnabled = False
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles
+
+    # Re-enabling emitter should resume emission
+    emitter2.isEnabled = True
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # One-shot emitter
+    emitter3 = pyjet.VolumeParticleEmitter2(
+        implicitSurface=sphere,
+        maxRegion=pyjet.BoundingBox2D((-1, -2), (4, 2)),
+        spacing=0.1,
+        initialVelocity=(-1, 0.5),
+        linearVelocity=(3, 4),
+        angularVelocity=5.0,
+        maxNumberOfParticles=3000,
+        jitter=0.01,
+        isOneShot=True,
+        allowOverlapping=True,
+        seed=42)
+
+    # Emit some particles
+    frame = pyjet.Frame()
+    solver = pyjet.ParticleSystemSolver2()
+    solver.emitter = emitter3
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > 0
+    assert not emitter3.isEnabled
+
+    # Should not emit more particles
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles
+
+    # Re-enabling the emitter should make it emit one more time
+    emitter3.isEnabled = True
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # ...and gets disabled again
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles
 
 
 def test_volume_particle_emitter3():
     sphere = pyjet.Sphere3()
     emitter = pyjet.VolumeParticleEmitter3(
         sphere,
-        pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)),
+        pyjet.BoundingBox3D((-1, -2, -3), (4, 2, 9)),
         0.1,
         (-1, 0.5, 2),
         (3, 4, 5),
@@ -80,41 +151,110 @@ def test_volume_particle_emitter3():
         True,
         42)
 
-    assert emitter.surface != None
+    assert emitter.surface
     assert_bounding_box_similar(
-        emitter.maxRegion, pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)))
+        emitter.maxRegion, pyjet.BoundingBox3D((-1, -2, -3), (4, 2, 9)))
     assert emitter.spacing == 0.1
     assert_vector_similar(emitter.initialVelocity, (-1, 0.5, 2))
     assert_vector_similar(emitter.linearVelocity, (3, 4, 5))
     assert_vector_similar(emitter.angularVelocity, (6, 7, 8))
     assert emitter.maxNumberOfParticles == 30
     assert emitter.jitter == 0.01
-    assert emitter.isOneShot == False
-    assert emitter.allowOverlapping == True
-    assert emitter.isEnabled == True
+    assert not emitter.isOneShot
+    assert emitter.allowOverlapping
+    assert emitter.isEnabled
 
     emitter2 = pyjet.VolumeParticleEmitter3(
         implicitSurface=sphere,
-        maxRegion=pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)),
+        maxRegion=pyjet.BoundingBox3D((-1, -2, -3), (4, 2, 9)),
         spacing=0.1,
         initialVelocity=(-1, 0.5, 2),
         linearVelocity=(3, 4, 5),
         angularVelocity=(6, 7, 8),
-        maxNumberOfParticles=30,
+        maxNumberOfParticles=300000,
         jitter=0.01,
         isOneShot=False,
         allowOverlapping=True,
         seed=42)
 
-    assert emitter2.surface != None
+    assert emitter2.surface
     assert_bounding_box_similar(
-        emitter2.maxRegion, pyjet.BoundingBox3D((-1, -2, 3), (4, 2, 9)))
+        emitter2.maxRegion, pyjet.BoundingBox3D((-1, -2, -3), (4, 2, 9)))
     assert emitter2.spacing == 0.1
     assert_vector_similar(emitter2.initialVelocity, (-1, 0.5, 2))
     assert_vector_similar(emitter2.linearVelocity, (3, 4, 5))
     assert_vector_similar(emitter2.angularVelocity, (6, 7, 8))
-    assert emitter2.maxNumberOfParticles == 30
+    assert emitter2.maxNumberOfParticles == 300000
     assert emitter2.jitter == 0.01
-    assert emitter2.isOneShot == False
-    assert emitter2.allowOverlapping == True
-    assert emitter2.isEnabled == True
+    assert not emitter2.isOneShot
+    assert emitter2.allowOverlapping
+    assert emitter2.isEnabled
+
+    # Emit some particles
+    frame = pyjet.Frame()
+    solver = pyjet.ParticleSystemSolver3()
+    solver.emitter = emitter2
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > 0
+
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # Disabling emitter should stop emitting particles
+    emitter2.isEnabled = False
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles
+
+    # Re-enabling emitter should resume emission
+    emitter2.isEnabled = True
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # One-shot emitter
+    emitter3 = pyjet.VolumeParticleEmitter3(
+        implicitSurface=sphere,
+        maxRegion=pyjet.BoundingBox3D((-1, -2, -3), (4, 2, 9)),
+        spacing=0.1,
+        initialVelocity=(-1, 0.5, 2),
+        linearVelocity=(3, 4, 5),
+        angularVelocity=(6, 7, 8),
+        maxNumberOfParticles=300000,
+        jitter=0.01,
+        isOneShot=True,
+        allowOverlapping=True,
+        seed=42)
+
+    # Emit some particles
+    frame = pyjet.Frame()
+    solver = pyjet.ParticleSystemSolver3()
+    solver.emitter = emitter3
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > 0
+    assert not emitter3.isEnabled
+
+    # Should not emit more particles
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles
+
+    # Re-enabling the emitter should make it emit one more time
+    emitter3.isEnabled = True
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles > old_num_particles
+
+    # ...and gets disabled again
+    old_num_particles = solver.particleSystemData.numberOfParticles
+    solver.update(frame)
+    frame.advance()
+    assert solver.particleSystemData.numberOfParticles == old_num_particles

--- a/src/tests/python_tests/test_volume_particle_emitter.py
+++ b/src/tests/python_tests/test_volume_particle_emitter.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2018 Doyub Kim
+Copyright (c) 2019 Doyub Kim
 
 I am making my contributions/submissions to this project solely in my personal
 capacity and am not conveying any rights to any intellectual property of any
@@ -36,6 +36,7 @@ def test_volume_particle_emitter2():
     assert emitter.jitter == 0.01
     assert emitter.isOneShot == False
     assert emitter.allowOverlapping == True
+    assert emitter.isEnabled == True
 
     emitter2 = pyjet.VolumeParticleEmitter2(
         implicitSurface=sphere,
@@ -61,6 +62,7 @@ def test_volume_particle_emitter2():
     assert emitter2.jitter == 0.01
     assert emitter2.isOneShot == False
     assert emitter2.allowOverlapping == True
+    assert emitter2.isEnabled == True
 
 
 def test_volume_particle_emitter3():
@@ -89,6 +91,7 @@ def test_volume_particle_emitter3():
     assert emitter.jitter == 0.01
     assert emitter.isOneShot == False
     assert emitter.allowOverlapping == True
+    assert emitter.isEnabled == True
 
     emitter2 = pyjet.VolumeParticleEmitter3(
         implicitSurface=sphere,
@@ -114,3 +117,4 @@ def test_volume_particle_emitter3():
     assert emitter2.jitter == 0.01
     assert emitter2.isOneShot == False
     assert emitter2.allowOverlapping == True
+    assert emitter2.isEnabled == True

--- a/src/tests/unit_tests/volume_particle_emitter2_tests.cpp
+++ b/src/tests/unit_tests/volume_particle_emitter2_tests.cpp
@@ -42,6 +42,7 @@ TEST(VolumeParticleEmitter2, Constructors) {
     EXPECT_EQ(0.5, emitter.initialVelocity().y);
     EXPECT_EQ(Vector2D(), emitter.linearVelocity());
     EXPECT_EQ(0.0, emitter.angularVelocity());
+    EXPECT_TRUE(emitter.isEnabled());
 }
 
 TEST(VolumeParticleEmitter2, Emit) {
@@ -81,8 +82,15 @@ TEST(VolumeParticleEmitter2, Emit) {
         EXPECT_VECTOR2_NEAR(Vector2D(2.0, 4.5) + w, vel[i], 1e-9);
     }
 
+    emitter.setIsEnabled(false);
     ++frame;
     emitter.setMaxNumberOfParticles(60);
+    emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
+
+    EXPECT_EQ(30u, particles->numberOfParticles());
+    emitter.setIsEnabled(true);
+
+    ++frame;
     emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
 
     EXPECT_EQ(51u, particles->numberOfParticles());

--- a/src/tests/unit_tests/volume_particle_emitter3_tests.cpp
+++ b/src/tests/unit_tests/volume_particle_emitter3_tests.cpp
@@ -43,6 +43,7 @@ TEST(VolumeParticleEmitter3, Constructors) {
     EXPECT_EQ(2.5, emitter.initialVelocity().z);
     EXPECT_EQ(Vector3D(), emitter.linearVelocity());
     EXPECT_EQ(Vector3D(), emitter.angularVelocity());
+    EXPECT_TRUE(emitter.isEnabled());
 }
 
 TEST(VolumeParticleEmitter3, Emit) {
@@ -82,8 +83,15 @@ TEST(VolumeParticleEmitter3, Emit) {
         EXPECT_VECTOR3_NEAR(Vector3D(2.0, 4.5, 7.5) + w, vel[i], 1e-9);
     }
 
+    emitter.setIsEnabled(false);
     ++frame;
     emitter.setMaxNumberOfParticles(80);
+    emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
+
+    EXPECT_EQ(30u, particles->numberOfParticles());
+    emitter.setIsEnabled(true);
+
+    ++frame;
     emitter.update(frame.timeInSeconds(), frame.timeIntervalInSeconds);
 
     EXPECT_EQ(79u, particles->numberOfParticles());


### PR DESCRIPTION
This revision adds `isEnabled` flag for emitters which also allows an emitter with `isOneShot == true` reusable by resetting `isEnabled` to `true`. This fixes Issue #242.