### PR TITLE
Add xyz file support for example apps

### DIFF
--- a/src/examples/example_utils/io_utils.h
+++ b/src/examples/example_utils/io_utils.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Doyub Kim
+//
+// I am making my contributions/submissions to this project solely in my
+// personal capacity and am not conveying any rights to any intellectual
+// property of any third parties.
+
+#include <jet/jet.h>
+#include <pystring/pystring.h>
+
+inline bool readPositions(const std::string& filename,
+                          jet::Array1<jet::Vector3D>& positions) {
+    if (pystring::endswith(filename, ".xyz")) {
+        std::ifstream xyzFile(filename.c_str());
+        while (xyzFile) {
+            jet::Vector3D xyz;
+
+            xyzFile >> xyz.x >> xyz.y >> xyz.z;
+
+            if (xyzFile.fail() || xyzFile.eof()) {
+                break;
+            }
+
+            positions.append(xyz);
+        }
+
+        xyzFile.close();
+        return true;
+    } else {
+        std::ifstream posFile(filename.c_str(), std::ifstream::binary);
+        if (posFile) {
+            std::vector<uint8_t> buffer(
+                (std::istreambuf_iterator<char>(posFile)),
+                (std::istreambuf_iterator<char>()));
+            deserialize(buffer, &positions);
+            posFile.close();
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/examples/particles2obj/main.cpp
+++ b/src/examples/particles2obj/main.cpp
@@ -8,6 +8,7 @@
 #include <pystring/pystring.h>
 
 #include <example_utils/clara_utils.h>
+#include <example_utils/io_utils.h>
 #include <clara.hpp>
 
 #include <algorithm>
@@ -107,8 +108,8 @@ int main(int argc, char* argv[]) {
     // Parsing
     auto parser =
         clara::Help(showHelp) |
-        clara::Opt(inputFilename,
-                   "inputFilename")["-i"]["--input"]("input obj file name") |
+        clara::Opt(inputFilename, "inputFilename")["-i"]["--input"](
+            "input pos/xyz file name") |
         clara::Opt(outputFilename,
                    "outputFilename")["-o"]["--output"]("output obj file name") |
         clara::Opt(strResolution, "resolution")["-r"]["--resolution"](
@@ -221,14 +222,7 @@ int main(int argc, char* argv[]) {
 
     // Read particle positions
     Array1<Vector3D> positions;
-    std::ifstream positionFile(inputFilename.c_str(), std::ifstream::binary);
-    if (positionFile) {
-        std::vector<uint8_t> buffer(
-            (std::istreambuf_iterator<char>(positionFile)),
-            (std::istreambuf_iterator<char>()));
-        deserialize(buffer, &positions);
-        positionFile.close();
-    } else {
+    if (!readPositions(inputFilename, positions)) {
         printf("Cannot read file %s.\n", inputFilename.c_str());
         exit(EXIT_FAILURE);
     }

--- a/src/examples/particles2xml/main.cpp
+++ b/src/examples/particles2xml/main.cpp
@@ -8,6 +8,7 @@
 #include <pystring/pystring.h>
 
 #include <example_utils/clara_utils.h>
+#include <example_utils/io_utils.h>
 #include <clara.hpp>
 
 #include <algorithm>
@@ -65,7 +66,7 @@ int main(int argc, char* argv[]) {
     auto parser =
         clara::Help(showHelp) |
         clara::Opt(inputFilename, "inputFilename")["-i"]["--input"](
-            "input particle position file name") |
+            "input particle pos/xyz file name") |
         clara::Opt(outputFilename,
                    "outputFilename")["-o"]["--output"]("output xml file name");
 
@@ -87,14 +88,7 @@ int main(int argc, char* argv[]) {
 
     // Read particle positions
     Array1<Vector3D> positions;
-    std::ifstream positionFile(inputFilename.c_str(), std::ifstream::binary);
-    if (positionFile) {
-        std::vector<uint8_t> buffer(
-            (std::istreambuf_iterator<char>(positionFile)),
-            (std::istreambuf_iterator<char>()));
-        deserialize(buffer, &positions);
-        positionFile.close();
-    } else {
+    if (!readPositions(inputFilename, positions)) {
         printf("Cannot read file %s.\n", inputFilename.c_str());
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
This revision adds `.xyz` file format support for the example apps (`particles2obj` and `particles2xml`) as suggested in #303 .