### PR TITLE
Fix ray marching interpolation bug

### DIFF
--- a/src/jet/custom_implicit_surface2.cpp
+++ b/src/jet/custom_implicit_surface2.cpp
@@ -116,6 +116,7 @@ SurfaceRayIntersection2 CustomImplicitSurface2::closestIntersectionLocal(
         }
 
         double t = tStart;
+        double tPrev = t;
         Vector2D pt = ray.pointAt(t);
         double prevPhi = _func(pt);
 
@@ -126,7 +127,7 @@ SurfaceRayIntersection2 CustomImplicitSurface2::closestIntersectionLocal(
 
             if (newPhi * prevPhi < 0.0) {
                 const double frac = prevPhi / (prevPhi - newPhi);
-                const double tSub = t + _rayMarchingResolution * frac;
+                const double tSub = tPrev + _rayMarchingResolution * frac;
 
                 result.isIntersecting = true;
                 result.distance = tSub;
@@ -139,6 +140,7 @@ SurfaceRayIntersection2 CustomImplicitSurface2::closestIntersectionLocal(
                 return result;
             }
 
+            tPrev = t;
             t += std::max(newPhiAbs, _rayMarchingResolution);
             prevPhi = newPhi;
         }

--- a/src/jet/custom_implicit_surface3.cpp
+++ b/src/jet/custom_implicit_surface3.cpp
@@ -116,6 +116,7 @@ SurfaceRayIntersection3 CustomImplicitSurface3::closestIntersectionLocal(
         }
 
         double t = tStart;
+        double tPrev = t;
         Vector3D pt = ray.pointAt(t);
         double prevPhi = _func(pt);
 
@@ -126,7 +127,7 @@ SurfaceRayIntersection3 CustomImplicitSurface3::closestIntersectionLocal(
 
             if (newPhi * prevPhi < 0.0) {
                 const double frac = prevPhi / (prevPhi - newPhi);
-                const double tSub = t + _rayMarchingResolution * frac;
+                const double tSub = tPrev + _rayMarchingResolution * frac;
 
                 result.isIntersecting = true;
                 result.distance = tSub;
@@ -139,6 +140,7 @@ SurfaceRayIntersection3 CustomImplicitSurface3::closestIntersectionLocal(
                 return result;
             }
 
+            tPrev = t;
             t += std::max(newPhiAbs, _rayMarchingResolution);
             prevPhi = newPhi;
         }

--- a/src/tests/unit_tests/custom_implicit_surface2_tests.cpp
+++ b/src/tests/unit_tests/custom_implicit_surface2_tests.cpp
@@ -88,7 +88,7 @@ TEST(CustomImplicitSurface2, ClosestIntersection) {
 
     CustomImplicitSurface2 cis1(
         [&](const Vector2D& pt) { return refSurf.signedDistance(pt); },
-        BoundingBox2D({0, 0}, {1, 1}), 1e-3, 1e-6);
+        BoundingBox2D({0, 0}, {1, 1}), 1e-3, 1e-3);
 
     for (size_t i = 0; i < getNumberOfSamplePoints2(); ++i) {
         auto x = getSamplePoints2()[i];

--- a/src/tests/unit_tests/custom_implicit_surface3_tests.cpp
+++ b/src/tests/unit_tests/custom_implicit_surface3_tests.cpp
@@ -96,7 +96,7 @@ TEST(CustomImplicitSurface3, ClosestIntersection) {
 
     CustomImplicitSurface3 cis1(
         [&](const Vector3D& pt) { return refSurf.signedDistance(pt); },
-        BoundingBox3D({0, 0, 0}, {1, 1, 1}), 1e-3, 1e-6);
+        BoundingBox3D({0, 0, 0}, {1, 1, 1}), 1e-3, 1e-3);
 
     for (size_t i = 0; i < getNumberOfSamplePoints3(); ++i) {
         auto x = getSamplePoints3()[i];


### PR DESCRIPTION
This revision fixes ray marching issue (reported from #260) where the current distance parameter `t` was used instead of the previous value.