### PR TITLE
Add VS 2019 image to Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ version: 1.3.3 ({build})
 skip_branch_with_pr: true
 
 os:
+  - Visual Studio 2019
   - Visual Studio 2017
   - Visual Studio 2015
 
@@ -23,7 +24,8 @@ install:
   - git submodule update --init
   - ps: |
       if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }
-      if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2017*") { $env:CMAKE_GENERATOR = "Visual Studio 15 2017" }
+      if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2019*") { $env:CMAKE_GENERATOR = "Visual Studio 16 2019" }
+      else if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2017*") { $env:CMAKE_GENERATOR = "Visual Studio 15 2017" }
       else { $env:CMAKE_GENERATOR = "Visual Studio 14 2015" }
       $env:PYTHON = "27"
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ install:
   - ps: |
       if ($env:PLATFORM -eq "x64") { $env:CMAKE_ARCH = "x64" }
       if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2019*") { $env:CMAKE_GENERATOR = "Visual Studio 16 2019" }
-      else if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2017*") { $env:CMAKE_GENERATOR = "Visual Studio 15 2017" }
-      else { $env:CMAKE_GENERATOR = "Visual Studio 14 2015" }
+      else { if ($env:APPVEYOR_JOB_NAME -like "*Visual Studio 2017*") { $env:CMAKE_GENERATOR = "Visual Studio 15 2017" }
+      else { $env:CMAKE_GENERATOR = "Visual Studio 14 2015" } }
       $env:PYTHON = "27"
       if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
       $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -86,6 +86,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         # /wd4201     # -> disable warning: nonstandard extension used: nameless struct/union (caused by GLM)
         # /wd4127     # -> disable warning: conditional expression is constant (caused by Qt)
         /wd4717 # -> disable warning:  recursive on all control paths, function will cause runtime stack overflow (wrong warning)
+        /wd4819 # -> disable warning:  The file contains a character that cannot be represented in the current code page (949) (wrong warning)
 
         #$<$<CONFIG:Debug>:
         #/RTCc         # -> value is assigned to a smaller data type and results in a data loss


### PR DESCRIPTION
This revision adds VS 2019 image to Appveyor in Issue #240.