### PR TITLE
Fix typo and missing newlines

### DIFF
--- a/include/jet/vector2.h
+++ b/include/jet/vector2.h
@@ -97,7 +97,7 @@ class Vector<T, 2> final {
     //! Computes dot product.
     T dot(const Vector& v) const;
 
-    //! Comptues cross product.
+    //! Computes cross product.
     T cross(const Vector& v) const;
 
     // MARK: Binary operations: new instance = v (+) this

--- a/include/jet/vector3.h
+++ b/include/jet/vector3.h
@@ -97,6 +97,7 @@ class Vector<T, 3> final {
 
     //! Computes this * (v.x, v.y, v.z).
     Vector mul(const Vector& v) const;
+
     //! Computes this / (v, v, v).
     Vector div(T v) const;
 
@@ -106,7 +107,7 @@ class Vector<T, 3> final {
     //! Computes dot product.
     T dot(const Vector& v) const;
 
-    //! Comptues cross product.
+    //! Computes cross product.
     Vector cross(const Vector& v) const;
 
     // MARK: Binary operations: new instance = v (+) this

--- a/include/jet/vector4.h
+++ b/include/jet/vector4.h
@@ -101,6 +101,7 @@ class Vector<T, 4> final {
 
     //! Computes this * (v.x, v.y, v.z, v.w).
     Vector mul(const Vector& v) const;
+
     //! Computes this / (v, v, v, v).
     Vector div(T v) const;
 


### PR DESCRIPTION
Noticed this when I went to double check the code, because page 27 of the book shows the return type of 2D vector cross product as `Vector<T,2>`, instead of being simply the scalar `T`:
```cpp
template <typename T>
Vector<T,2> Vector<T,2>::cross(const Vector& v) const {
    return x*v.y - v.x*y;
}
```