### PR TITLE
Fix for GridSmokeSolver3 and GridSmokeSolver2

### DIFF
--- a/src/jet/grid_smoke_solver2.cpp
+++ b/src/jet/grid_smoke_solver2.cpp
@@ -104,7 +104,7 @@ void GridSmokeSolver2::computeDiffusion(double timeIntervalInSeconds) {
         }
 
         if (_temperatureDiffusionCoefficient > kEpsilonD) {
-            auto temp = smokeDensity();
+            auto temp = temperature();
             auto temp0 = std::dynamic_pointer_cast<CellCenteredScalarGrid2>(
                 temp->clone());
 

--- a/src/jet/grid_smoke_solver3.cpp
+++ b/src/jet/grid_smoke_solver3.cpp
@@ -104,7 +104,7 @@ void GridSmokeSolver3::computeDiffusion(double timeIntervalInSeconds) {
         }
 
         if (_temperatureDiffusionCoefficient > kEpsilonD) {
-            auto temp = smokeDensity();
+            auto temp = temperature();
             auto temp0 = std::dynamic_pointer_cast<CellCenteredScalarGrid3>(
                 temp->clone());
 


### PR DESCRIPTION
ComputeDiffusion was diffusing the smokeDensity grid instead of the temperature grid.