### PR TITLE
Make timer test more relaxed

### DIFF
--- a/src/tests/unit_tests/timer_tests.cpp
+++ b/src/tests/unit_tests/timer_tests.cpp
@@ -14,8 +14,8 @@ using namespace jet;
 
 TEST(Timer, Basics) {
     Timer timer, timer2;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    EXPECT_LT(0.01, timer.durationInSeconds());
+    std::this_thread::sleep_for(std::chrono::milliseconds(101));
+    EXPECT_LT(0.1, timer.durationInSeconds());
 
     timer.reset();
     EXPECT_LE(timer.durationInSeconds(), timer2.durationInSeconds());


### PR DESCRIPTION
For some reason std::chrono::steady_clock and std::this_thread::sleep_for is not super accurate on MinGW + gcc combination. Just relaxing the test criteria a bit.