### PR TITLE
Add Ubuntu 20.04 Focal to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,20 +39,27 @@ matrix:
       services: docker
       script:
         - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic bionic
-    - name: Test Docker based on Ubuntu 18.04 LTS + gcc-latest
+    - name: Test Docker based on Ubuntu 20.04 LTS + gcc
       os: linux
       dist: trusty
       sudo: required
       services: docker
       script:
-        - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic.gcc-latest bionic-gcc-latest
-    - name: Test Docker based on Ubuntu 18.04 LTS + clang-latest
+        - sh scripts/travis_build_docker.sh scripts/Dockerfile.focal focal
+    - name: Test Docker based on Ubuntu 20.04 LTS + gcc-latest
       os: linux
       dist: trusty
       sudo: required
       services: docker
       script:
-        - sh scripts/travis_build_docker.sh scripts/Dockerfile.bionic.gcc-latest bionic-clang-latest
+        - sh scripts/travis_build_docker.sh scripts/Dockerfile.focal.gcc-latest focal-gcc-latest
+    - name: Test Docker based on Ubuntu 20.04 LTS + clang-latest
+      os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      script:
+        - sh scripts/travis_build_docker.sh scripts/Dockerfile.focal.clang-latest focal-clang-latest
     - name: Test OS X 10.11 + Xcode 7.3 + clang
       os: osx
       osx_image: xcode7.3

--- a/scripts/Dockerfile.focal
+++ b/scripts/Dockerfile.focal
@@ -1,14 +1,15 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Doyub Kim <doyubkim@gmail.com>
 
-RUN apt-get update -yq && \
-    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake clang-6.0 && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -yq && \
+    apt-get install -yq build-essential python3-dev python3-pip cmake && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 && \
+RUN cmake .. && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests

--- a/scripts/Dockerfile.focal.clang-latest
+++ b/scripts/Dockerfile.focal.clang-latest
@@ -3,13 +3,13 @@ MAINTAINER Doyub Kim <doyubkim@gmail.com>
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -yq && \
-    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake clang-9.0 && \
+    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake clang-9 && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. -DCMAKE_C_COMPILER=clang-9.0 -DCMAKE_CXX_COMPILER=clang++-9.0 && \
+RUN cmake .. -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests

--- a/scripts/Dockerfile.focal.clang-latest
+++ b/scripts/Dockerfile.focal.clang-latest
@@ -1,14 +1,15 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Doyub Kim <doyubkim@gmail.com>
 
-RUN apt-get update -yq && \
-    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake gcc-8 g++-8 && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -yq && \
+    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake clang-9.0 && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 && \
+RUN cmake .. -DCMAKE_C_COMPILER=clang-9.0 -DCMAKE_CXX_COMPILER=clang++-9.0 && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests

--- a/scripts/Dockerfile.focal.gcc-latest
+++ b/scripts/Dockerfile.focal.gcc-latest
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04
+MAINTAINER Doyub Kim <doyubkim@gmail.com>
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -yq && \
+    apt-get install -yq build-essential python3-dev python3-pip python3-venv cmake gcc-9 g++-9 && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+ADD . /app
+
+WORKDIR /app/build
+RUN cmake .. -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-9 && \
+    make -j`nproc` && \
+    make install && \
+    bin/unit_tests
+
+RUN apt-get install -yq pkg-config libfreetype6-dev libpng-dev
+
+WORKDIR /app/ENV
+RUN pip3 install -r ../requirements.txt && \
+    pip3 install .. && \
+    python3 -m pytest ../src/tests/python_tests/
+
+WORKDIR /

--- a/scripts/Dockerfile.focal.gcc-latest
+++ b/scripts/Dockerfile.focal.gcc-latest
@@ -9,7 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 ADD . /app
 
 WORKDIR /app/build
-RUN cmake .. -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-9 && \
+RUN cmake .. -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_CXX_COMPILER=g++-9 && \
     make -j`nproc` && \
     make install && \
     bin/unit_tests


### PR DESCRIPTION
This revision adds Ubuntu 20.04 to the CI chain. This requires updating GTest to the latest release version (1.10) due to GCC 9.x deprecated-copy warning.