### PR TITLE
fix python example: apic_example03.py

### DIFF
--- a/src/examples/python_examples/apic_example03.py
+++ b/src/examples/python_examples/apic_example03.py
@@ -37,7 +37,14 @@ def main():
     def write_surface(frame_cnt, pos):
         converter = SphPointsToImplicit3(1.5 * grid_size, 0.5)
         converter.convert(pos.tolist(), grid)
-        surface_mesh = marchingCubes(grid, (grid_size, grid_size, grid_size), (0, 0, 0), 0.0, DIRECTION_ALL)
+        surface_mesh = marchingCubes(
+            grid,
+            (grid_size, grid_size, grid_size),
+            (0, 0, 0),
+            0.0,
+            DIRECTION_ALL,
+            DIRECTION_ALL
+        )
         surface_mesh.writeObj('frame_{:06d}.obj'.format(frame_cnt))
 
     # Make first frame


### PR DESCRIPTION
I have fixed the error in the python example. The new version of the marchingCubes function requires 6 parameters instead of 5 (the old version of the function).