### PR TITLE
Fix 2nd-order derivative for standard SPH kernel

### DIFF
--- a/include/jet/detail/sph_kernels3-inl.h
+++ b/include/jet/detail/sph_kernels3-inl.h
@@ -64,7 +64,7 @@ inline double SphStdKernel3::secondDerivative(double distance) const {
         return 0.0;
     } else {
         double x = distance * distance / h2;
-        return 945.0 / (32.0 * kPiD * h5) * (1 - x) * (3 * x - 1);
+        return 945.0 / (32.0 * kPiD * h5) * (1 - x) * (5 * x - 1);
     }
 }
 

--- a/src/tests/unit_tests/sph_kernels2_tests.cpp
+++ b/src/tests/unit_tests/sph_kernels2_tests.cpp
@@ -36,7 +36,28 @@ TEST(SphStdKernel2, FirstDerivative) {
     double value2 = kernel.firstDerivative(10.0);
     EXPECT_DOUBLE_EQ(0.0, value0);
     EXPECT_DOUBLE_EQ(0.0, value2);
-    EXPECT_LT(value1, value0);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - kernel(5.0 - e)) / (2.0 * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
+}
+
+TEST(SphStdKernel2, SecondDerivative) {
+    SphStdKernel2 kernel(10.0);
+
+    double value0 = kernel.secondDerivative(0.0);
+    double value1 = kernel.secondDerivative(5.0);
+    double value2 = kernel.secondDerivative(10.0);
+
+    const double h4 = pow(10.0, 4.0);
+    EXPECT_DOUBLE_EQ(-24.0 / (kPiD * h4), value0);
+    EXPECT_DOUBLE_EQ(0.0, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - 2.0 * kernel(5.0) + kernel(5.0 - e)) / (e * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }
 
 TEST(SphStdKernel2, Gradient) {
@@ -81,6 +102,11 @@ TEST(SphSpikyKernel2, FirstDerivative) {
     double value2 = kernel.firstDerivative(10.0);
     EXPECT_LT(value0, value1);
     EXPECT_LT(value1, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - kernel(5.0 - e)) / (2.0 * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }
 
 TEST(SphSpikyKernel2, Gradient) {
@@ -104,6 +130,13 @@ TEST(SphSpikyKernel2, SecondDerivative) {
     double value0 = kernel.secondDerivative(0.0);
     double value1 = kernel.secondDerivative(5.0);
     double value2 = kernel.secondDerivative(10.0);
-    EXPECT_LT(value1, value0);
-    EXPECT_LT(value2, value1);
+
+    const double h4 = pow(10.0, 4.0);
+    EXPECT_DOUBLE_EQ(60.0 / (kPiD * h4), value0);
+    EXPECT_DOUBLE_EQ(0.0, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - 2.0 * kernel(5.0) + kernel(5.0 - e)) / (e * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }

--- a/src/tests/unit_tests/sph_kernels3_tests.cpp
+++ b/src/tests/unit_tests/sph_kernels3_tests.cpp
@@ -36,7 +36,28 @@ TEST(SphStdKernel3, FirstDerivative) {
     double value2 = kernel.firstDerivative(10.0);
     EXPECT_DOUBLE_EQ(0.0, value0);
     EXPECT_DOUBLE_EQ(0.0, value2);
-    EXPECT_LT(value1, value0);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - kernel(5.0 - e)) / (2.0 * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
+}
+
+TEST(SphStdKernel3, SecondDerivative) {
+    SphStdKernel3 kernel(10.0);
+
+    double value0 = kernel.secondDerivative(0.0);
+    double value1 = kernel.secondDerivative(5.0);
+    double value2 = kernel.secondDerivative(10.0);
+
+    const double h5 = pow(10.0, 5.0);
+    EXPECT_DOUBLE_EQ(-945.0 / (32.0 * kPiD * h5), value0);
+    EXPECT_DOUBLE_EQ(0.0, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - 2.0 * kernel(5.0) + kernel(5.0 - e)) / (e * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }
 
 TEST(SphStdKernel3, Gradient) {
@@ -83,6 +104,11 @@ TEST(SphSpikyKernel3, FirstDerivative) {
     double value2 = kernel.firstDerivative(10.0);
     EXPECT_LT(value0, value1);
     EXPECT_LT(value1, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - kernel(5.0 - e)) / (2.0 * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }
 
 TEST(SphSpikyKernel3, Gradient) {
@@ -108,6 +134,13 @@ TEST(SphSpikyKernel3, SecondDerivative) {
     double value0 = kernel.secondDerivative(0.0);
     double value1 = kernel.secondDerivative(5.0);
     double value2 = kernel.secondDerivative(10.0);
-    EXPECT_LT(value1, value0);
-    EXPECT_LT(value2, value1);
+
+    const double h5 = pow(10.0, 5.0);
+    EXPECT_DOUBLE_EQ(90.0 / (kPiD * h5), value0);
+    EXPECT_DOUBLE_EQ(0.0, value2);
+
+    // Compare with finite difference
+    const double e = 0.001;
+    double fdm = (kernel(5.0 + e) - 2.0 * kernel(5.0) + kernel(5.0 - e)) / (e * e);
+    EXPECT_NEAR(fdm, value1, 1e-10);
 }


### PR DESCRIPTION
This revision fixes the issue with 2nd-order derivative of standard SPH kernel being wrong. It also fixes nearly meaningless unit tests to avoid similar issues.